### PR TITLE
[APG-1012] Add support for referral entity, referral status history, and related persistence logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0"
   kotlin("plugin.spring") version "2.2.0"
+  kotlin("plugin.jpa") version "2.2.0"
 }
 
 configurations {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,5 +53,21 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin_password
 
+  localstack:
+    image: localstack/localstack:3
+    networks:
+      - hmpps
+    container_name: hmpps-mandd-localstack
+    ports:
+      - "4566:4566"
+      - 8999:8080
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 networks:
   hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntity.kt
@@ -2,8 +2,11 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ent
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 import java.util.UUID
@@ -34,4 +37,8 @@ open class MessageHistoryEntity(
 
   @Column(name = "created_at")
   var createdAt: LocalDateTime? = null,
+
+  @OneToOne(fetch = FetchType.LAZY, optional = true)
+  @JoinColumn(name = "referral_id")
+  var referral: ReferralEntity? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -21,10 +22,10 @@ open class MessageHistoryEntity(
   var id: UUID? = null,
 
   @Column(name = "event_type")
-  var eventType: String? = null,
+  var eventType: String,
 
   @Column(name = "detail_url")
-  var detailUrl: String? = null,
+  var detailUrl: String,
 
   @Column(name = "description")
   var description: String? = null,
@@ -33,9 +34,10 @@ open class MessageHistoryEntity(
   var occurredAt: LocalDateTime? = null,
 
   @Column(name = "message")
-  var message: String? = null,
+  var message: String,
 
   @Column(name = "created_at")
+  @CreatedDate
   var createdAt: LocalDateTime? = null,
 
   @OneToOne(fetch = FetchType.LAZY, optional = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinTable
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
-import java.time.LocalDate
+import org.springframework.data.annotation.CreatedDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -23,18 +23,13 @@ class ReferralEntity(
   var id: UUID? = null,
 
   @Column(name = "person_name")
-  var personName: String? = null,
+  var personName: String,
 
   @Column(name = "crn")
-  var crn: String? = null,
-
-  @Column(name = "cohort")
-  var cohort: String? = null,
-
-  @Column(name = "sentence_end_date")
-  var sentenceEndDate: LocalDate? = null,
+  var crn: String,
 
   @Column(name = "created_at")
+  @CreatedDate
   var createdAt: LocalDateTime = LocalDateTime.now(),
 
   @OneToMany(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "referral")
+class ReferralEntity(
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  var id: UUID? = null,
+
+  @Column(name = "person_name")
+  var personName: String? = null,
+
+  @Column(name = "crn")
+  var crn: String? = null,
+
+  @Column(name = "cohort")
+  var cohort: String? = null,
+
+  @Column(name = "sentence_end_date")
+  var sentenceEndDate: LocalDate? = null,
+
+  @Column(name = "created_at")
+  var createdAt: LocalDateTime = LocalDateTime.now(),
+
+  @OneToMany(
+    fetch = FetchType.LAZY,
+    cascade = [CascadeType.ALL],
+    orphanRemoval = true,
+  )
+  @JoinTable(
+    name = "referral_status_history_mapping",
+    joinColumns = [JoinColumn(name = "referral_id")],
+    inverseJoinColumns = [JoinColumn(name = "referral_status_history_id")],
+  )
+  var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "referral_status_history")
+class ReferralStatusHistoryEntity(
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  var id: UUID? = null,
+
+  @Column(name = "status")
+  var status: String? = null,
+
+  @Column(name = "created_at")
+  var createdAt: LocalDateTime = LocalDateTime.now(),
+
+  @Column(name = "created_by")
+  var createdBy: String? = null,
+
+  @Column(name = "start_date")
+  var startDate: LocalDateTime? = null,
+
+  @Column(name = "end_date")
+  var endDate: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -20,9 +22,11 @@ class ReferralStatusHistoryEntity(
   var status: String? = null,
 
   @Column(name = "created_at")
+  @CreatedDate
   var createdAt: LocalDateTime = LocalDateTime.now(),
 
   @Column(name = "created_by")
+  @CreatedBy
   var createdBy: String? = null,
 
   @Column(name = "start_date")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
@@ -12,7 +12,7 @@ class ReferralCreatedHandler(
 
 ) {
   fun handle(domainEventMessage: DomainEventsMessage) {
-    val sqsMessageHistoryEntity = DomainEventsMessage.toEntity(domainEventMessage, objectMapper)
-    messageHistoryRepository.save(sqsMessageHistoryEntity)
+    val messageHistoryEntity = DomainEventsMessage.toEntity(domainEventMessage, objectMapper)
+    messageHistoryRepository.save(messageHistoryEntity)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/ReferralCreatedHandler.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.lis
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.DomainEventsMessage
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model.toEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.MessageHistoryRepository
 
 @Service
@@ -12,7 +13,6 @@ class ReferralCreatedHandler(
 
 ) {
   fun handle(domainEventMessage: DomainEventsMessage) {
-    val messageHistoryEntity = DomainEventsMessage.toEntity(domainEventMessage, objectMapper)
-    messageHistoryRepository.save(messageHistoryEntity)
+    messageHistoryRepository.save(domainEventMessage.toEntity(objectMapper.writeValueAsString(domainEventMessage)))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/DomainEventsMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/model/DomainEventsMessage.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.listener.model
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.MessageHistoryEntity
 import java.time.LocalDateTime
 
@@ -11,19 +10,7 @@ data class DomainEventsMessage(
   val additionalInformation: Map<String, Any>? = mapOf(),
   val personReference: PersonReference = PersonReference(),
   val occurredAt: LocalDateTime,
-) {
-  companion object {
-    fun toEntity(domainEventsMessage: DomainEventsMessage, objectMapper: ObjectMapper): MessageHistoryEntity = MessageHistoryEntity(
-      id = null,
-      eventType = domainEventsMessage.eventType,
-      detailUrl = domainEventsMessage.detailUrl,
-      description = domainEventsMessage.description,
-      occurredAt = domainEventsMessage.occurredAt,
-      message = objectMapper.writeValueAsString(domainEventsMessage),
-      createdAt = LocalDateTime.now(),
-    )
-  }
-}
+)
 
 data class PersonReference(val identifiers: List<PersonIdentifier> = listOf()) {
   fun findCrn() = get("CRN")
@@ -31,3 +18,13 @@ data class PersonReference(val identifiers: List<PersonIdentifier> = listOf()) {
   operator fun get(key: String) = identifiers.find { it.type == key }?.value
 }
 data class PersonIdentifier(val type: String, val value: String)
+
+fun DomainEventsMessage.toEntity(messageAsJson: String): MessageHistoryEntity = MessageHistoryEntity(
+  id = null,
+  eventType = eventType,
+  detailUrl = detailUrl,
+  description = description,
+  occurredAt = occurredAt,
+  message = messageAsJson,
+  createdAt = LocalDateTime.now(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import java.util.UUID
+
+interface ReferralRepository : JpaRepository<ReferralEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusHistoryRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import java.util.UUID
+
+interface ReferralStatusHistoryRepository : JpaRepository<ReferralStatusHistoryEntity, UUID>

--- a/src/main/resources/db/migration/V2__create_referral_tables.sql
+++ b/src/main/resources/db/migration/V2__create_referral_tables.sql
@@ -2,7 +2,6 @@ CREATE TABLE IF NOT EXISTS referral (
     id UUID NOT NULL PRIMARY KEY,
     person_name TEXT,
     crn TEXT,
-    cohort TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -11,7 +10,6 @@ CREATE TABLE IF NOT EXISTS referral_status_history (
     status TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_by TEXT,
-    sentence_end_date DATE,
     start_date TIMESTAMP,
     end_date TIMESTAMP
 );

--- a/src/main/resources/db/migration/V2__create_referral_tables.sql
+++ b/src/main/resources/db/migration/V2__create_referral_tables.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS referral (
+    id UUID NOT NULL PRIMARY KEY,
+    person_name TEXT,
+    crn TEXT,
+    cohort TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS referral_status_history (
+    id UUID NOT NULL PRIMARY KEY,
+    status TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by TEXT,
+    sentence_end_date DATE,
+    start_date TIMESTAMP,
+    end_date TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS referral_status_history_mapping (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    referral_id UUID NOT NULL REFERENCES referral(id),
+    referral_status_history_id UUID NOT NULL REFERENCES referral_status_history(id),
+    CONSTRAINT unique_referral_status_history_mapping UNIQUE (referral_id, referral_status_history_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_referral_status_history_mapping_referral_id ON referral_status_history_mapping(referral_id);
+CREATE INDEX IF NOT EXISTS idx_referral_status_history_mapping_history_id ON referral_status_history_mapping(referral_status_history_id);

--- a/src/main/resources/db/migration/V3__add_referral_to_message_history.sql
+++ b/src/main/resources/db/migration/V3__add_referral_to_message_history.sql
@@ -1,0 +1,5 @@
+ALTER TABLE message_history
+ADD COLUMN referral_id UUID,
+ADD CONSTRAINT fk_message_history_referral FOREIGN KEY (referral_id) REFERENCES referral(id);
+
+CREATE INDEX IF NOT EXISTS idx_message_history_referral_id ON message_history(referral_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/MessageHistoryEntityTest.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.MessageHistoryEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.MessageHistoryRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+
+class MessageHistoryEntityTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var messageHistoryRepository: MessageHistoryRepository
+
+  @Autowired
+  private lateinit var referralRepository: ReferralRepository
+
+  @Test
+  @Transactional
+  fun `should save and retrieve message history with optional referral`() {
+    // Given
+    val referral = ReferralEntityFactory().withCrn("CRN123").produce()
+    referralRepository.save(referral)
+
+    val messageHistory = MessageHistoryEntityFactory().withReferral(referral).produce()
+    messageHistoryRepository.save(messageHistory)
+
+    // When
+    val retrievedMessageHistory = messageHistoryRepository.findById(messageHistory.id!!).get()
+
+    // Then
+    assertThat(retrievedMessageHistory).isNotNull
+    assertThat(retrievedMessageHistory.eventType).isEqualTo(messageHistory.eventType)
+    assertThat(retrievedMessageHistory.referral).isNotNull
+    assertThat(retrievedMessageHistory.referral!!.id).isEqualTo(referral.id)
+    assertThat(retrievedMessageHistory.referral!!.crn).isEqualTo("CRN123")
+  }
+
+  @Test
+  @Transactional
+  fun `should save and retrieve message history without referral`() {
+    // Given
+    val messageHistory = MessageHistoryEntityFactory().withReferral(null).produce()
+
+    messageHistoryRepository.save(messageHistory)
+
+    // When
+    val retrievedMessageHistory = messageHistoryRepository.findById(messageHistory.id!!).get()
+
+    // Then
+    assertThat(retrievedMessageHistory).isNotNull
+    assertThat(retrievedMessageHistory.eventType).isEqualTo(messageHistory.eventType)
+    assertThat(retrievedMessageHistory.description).isEqualTo(messageHistory.description)
+    assertThat(retrievedMessageHistory.message).isEqualTo(messageHistory.message)
+    assertThat(retrievedMessageHistory.referral).isNull()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntityTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusHistoryEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
+import java.time.LocalDate
+
+class ReferralEntityTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var referralRepository: ReferralRepository
+
+  @Autowired
+  private lateinit var referralStatusHistoryRepository: ReferralStatusHistoryRepository
+
+  @Test
+  @Transactional
+  fun `should save and retrieve referral with status`() {
+    // Given
+    val sentenceEndDate = LocalDate.of(2030, 1, 1)
+    val referral = ReferralEntityFactory()
+      .withCrn("CRN123")
+      .withCohort("Test Cohort")
+      .withPersonName("John Doe")
+      .withSentenceEndDate(sentenceEndDate)
+      .produce()
+
+    referralRepository.save(referral)
+
+    val referralStatusHistory = ReferralStatusHistoryEntityFactory()
+      .withStatus("Assessment started").produce()
+
+    referralStatusHistoryRepository.save(referralStatusHistory)
+
+    referral.statusHistories.add(referralStatusHistory)
+
+    // When
+    val retrievedReferral = referralRepository.findById(referral.id!!).get()
+
+    // Then
+    assertThat(retrievedReferral).isNotNull
+    assertThat(retrievedReferral.crn).isEqualTo("CRN123")
+    assertThat(retrievedReferral.cohort).isEqualTo("Test Cohort")
+    assertThat(retrievedReferral.sentenceEndDate).isEqualTo(sentenceEndDate)
+    assertThat(retrievedReferral.statusHistories).hasSize(1)
+    assertThat(retrievedReferral.statusHistories[0].status).isEqualTo("Assessment started")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntityTest.kt
@@ -26,9 +26,7 @@ class ReferralEntityTest : IntegrationTestBase() {
     val sentenceEndDate = LocalDate.of(2030, 1, 1)
     val referral = ReferralEntityFactory()
       .withCrn("CRN123")
-      .withCohort("Test Cohort")
       .withPersonName("John Doe")
-      .withSentenceEndDate(sentenceEndDate)
       .produce()
 
     referralRepository.save(referral)
@@ -46,8 +44,6 @@ class ReferralEntityTest : IntegrationTestBase() {
     // Then
     assertThat(retrievedReferral).isNotNull
     assertThat(retrievedReferral.crn).isEqualTo("CRN123")
-    assertThat(retrievedReferral.cohort).isEqualTo("Test Cohort")
-    assertThat(retrievedReferral.sentenceEndDate).isEqualTo(sentenceEndDate)
     assertThat(retrievedReferral.statusHistories).hasSize(1)
     assertThat(retrievedReferral.statusHistories[0].status).isEqualTo("Assessment started")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -61,7 +61,6 @@ class EntityFactoriesTest {
     assertThat(referral.id).isNull()
     assertThat(referral.personName).isNotNull()
     assertThat(referral.crn).isNotNull()
-    assertThat(referral.cohort).isNotNull()
     assertThat(referral.createdAt).isNotNull()
     assertThat(referral.statusHistories).isEmpty()
   }
@@ -84,7 +83,6 @@ class EntityFactoriesTest {
       .withId(id)
       .withPersonName(personName)
       .withCrn(crn)
-      .withCohort(cohort)
       .withCreatedAt(createdAt)
       .addStatusHistory(statusHistory)
       .produce()
@@ -92,7 +90,6 @@ class EntityFactoriesTest {
     assertThat(referral.id).isEqualTo(id)
     assertThat(referral.personName).isEqualTo(personName)
     assertThat(referral.crn).isEqualTo(crn)
-    assertThat(referral.cohort).isEqualTo(cohort)
     assertThat(referral.createdAt).isEqualTo(createdAt)
     assertThat(referral.statusHistories).hasSize(1)
     assertThat(referral.statusHistories[0]).isEqualTo(statusHistory)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -1,0 +1,138 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EntityFactoriesTest {
+
+  @Test
+  fun `MessageHistoryEntityFactory should create entity with default values`() {
+    val messageHistory = MessageHistoryEntityFactory().produce()
+
+    assertThat(messageHistory.id).isNull()
+    assertThat(messageHistory.eventType).isNotNull()
+    assertThat(messageHistory.detailUrl).isNotNull()
+    assertThat(messageHistory.description).isNotNull()
+    assertThat(messageHistory.occurredAt).isNotNull()
+    assertThat(messageHistory.message).isNotNull()
+    assertThat(messageHistory.createdAt).isNotNull()
+    assertThat(messageHistory.referral).isNull()
+  }
+
+  @Test
+  fun `MessageHistoryEntityFactory should create entity with custom values`() {
+    val id = UUID.randomUUID()
+    val eventType = "custom-event-type"
+    val detailUrl = "https://custom.url"
+    val description = "Custom description"
+    val occurredAt = LocalDateTime.of(2023, 1, 1, 12, 0)
+    val message = "Custom message"
+    val createdAt = LocalDateTime.of(2023, 1, 1, 12, 30)
+    val referral = ReferralEntityFactory().produce()
+
+    val messageHistory = MessageHistoryEntityFactory()
+      .withId(id)
+      .withEventType(eventType)
+      .withDetailUrl(detailUrl)
+      .withDescription(description)
+      .withOccurredAt(occurredAt)
+      .withMessage(message)
+      .withCreatedAt(createdAt)
+      .withReferral(referral)
+      .produce()
+
+    assertThat(messageHistory.id).isEqualTo(id)
+    assertThat(messageHistory.eventType).isEqualTo(eventType)
+    assertThat(messageHistory.detailUrl).isEqualTo(detailUrl)
+    assertThat(messageHistory.description).isEqualTo(description)
+    assertThat(messageHistory.occurredAt).isEqualTo(occurredAt)
+    assertThat(messageHistory.message).isEqualTo(message)
+    assertThat(messageHistory.createdAt).isEqualTo(createdAt)
+    assertThat(messageHistory.referral).isEqualTo(referral)
+  }
+
+  @Test
+  fun `ReferralEntityFactory should create entity with default values`() {
+    val referral = ReferralEntityFactory().produce()
+
+    assertThat(referral.id).isNull()
+    assertThat(referral.personName).isNotNull()
+    assertThat(referral.crn).isNotNull()
+    assertThat(referral.cohort).isNotNull()
+    assertThat(referral.createdAt).isNotNull()
+    assertThat(referral.statusHistories).isEmpty()
+  }
+
+  @Test
+  fun `ReferralEntityFactory should create entity with custom values`() {
+    val id = UUID.randomUUID()
+    val personName = "Custom Person"
+    val crn = "CUSTOM123"
+    val cohort = "CUSTOM-COHORT"
+    val createdAt = LocalDateTime.of(2023, 1, 1, 12, 0)
+    val statusHistory = ReferralStatusHistoryEntity(
+      status = "Custom Status",
+      createdBy = "Test User",
+      startDate = LocalDateTime.now(),
+      endDate = null,
+    )
+
+    val referral = ReferralEntityFactory()
+      .withId(id)
+      .withPersonName(personName)
+      .withCrn(crn)
+      .withCohort(cohort)
+      .withCreatedAt(createdAt)
+      .addStatusHistory(statusHistory)
+      .produce()
+
+    assertThat(referral.id).isEqualTo(id)
+    assertThat(referral.personName).isEqualTo(personName)
+    assertThat(referral.crn).isEqualTo(crn)
+    assertThat(referral.cohort).isEqualTo(cohort)
+    assertThat(referral.createdAt).isEqualTo(createdAt)
+    assertThat(referral.statusHistories).hasSize(1)
+    assertThat(referral.statusHistories[0]).isEqualTo(statusHistory)
+  }
+
+  @Test
+  fun `ReferralStatusHistoryEntityFactory should create entity with default values`() {
+    val statusHistory = ReferralStatusHistoryEntityFactory().produce()
+
+    assertThat(statusHistory.id).isNull()
+    assertThat(statusHistory.status).isNotNull()
+    assertThat(statusHistory.createdAt).isNotNull()
+    assertThat(statusHistory.createdBy).isNotNull()
+    assertThat(statusHistory.startDate).isNotNull()
+    assertThat(statusHistory.endDate).isNull()
+  }
+
+  @Test
+  fun `ReferralStatusHistoryEntityFactory should create entity with custom values`() {
+    val id = UUID.randomUUID()
+    val status = "Custom Status"
+    val createdAt = LocalDateTime.of(2023, 1, 1, 12, 0)
+    val createdBy = "Custom User"
+    val startDate = LocalDateTime.of(2023, 1, 1, 12, 0)
+    val endDate = LocalDateTime.of(2023, 1, 2, 12, 0)
+
+    val statusHistory = ReferralStatusHistoryEntityFactory()
+      .withId(id)
+      .withStatus(status)
+      .withCreatedAt(createdAt)
+      .withCreatedBy(createdBy)
+      .withStartDate(startDate)
+      .withEndDate(endDate)
+      .produce()
+
+    assertThat(statusHistory.id).isEqualTo(id)
+    assertThat(statusHistory.status).isEqualTo(status)
+    assertThat(statusHistory.createdAt).isEqualTo(createdAt)
+    assertThat(statusHistory.createdBy).isEqualTo(createdBy)
+    assertThat(statusHistory.startDate).isEqualTo(startDate)
+    assertThat(statusHistory.endDate).isEqualTo(endDate)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/MessageHistoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/MessageHistoryEntityFactory.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomAlphanumericString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.MessageHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import java.time.LocalDateTime
+import java.util.UUID
+
+class MessageHistoryEntityFactory {
+  private var id: UUID? = null
+  private var eventType: String? = randomUppercaseString()
+  private var detailUrl: String? = "https://api.example.com/message/${randomAlphanumericString()}"
+  private var description: String? = randomSentence()
+  private var occurredAt: LocalDateTime? = LocalDateTime.now()
+  private var message: String? = randomSentence()
+  private var createdAt: LocalDateTime? = LocalDateTime.now()
+  private var referral: ReferralEntity? = null
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withEventType(eventType: String?) = apply { this.eventType = eventType }
+  fun withDetailUrl(detailUrl: String?) = apply { this.detailUrl = detailUrl }
+  fun withDescription(description: String?) = apply { this.description = description }
+  fun withOccurredAt(occurredAt: LocalDateTime?) = apply { this.occurredAt = occurredAt }
+  fun withMessage(message: String?) = apply { this.message = message }
+  fun withCreatedAt(createdAt: LocalDateTime?) = apply { this.createdAt = createdAt }
+  fun withReferral(referral: ReferralEntity?) = apply { this.referral = referral }
+
+  fun produce() = MessageHistoryEntity(
+    id = this.id,
+    eventType = this.eventType,
+    detailUrl = this.detailUrl,
+    description = this.description,
+    occurredAt = this.occurredAt,
+    message = this.message,
+    createdAt = this.createdAt,
+    referral = this.referral,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/MessageHistoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/MessageHistoryEntityFactory.kt
@@ -29,11 +29,11 @@ class MessageHistoryEntityFactory {
 
   fun produce() = MessageHistoryEntity(
     id = this.id,
-    eventType = this.eventType,
-    detailUrl = this.detailUrl,
+    eventType = this.eventType!!,
+    detailUrl = this.detailUrl!!,
     description = this.description,
     occurredAt = this.occurredAt,
-    message = this.message,
+    message = this.message!!,
     createdAt = this.createdAt,
     referral = this.referral,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -4,7 +4,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -12,28 +11,22 @@ class ReferralEntityFactory {
   private var id: UUID? = null
   private var personName: String? = randomSentence(wordRange = 1..3)
   private var crn: String? = randomUppercaseString(6)
-  private var cohort: String? = randomUppercaseString(4)
   private var createdAt: LocalDateTime = LocalDateTime.now()
-  private var sentenceEndDate: LocalDate = LocalDate.now().plusMonths(6)
   private var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf()
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withPersonName(personName: String?) = apply { this.personName = personName }
   fun withCrn(crn: String?) = apply { this.crn = crn }
-  fun withCohort(cohort: String?) = apply { this.cohort = cohort }
   fun withCreatedAt(createdAt: LocalDateTime) = apply { this.createdAt = createdAt }
-  fun withSentenceEndDate(sentenceEndDate: LocalDate) = apply { this.sentenceEndDate = sentenceEndDate }
   fun withStatusHistories(statusHistories: MutableList<ReferralStatusHistoryEntity>) = apply { this.statusHistories = statusHistories }
 
   fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
 
   fun produce() = ReferralEntity(
     id = this.id,
-    personName = this.personName,
-    crn = this.crn,
-    cohort = this.cohort,
+    personName = this.personName!!,
+    crn = this.crn!!,
     createdAt = this.createdAt,
     statusHistories = this.statusHistories,
-    sentenceEndDate = this.sentenceEndDate,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class ReferralEntityFactory {
+  private var id: UUID? = null
+  private var personName: String? = randomSentence(wordRange = 1..3)
+  private var crn: String? = randomUppercaseString(6)
+  private var cohort: String? = randomUppercaseString(4)
+  private var createdAt: LocalDateTime = LocalDateTime.now()
+  private var sentenceEndDate: LocalDate = LocalDate.now().plusMonths(6)
+  private var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf()
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withPersonName(personName: String?) = apply { this.personName = personName }
+  fun withCrn(crn: String?) = apply { this.crn = crn }
+  fun withCohort(cohort: String?) = apply { this.cohort = cohort }
+  fun withCreatedAt(createdAt: LocalDateTime) = apply { this.createdAt = createdAt }
+  fun withSentenceEndDate(sentenceEndDate: LocalDate) = apply { this.sentenceEndDate = sentenceEndDate }
+  fun withStatusHistories(statusHistories: MutableList<ReferralStatusHistoryEntity>) = apply { this.statusHistories = statusHistories }
+
+  fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
+
+  fun produce() = ReferralEntity(
+    id = this.id,
+    personName = this.personName,
+    crn = this.crn,
+    cohort = this.cohort,
+    createdAt = this.createdAt,
+    statusHistories = this.statusHistories,
+    sentenceEndDate = this.sentenceEndDate,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusHistoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusHistoryEntityFactory.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ReferralStatusHistoryEntityFactory {
+  private var id: UUID? = null
+  private var status: String? = randomUppercaseString(10)
+  private var createdAt: LocalDateTime = LocalDateTime.now()
+  private var createdBy: String? = randomSentence(wordRange = 1..2)
+  private var startDate: LocalDateTime? = LocalDateTime.now()
+  private var endDate: LocalDateTime? = null
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withStatus(status: String?) = apply { this.status = status }
+  fun withCreatedAt(createdAt: LocalDateTime) = apply { this.createdAt = createdAt }
+  fun withCreatedBy(createdBy: String?) = apply { this.createdBy = createdBy }
+  fun withStartDate(startDate: LocalDateTime?) = apply { this.startDate = startDate }
+  fun withEndDate(endDate: LocalDateTime?) = apply { this.endDate = endDate }
+
+  fun produce() = ReferralStatusHistoryEntity(
+    id = this.id,
+    status = this.status,
+    createdAt = this.createdAt,
+    createdBy = this.createdBy,
+    startDate = this.startDate,
+    endDate = this.endDate,
+  )
+}


### PR DESCRIPTION


- Created `ReferralEntity` and `ReferralStatusHistoryEntity` with mappings
- Added corresponding repositories and factories for testing
- Extended `MessageHistoryEntity` to include optional referral association
- Updated tests and integration tests for referral handling
- Added database migrations for referral-related tables
- Updated Docker Compose to include PostgreSQL and LocalStack configurations for testing