### PR TITLE
[APG-956] Add service account name for accessing AWS resources to Helm values

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/values.yaml
@@ -14,6 +14,9 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-accredited-programmes-manage-and-deliver-api-cert
 
+  # Used to access AWS resources like S3 buckets, SQS queues and SNS topics
+  serviceAccountName: hmpps-manage-and-deliver-accredited-programmes
+
   # Environment variables to load into the deployment
   env:
     JAVA_OPTS: "-Xmx512m"


### PR DESCRIPTION

* Added missing bit of config which is causing sprint boot startup issues