### PR TITLE
APG-1041 Implement SQS domain events listener for handling referral creation events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
-  kotlin("plugin.spring") version "2.1.21"
+  kotlin("plugin.spring") version "2.2.0"
 }
 
 configurations {
@@ -13,14 +15,19 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
+  // AWS
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.6")
+
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.5")
   testImplementation("org.wiremock:wiremock-standalone:3.13.0")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.29") {
     exclude(group = "io.swagger.core.v3")
   }
-  testImplementation("org.testcontainers:testcontainers:1.21.1")
-  testImplementation("org.testcontainers:postgresql:1.21.1")
-  testImplementation("org.testcontainers:junit-jupiter:1.21.1")
+  testImplementation("org.testcontainers:testcontainers:1.21.2")
+  testImplementation("org.testcontainers:localstack:1.21.2")
+  testImplementation("org.testcontainers:postgresql:1.21.2")
+  testImplementation("org.testcontainers:junit-jupiter:1.21.2")
+  testImplementation("org.awaitility:awaitility-kotlin")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql:42.7.7")
@@ -34,4 +41,8 @@ tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
   }
+}
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.compilerOptions {
+  freeCompilerArgs.set(listOf("-Xannotation-default-target=param-property"))
 }

--- a/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/Chart.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: "3.11"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.11"
+    version: "1.13"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/values.yaml
@@ -27,6 +27,13 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"
+    sqs-domain-events-secret:
+      HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_QUEUE_NAME: "queue_name"
+    sqs-domain-events-dlq-secret:
+      HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_DLQ_NAME: "queue_name"
+
     hmpps-accredited-programmes-manage-and-deliver-api-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListener.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.awspring.cloud.sqs.annotation.SqsListener
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.DomainEventsMessage
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.SQSMessage
+
+@Service
+class DomainEventsListener(
+  private val objectMapper: ObjectMapper,
+  val referralCreatedHandler: ReferralCreatedHandler,
+) {
+
+  @SqsListener("hmppsdomaineventsqueue", factory = "hmppsQueueContainerFactoryProxy")
+  fun receive(sqsMessage: SQSMessage) {
+    val domainEventMessage = objectMapper.readValue<DomainEventsMessage>(sqsMessage.message)
+    when (domainEventMessage.eventType) {
+      REFERRAL_CREATED -> referralCreatedHandler.handle(domainEventMessage)
+    }
+  }
+
+  companion object {
+    const val REFERRAL_CREATED = "interventions.community-referral.created"
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.DomainEventsMessage
+
+@Service
+class ReferralCreatedHandler {
+  fun handle(domainEventMessage: DomainEventsMessage) {
+    TODO("Not yet implemented")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/DomainEventsMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/DomainEventsMessage.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model
+
+data class DomainEventsMessage(
+  val eventType: String,
+  val detailUrl: String,
+  val additionalInformation: Map<String, Any>? = mapOf(),
+  val personReference: PersonReference = PersonReference(),
+)
+
+data class PersonReference(val identifiers: List<PersonIdentifier> = listOf()) {
+  fun findCrn() = get("CRN")
+  fun findNomsNumber() = get("NOMS")
+  operator fun get(key: String) = identifiers.find { it.type == key }?.value
+}
+data class PersonIdentifier(val type: String, val value: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/SQSMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/SQSMessage.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class SQSMessage(
+  @JsonProperty("Message") val message: String,
+)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,3 +6,18 @@ spring:
 
 hmpps-auth:
   url: "http://localhost:8090/auth"
+
+hmpps:
+  sqs:
+    provider: localstack
+    queues:
+      hmppsdomaineventsqueue:
+        queueName: hmpps_domain_events_queue
+        dlqName: hmpps_domain_events_dlq
+        subscribeTopicId: hmppsdomaineventstopic
+        subscribeFilter: '{"eventType":[ "interventions.community-referral.created"] }'
+        asyncQueueClient: true
+
+    topics:
+      hmppsdomaineventstopic:
+        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,10 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+hmpps:
+  sqs:
+    reactiveApi: true
+    queues:
+      hmppsdomaineventsqueue:
+        asyncQueueClient: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/IntegrationTestBase.kt
@@ -1,16 +1,30 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingQueueException
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
+@Testcontainers
 @ExtendWith(HmppsAuthApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -21,6 +35,50 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
+
+  @Autowired
+  lateinit var hmppsQueueService: HmppsQueueService
+
+  val objectMapper = jacksonObjectMapper().apply {
+    registerModule(JavaTimeModule())
+  }
+
+  val domainEventQueue by lazy {
+    hmppsQueueService.findByQueueId("hmppsdomaineventsqueue")
+      ?: throw MissingQueueException("HmppsQueue hmppsdomaineventsqueue not found")
+  }
+  val domainEventQueueDlqClient by lazy { domainEventQueue.sqsDlqClient }
+  val domainEventQueueClient by lazy { domainEventQueue.sqsClient }
+
+  @BeforeEach
+  fun beforeEach() {
+    domainEventQueueClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(domainEventQueue.queueUrl).build()).get()
+    domainEventQueueDlqClient!!.purgeQueue(PurgeQueueRequest.builder().queueUrl(domainEventQueue.dlqUrl).build()).get()
+  }
+
+  companion object {
+
+    @JvmStatic
+    private val localStackContainer: LocalStackContainer =
+      LocalStackContainer(DockerImageName.parse("localstack/localstack"))
+        .apply {
+          withEnv("DEFAULT_REGION", "eu-west-2")
+          withServices(Service.SNS, Service.SQS)
+        }
+
+    @BeforeAll
+    @JvmStatic
+    fun startLocalStack() {
+      localStackContainer.start()
+    }
+
+    @DynamicPropertySource
+    @JvmStatic
+    fun setUpProperties(registry: DynamicPropertyRegistry) {
+      registry.add("hmpps.sqs.localstackUrl") { localStackContainer.getEndpointOverride(Service.SNS).toString() }
+      registry.add("hmpps.sqs.region") { localStackContainer.region }
+    }
+  }
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/ResourceSecurityTest.kt
@@ -19,6 +19,7 @@ class ResourceSecurityTest : IntegrationTestBase() {
     "GET /v3/api-docs",
     "GET /v3/api-docs/swagger-config",
     " /error",
+    "PUT /queue-admin/retry-all-dlqs"
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.DomainEventsMessage
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.SQSMessage
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
+
+  fun sendDomainEvent(message: DomainEventsMessage, queueUrl: String = domainEventQueue.queueUrl): SendMessageResponse = domainEventQueueClient.sendMessage(
+    SendMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .messageBody(
+        objectMapper.writeValueAsString(SQSMessage(objectMapper.writeValueAsString(message))),
+      ).build(),
+  ).get()
+
+  @Test
+  fun `should handle create referral message successfully`() {
+    // Given
+    val eventType = "interventions.community-referral.created"
+    val domainEventsMessage = DomainEventsMessage(
+      eventType,
+      detailUrl = "https://find-and-refer-dev.justice.gov.uk/api/referral/X234234",
+      additionalInformation = emptyMap(),
+    )
+
+    // When
+    sendDomainEvent(domainEventsMessage)
+
+    // Then
+    await untilCallTo {
+      domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+    } matches { it == 0 }
+
+    // Then
+    assertEquals(0, domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get())
+    // TODO verify a referral has been persisted etc
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,3 +21,18 @@ spring:
     password: admin_password
   application:
     environment: dev
+
+hmpps:
+  sqs:
+    provider: localstack
+    queues:
+      hmppsdomaineventsqueue:
+        queueName: hmpps_domain_events_queue
+        dlqName: hmpps_domain_events_dlq
+        subscribeTopicId: hmppsdomaineventstopic
+        subscribeFilter: '{"eventType":[ "interventions.community-referral.created"] }'
+        asyncQueueClient: true
+
+    topics:
+      hmppsdomaineventstopic:
+        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
Add DomainEventsListener to process domain events from SQS
Introduce ReferralCreatedHandler for handling "interventions.community-referral.created" events
Update configuration files for SQS and localstack
Added namespace secretes to helm config
Added integration tests for DomainEventsListener
Update dependencies for SQS and testing