### PR TITLE
[APG-1041] Refactor security configuration and add custom JWT converter

### DIFF
--- a/scripts/local-scripts/get-token
+++ b/scripts/local-scripts/get-token
@@ -2,7 +2,7 @@
 
 # GET a JWT access token from hmpps-auth at localhost:9090 (See docker-compose.yml)
 
-curl --location -s --request POST "http://localhost:9090/auth/oauth/token?grant_type=client_credentials" \
+curl --location --request POST "http://localhost:8090/auth/oauth/token?grant_type=client_credentials" \
      --header 'Content-Type: application/json' \
      --header 'Content-Length: 0' \
      --header "Authorization: Basic $(echo -n 'whereabouts-api-client:clientsecret' | base64 -b 0)" | jq -r .access_token

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/security/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/security/AuthAwareTokenConverter.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.security
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+const val AUTHORITY_CLAIM_KEY = "authorities"
+
+class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+
+  override fun convert(jwt: Jwt): AbstractAuthenticationToken = AuthAwareAuthenticationToken(
+    jwt = jwt,
+    authorities = extractAuthorities(jwt),
+  )
+
+  private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> = jwt.claims[AUTHORITY_CLAIM_KEY]
+    ?.let { claimValue ->
+      claimValue.let { it as Collection<*> }
+        .mapNotNull { it as? String }
+        .map { SimpleGrantedAuthority(it) }
+    } ?: emptyList()
+}
+
+class AuthAwareAuthenticationToken(
+  jwt: Jwt,
+  authorities: Collection<GrantedAuthority>,
+) : JwtAuthenticationToken(jwt, authorities)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/security/SecurityConfiguration.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -24,13 +24,12 @@ class SecurityConfiguration {
           "/info",
           "/swagger-ui.html",
         ).permitAll()
-        .anyRequest().permitAll() // TODO remove this and replace with .anyRequest().hasRole("SOME_ROLE_TBD")
     }
     .sessionManagement { session ->
       session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
     }
     .oauth2ResourceServer { oauth2 ->
-      oauth2.jwt { }
+      oauth2.jwt { jwt -> jwt.jwtAuthenticationConverter(AuthAwareTokenConverter()) }
     }
     .build()
 }


### PR DESCRIPTION
* Move security configuration to a dedicated package.
* Implement `AuthAwareTokenConverter` to handle custom JWT authority claims.
* Update local token script to use the correct port.