### PR TITLE
Add PNI score endpoint with domain score mapping

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/PniController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/PniController.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.PniService
+
+@RestController
+class PniController(
+  private val pniService: PniService,
+) {
+  @Operation(
+    tags = ["PNI Score"],
+    summary = "Retrieve PNI Score",
+    operationId = "getPniScoreByCrn",
+    description = """""",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The PNI Score and associated domain scores for this CRN",
+        content = [Content(schema = Schema(implementation = PniScore::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden.  The client is not authorised to access this PNI Score.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The PNI Score does not exist for this CRN",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
+  @GetMapping("/pni-score/{crn}", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getPniScoreByCrn(
+    @Parameter(description = "The unique crn of an individual", required = true)
+    @PathVariable("crn") crn: String,
+  ) = pniService.getPniScore(crn)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DomainScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DomainScores.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.NeedLevel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.PniResponse
+
+@Schema(description = "Domain scores from PNI assessment")
+data class DomainScores(
+
+  @Schema(description = "Sex domain assessment scores", required = true)
+  @get:JsonProperty("SexDomainScore") val sexDomainScore: SexDomainScore,
+  @Schema(description = "Thinking domain assessment scores", required = true)
+  @get:JsonProperty("ThinkingDomainScore") val thinkingDomainScore: ThinkingDomainScore,
+  @Schema(description = "Relationship domain assessment scores", required = true)
+  @get:JsonProperty("RelationshipDomainScore") val relationshipDomainScore: RelationshipDomainScore,
+  @Schema(description = "Self-management domain assessment scores", required = true)
+  @get:JsonProperty("SelfManagementDomainScore") val selfManagementDomainScore: SelfManagementDomainScore,
+) {
+  companion object {
+    fun from(pniResponse: PniResponse): DomainScores = DomainScores(
+      sexDomainScore = SexDomainScore(
+        overallSexDomainLevel = NeedLevel.fromLevel(pniResponse.pniCalculation?.sexDomain?.level),
+        individualSexScores = IndividualSexScores(
+          sexualPreOccupation = pniResponse.assessment?.questions?.sexualPreOccupation?.score,
+          offenceRelatedSexualInterests = pniResponse.assessment?.questions?.offenceRelatedSexualInterests?.score,
+          emotionalCongruence = pniResponse.assessment?.questions?.emotionalCongruence?.score,
+        ),
+      ),
+      thinkingDomainScore = ThinkingDomainScore(
+        overallThinkingDomainLevel = NeedLevel.fromLevel(pniResponse.pniCalculation?.thinkingDomain?.level),
+        individualThinkingScores = IndividualCognitiveScores(
+          proCriminalAttitudes = pniResponse.assessment?.questions?.proCriminalAttitudes?.score,
+          hostileOrientation = pniResponse.assessment?.questions?.hostileOrientation?.score,
+        ),
+      ),
+      relationshipDomainScore = RelationshipDomainScore(
+        overallRelationshipDomainLevel = NeedLevel.fromLevel(pniResponse.pniCalculation?.relationshipDomain?.level),
+        individualRelationshipScores = IndividualRelationshipScores(
+          curRelCloseFamily = pniResponse.assessment?.questions?.relCloseFamily?.score,
+          prevCloseRelationships = pniResponse.assessment?.questions?.prevCloseRelationships?.score,
+          easilyInfluenced = pniResponse.assessment?.questions?.easilyInfluenced?.score,
+          aggressiveControllingBehaviour = pniResponse.assessment?.questions?.aggressiveControllingBehaviour?.score,
+        ),
+      ),
+      selfManagementDomainScore = SelfManagementDomainScore(
+        overallSelfManagementDomainLevel = NeedLevel.fromLevel(pniResponse.pniCalculation?.selfManagementDomain?.level),
+        individualSelfManagementScores = IndividualSelfManagementScores(
+          impulsivity = pniResponse.assessment?.questions?.impulsivity?.score,
+          temperControl = pniResponse.assessment?.questions?.temperControl?.score,
+          problemSolvingSkills = pniResponse.assessment?.questions?.problemSolvingSkills?.score,
+          difficultiesCoping = pniResponse.assessment?.questions?.difficultiesCoping?.score,
+        ),
+      ),
+    )
+  }
+}
+
+data class SexDomainScore(
+  @Schema(example = "2", required = true)
+  @get:JsonProperty("overallSexDomainLevel") val overallSexDomainLevel: NeedLevel?,
+  @get:JsonProperty("individualSexScores") val individualSexScores: IndividualSexScores,
+)
+
+data class ThinkingDomainScore(
+  @get:JsonProperty("overallThinkingDomainLevel") val overallThinkingDomainLevel: NeedLevel?,
+  @get:JsonProperty("individualThinkingScores") val individualThinkingScores: IndividualCognitiveScores,
+)
+
+data class RelationshipDomainScore(
+  @get:JsonProperty("overallRelationshipDomainLevel") val overallRelationshipDomainLevel: NeedLevel?,
+  @get:JsonProperty("individualRelationshipScores") val individualRelationshipScores: IndividualRelationshipScores,
+)
+
+data class SelfManagementDomainScore(
+  @get:JsonProperty("overallSelfManagementDomainLevel") val overallSelfManagementDomainLevel: NeedLevel?,
+  @get:JsonProperty("individualSelfManagementScores") val individualSelfManagementScores: IndividualSelfManagementScores,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/IndividualNeedsScores.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class IndividualSexScores(
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("sexualPreOccupation") val sexualPreOccupation: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("offenceRelatedSexualInterests") val offenceRelatedSexualInterests: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("emotionalCongruence") val emotionalCongruence: Int? = null,
+)
+
+data class IndividualCognitiveScores(
+
+  @Schema(example = "2", description = "")
+  @get:JsonProperty("proCriminalAttitudes") val proCriminalAttitudes: Int? = null,
+
+  @Schema(example = "2", description = "")
+  @get:JsonProperty("hostileOrientation") val hostileOrientation: Int? = null,
+)
+
+data class IndividualSelfManagementScores(
+  @Schema(example = "2", description = "")
+  @get:JsonProperty("impulsivity") val impulsivity: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("temperControl") val temperControl: Int? = null,
+
+  @Schema(example = "0", description = "")
+  @get:JsonProperty("problemSolvingSkills") val problemSolvingSkills: Int? = null,
+
+  @Schema(example = "", description = "")
+  @get:JsonProperty("difficultiesCoping") val difficultiesCoping: Int? = null,
+)
+
+data class IndividualRelationshipScores(
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("curRelCloseFamily") val curRelCloseFamily: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("prevCloseRelationships") val prevCloseRelationships: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("easilyInfluenced") val easilyInfluenced: Int? = null,
+
+  @Schema(example = "1", description = "")
+  @get:JsonProperty("aggressiveControllingBehaviour") val aggressiveControllingBehaviour: Int? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PniScore.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PniScore.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.OverallIntensity
+
+@Schema(description = "Represents an individual's Programme Needs Identifier (PNI) score assessment")
+data class PniScore(
+
+  @Schema(description = "The overall intensity level derived from the PNI assessment", example = "HIGH")
+  val overallIntensity: OverallIntensity,
+  @Schema(description = "Detailed scores across different assessment domains")
+  val domainScores: DomainScores,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/PniCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/PniCalculation.kt
@@ -29,9 +29,9 @@ data class SaraRiskLevel(val toPartner: Int, val toOther: Int) {
   }
 }
 
-enum class ProgrammePathway {
-  HIGH_INTENSITY_BC,
-  MODERATE_INTENSITY_BC,
+enum class OverallIntensity {
+  HIGH,
+  MODERATE,
   ALTERNATIVE_PATHWAY,
   MISSING_INFORMATION,
 }
@@ -44,12 +44,12 @@ enum class Type {
   ;
 
   companion object {
-    fun toPathway(type: Type?): ProgrammePathway = when (type) {
-      H -> ProgrammePathway.HIGH_INTENSITY_BC
-      M -> ProgrammePathway.MODERATE_INTENSITY_BC
-      A -> ProgrammePathway.ALTERNATIVE_PATHWAY
-      O -> ProgrammePathway.MISSING_INFORMATION
-      else -> throw IllegalArgumentException("Unknown Programme Pathway type: $type")
+    fun toIntensity(type: Type?): OverallIntensity = when (type) {
+      H -> OverallIntensity.HIGH
+      M -> OverallIntensity.MODERATE
+      A -> OverallIntensity.ALTERNATIVE_PATHWAY
+      O -> OverallIntensity.MISSING_INFORMATION
+      else -> throw IllegalArgumentException("Unknown overall intensity type: $type")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/PniResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/PniResponse.kt
@@ -1,3 +1,11 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model
 
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DomainScores
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
+
 data class PniResponse(val pniCalculation: PniCalculation?, val assessment: PniAssessment?)
+
+fun PniResponse.toPniScore() = PniScore(
+  overallIntensity = Type.toIntensity(pniCalculation?.pni),
+  domainScores = DomainScores.from(this),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniService.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.OasysApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.toPniScore
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+
+@Service
+class PniService(
+  private val oasysApiClient: OasysApiClient,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getPniScore(crn: String): PniScore {
+    val pniResponse =
+      when (val result = oasysApiClient.getPniCalculation(crn)) {
+        is ClientResult.Failure -> {
+          log.warn("Failure to retrieve PNI score for crn : $crn")
+          throw NotFoundException("No PNI score found for crn: $crn")
+        }
+        is ClientResult.Success -> result.body
+      }
+    return pniResponse.toPniScore()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/PniControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/PniControllerIntegrationTest.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.NeedLevel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.OverallIntensity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.PniResponseFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+
+class PniControllerIntegrationTest : IntegrationTestBase() {
+
+  @Test
+  fun `should successfully retrieve PNI score for a known CRN`() {
+    // Given
+    stubAuthTokenEndpoint()
+    val crn = "X123456"
+    stubSuccessfulPniResponse(crn)
+
+    // When
+    val response = performRequestAndExpectOk(
+      HttpMethod.GET,
+      "/pni-score/$crn",
+      object : ParameterizedTypeReference<PniScore>() {},
+    )
+
+    // Then
+    assertThat(response).isNotNull
+    assertThat(response.overallIntensity).isEqualTo(OverallIntensity.HIGH)
+    assertThat(response.domainScores).isNotNull
+
+    // Sex Domain assertions
+    assertThat(response.domainScores.sexDomainScore.overallSexDomainLevel).isEqualTo(NeedLevel.HIGH_NEED)
+    assertThat(response.domainScores.sexDomainScore.individualSexScores.sexualPreOccupation).isEqualTo(2)
+    assertThat(response.domainScores.sexDomainScore.individualSexScores.offenceRelatedSexualInterests).isEqualTo(1)
+    assertThat(response.domainScores.sexDomainScore.individualSexScores.emotionalCongruence).isEqualTo(1)
+
+    // Thinking Domain assertions
+    assertThat(response.domainScores.thinkingDomainScore.overallThinkingDomainLevel).isEqualTo(NeedLevel.HIGH_NEED)
+    assertThat(response.domainScores.thinkingDomainScore.individualThinkingScores.proCriminalAttitudes).isEqualTo(1)
+    assertThat(response.domainScores.thinkingDomainScore.individualThinkingScores.hostileOrientation).isEqualTo(1)
+
+    // Relationship Domain assertions
+    assertThat(response.domainScores.relationshipDomainScore.overallRelationshipDomainLevel).isEqualTo(NeedLevel.HIGH_NEED)
+    assertThat(response.domainScores.relationshipDomainScore.individualRelationshipScores.curRelCloseFamily).isEqualTo(0)
+    assertThat(response.domainScores.relationshipDomainScore.individualRelationshipScores.prevCloseRelationships).isEqualTo(0)
+    assertThat(response.domainScores.relationshipDomainScore.individualRelationshipScores.easilyInfluenced).isEqualTo(0)
+    assertThat(response.domainScores.relationshipDomainScore.individualRelationshipScores.aggressiveControllingBehaviour).isEqualTo(0)
+
+    // Self-Management Domain assertions
+    assertThat(response.domainScores.selfManagementDomainScore.overallSelfManagementDomainLevel).isEqualTo(NeedLevel.HIGH_NEED)
+    assertThat(response.domainScores.selfManagementDomainScore.individualSelfManagementScores.impulsivity).isEqualTo(0)
+    assertThat(response.domainScores.selfManagementDomainScore.individualSelfManagementScores.temperControl).isEqualTo(0)
+    assertThat(response.domainScores.selfManagementDomainScore.individualSelfManagementScores.problemSolvingSkills).isEqualTo(0)
+    assertThat(response.domainScores.selfManagementDomainScore.individualSelfManagementScores.difficultiesCoping).isNull()
+  }
+
+  @Test
+  fun `should return HTTP 404 not found when retrieving PNI score for an unknown CRN`() {
+    // Given
+    stubAuthTokenEndpoint()
+    val crn = "UNKNOWN_CRN"
+    stubNotFoundPniResponse(crn)
+
+    // When & Then
+    performRequestAndExpectStatus(
+      HttpMethod.GET,
+      "/pni-score/$crn",
+      object : ParameterizedTypeReference<ErrorResponse>() {},
+      HttpStatus.NOT_FOUND.value(),
+    )
+  }
+
+  @Test
+  fun `should return HTTP 403 Forbidden when retrieving PNI score without the appropriate role`() {
+    // Given
+    val crn = "X123456"
+
+    // When & Then
+    webTestClient
+      .method(HttpMethod.GET)
+      .uri("/pni-score/$crn")
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_OTHER")))
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN)
+      .expectBody(object : ParameterizedTypeReference<ErrorResponse>() {})
+      .returnResult().responseBody!!
+  }
+
+  private fun stubSuccessfulPniResponse(crn: String) {
+    val pniResponse = PniResponseFactory().produce()
+    wiremock.stubFor(
+      get(urlEqualTo("/assessments/pni/$crn?community=true"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(pniResponse)),
+        ),
+    )
+  }
+
+  private fun stubNotFoundPniResponse(crn: String) {
+    wiremock.stubFor(
+      get(urlEqualTo("/assessments/pni/$crn?community=true"))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+}


### PR DESCRIPTION
### Description of changes

* Introduced a new endpoint for accessing PNI scores by CRN, including domain score mapping and integration with the respective service.
* Added integration tests for success and failure scenarios

The endpoint was developed to provide the required data for the the Programme needs Identifier section of the View referrals screen:

<img width="686" height="1658" alt="image" src="https://github.com/user-attachments/assets/3e7746d9-4635-46df-8b50-7479216a2256" />




