### PR TITLE
APG-1209 Enable Wiremock for Spring Boot local profile

### DIFF
--- a/.run/Local - Run.run.xml
+++ b/.run/Local - Run.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Local - Run" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="LOCAL" />
+    <option name="ACTIVE_PROFILES" value="local" />
     <module name="hmpps-accredited-programmes-manage-and-deliver-api.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.AccreditedProgrammesManageAndDeliverApi" />
     <method v="2">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 services:
 
+  wiremock:
+    image: wiremock/wiremock:3.3.1
+    networks:
+      - hmpps
+    container_name: hmpps-mandd-wiremock
+    ports:
+      - "8097:8080"
+    volumes:
+      - ./wiremock:/home/wiremock
+    command: --global-response-templating --verbose
+
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,6 +10,22 @@ spring:
 hmpps-auth:
   url: "http://localhost:8090/auth"
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${hmpps-auth.url}/.well-known/jwks.json
+      client:
+        registration:
+          manage-and-deliver-api-client:
+            provider: hmpps-auth
+            client-id: hmpps-accredited-programmes-manage-and-deliver-api-client-1
+            client-secret: clientsecret
+            authorization-grant-type: client_credentials
+        provider:
+          hmpps-auth:
+            token-uri: ${hmpps-auth.url}/oauth/token
+
 manage-and-deliver-ndelius:
   locations:
     find-person: "/person/find/{identifier}"
@@ -28,3 +44,11 @@ hmpps:
     topics:
       hmppsdomaineventstopic:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+services:
+  find-and-refer-intervention-api:
+    base-url: http://localhost:8097
+  ndelius-integration-api:
+    base-url: http://localhost:8097
+  oasys-api:
+    base-url: http://localhost:8097

--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -1,0 +1,99 @@
+# WireMock for Local Development
+
+This directory contains WireMock stub mappings for mocking external services when running the application with the local profile.
+
+## Overview
+
+When running the application with the local profile, it is configured to connect to external services at `http://localhost:8097`. The docker-compose.yml file includes a WireMock service that runs on this port and serves mock responses for these external services.
+
+## Included Stubs
+
+The following external services are mocked:
+
+### OasysApi
+- `GET /assessments/pni/{crn}?community=true` - Returns PNI assessment data
+  - Success response for any CRN
+  - 404 response for CRNs starting with "UNKNOWN"
+
+### FindAndReferInterventionApi
+- `GET /referral/{referralId}` - Returns referral details
+  - Success response for any valid UUID
+  - 404 response for referral ID "00000000-0000-0000-0000-000000000000"
+
+### NDeliusIntegrationApi
+- `GET /case/{crn}/personal-details` - Returns offender identifiers
+  - Success response for any CRN
+  - 404 response for CRNs starting with "UNKNOWN"
+- `POST /users/{username}/access` - Checks user access to offenders
+  - Success response for any username
+  - 403 response for username "restricted.user"
+
+### HMPPS Auth
+- `POST /auth/oauth/token` - Returns an OAuth token
+- `GET /auth/health/ping` - Returns a health check response
+
+## How to Use
+
+1. Start the Docker containers:
+   ```
+   docker-compose up -d
+   ```
+
+2. Run the application with the local profile:
+   ```
+   ./gradlew bootRun --args='--spring.profiles.active=local'
+   ```
+   
+   Or use the IntelliJ run configuration "Local - Run"
+
+3. The application will automatically use the WireMock server for all external API calls.
+
+## Adding New Stubs
+
+To add a new stub:
+
+1. Create a new JSON file in the `mappings` directory
+2. Define the request pattern and response using the WireMock JSON format
+3. Restart the WireMock container to load the new stub:
+   ```
+   docker-compose restart wiremock
+   ```
+
+## Verifying Stubs
+
+You can verify that the stubs are working by making requests directly to the WireMock server:
+
+```
+curl -v http://localhost:8097/auth/health/ping
+```
+
+You should see a response with a 200 status code and a JSON body.
+
+## Viewing Requests
+
+WireMock logs all requests it receives. You can view these logs with:
+
+```
+docker logs hmpps-mandd-wiremock
+```
+
+## Troubleshooting
+
+If the application is not connecting to the WireMock server:
+
+1. Verify that the WireMock container is running:
+   ```
+   docker ps | grep wiremock
+   ```
+
+2. Verify that the stubs are loaded:
+   ```
+   docker exec hmpps-mandd-wiremock ls -la /home/wiremock/mappings
+   ```
+
+3. Test the WireMock server directly:
+   ```
+   curl -v http://localhost:8097/auth/health/ping
+   ```
+
+4. Check the application logs for connection errors.

--- a/wiremock/mappings/find-and-refer-intervention-api-referral-not-found.json
+++ b/wiremock/mappings/find-and-refer-intervention-api-referral-not-found.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/referral/00000000-0000-0000-0000-000000000000"
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/find-and-refer-intervention-api-referral-success.json
+++ b/wiremock/mappings/find-and-refer-intervention-api-referral-success.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/referral/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "interventionName": "Test Intervention",
+      "interventionType": "ACP",
+      "referralId": "{{request.pathSegments.[1]}}",
+      "personReference": "X123456",
+      "personReferenceType": "CRN",
+      "setting": "Community"
+    }
+  }
+}

--- a/wiremock/mappings/ndelius-integration-api-access-check-forbidden.json
+++ b/wiremock/mappings/ndelius-integration-api-access-check-forbidden.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/users/restricted.user/access"
+  },
+  "response": {
+    "status": 403,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/ndelius-integration-api-access-check-success.json
+++ b/wiremock/mappings/ndelius-integration-api-access-check-success.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/users/[a-zA-Z0-9.]+/access"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "access": [
+        {
+          "crn": "X123456",
+          "userExcluded": false,
+          "userRestricted": false,
+          "exclusionMessage": null,
+          "restrictionMessage": null
+        }
+      ]
+    }
+  }
+}

--- a/wiremock/mappings/ndelius-integration-api-personal-details-not-found.json
+++ b/wiremock/mappings/ndelius-integration-api-personal-details-not-found.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/case/UNKNOWN[A-Z0-9]*/personal-details"
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/ndelius-integration-api-personal-details-success.json
+++ b/wiremock/mappings/ndelius-integration-api-personal-details-success.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/case/[A-Z0-9]+/personal-details"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "crn": "{{request.pathSegments.[1]}}",
+      "name": {
+        "forename": "John",
+        "middleNames": "William",
+        "surname": "Doe"
+      },
+      "dateOfBirth": "1980-01-01",
+      "age": "45",
+      "sex": {
+        "code": "M",
+        "description": "Male"
+      },
+      "ethnicity": {
+        "code": "W1",
+        "description": "White"
+      },
+      "probationPractitioner": {
+        "name": {
+          "forename": "Sam",
+          "middleNames": "A",
+          "surname": "Smith"
+        },
+        "code": "X321",
+        "email": "sam.smith@probation.gov.uk"
+      },
+      "probationDeliveryUnit": {
+        "code": "PDU123",
+        "description": "North London"
+      }
+    }
+  }
+}

--- a/wiremock/mappings/oasys-api-pni-not-found.json
+++ b/wiremock/mappings/oasys-api-pni-not-found.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/assessments/pni/UNKNOWN[A-Z0-9]*",
+    "queryParameters": {
+      "community": {
+        "equalTo": "true"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/wiremock/mappings/oasys-api-pni-success.json
+++ b/wiremock/mappings/oasys-api-pni-success.json
@@ -1,0 +1,35 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/assessments/pni/X123456"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "pniCalculation": {
+        "pni": "H",
+        "calculatedAt": "{{now}}"
+      },
+      "assessment": {
+        "offenderAge": 32,
+        "questions": {
+          "impulsivity": {
+            "score": 0,
+            "problem": "NONE"
+          },
+          "hostileOrientation": {
+            "score": 1,
+            "problem": "SOME"
+          },
+          "sexualPreOccupation": {
+            "score": 2,
+            "problem": "SIGNIFICANT"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Added wiremock container to `docker-compose.yml` running on port 8097 
- Updated `application-local.yml` accordingly 
- Added wiremock mapping files for downstream services
- Added README

Pinging the mocks directly returns results, but when invoking the M&D API endpoints we are seeing the following error:

`Exception occurred whilst processing request: [invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: 401 : [no body]. |`