### PR TITLE
[APG-963] Add AWS RDS root cert to Java truststore in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezo
 RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
+# Install AWS RDS Root cert into Java truststore
+RUN mkdir /home/appuser/.postgresql \
+  && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+    > /home/appuser/.postgresql/root.crt
+
 WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-accredited-programmes-manage-and-deliver-api*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar


### PR DESCRIPTION
Seeing the following error on API startup:

`SQL State  : 08006
Error Code : 0
Message    : Could not open SSL root certificate file /home/appuser/.postgresql/root.crt.`

- Add AWS RDS root cert to Java truststore in Dockerfile