### PR TITLE
Allow middle name to be null for nDelius Personal details response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 data class NDeliusPersonalDetails(
   val crn: String,
   val name: FullName,
@@ -11,9 +13,10 @@ data class NDeliusPersonalDetails(
   val probationDeliveryUnit: CodeDescription,
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class FullName(
   val forename: String,
-  val middleNames: String?,
+  val middleNames: String? = null,
   val surname: String,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
@@ -13,7 +13,7 @@ data class NDeliusPersonalDetails(
 
 data class FullName(
   val forename: String,
-  val middleNames: String,
+  val middleNames: String?,
   val surname: String,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -13,10 +13,10 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
@@ -84,10 +84,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       val referralEntity = ReferralEntityFactory().withCreatedAt(createdAt).produce()
       testDataGenerator.createReferral(referralEntity)
       val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
-      val fullName = FullName(
-        forename = "Jim",
-        surname = "Halbert",
-      )
+      val fullName = randomFullName(middleName = null)
 
       val nDeliusPersonalDetails = NDeliusPersonalDetailsFactory().withName(fullName).produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -86,7 +86,6 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
       val fullName = FullName(
         forename = "Jim",
-        middleNames = null,
         surname = "Halbert",
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
@@ -56,6 +57,40 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
 
       val nDeliusPersonalDetails = NDeliusPersonalDetailsFactory().produce()
+
+      nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(nDeliusPersonalDetails)
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}",
+        returnType = object : ParameterizedTypeReference<ReferralDetails>() {},
+      )
+
+      Assertions.assertThat(response.id).isEqualTo(savedReferral.id)
+      Assertions.assertThat(response.crn).isEqualTo(savedReferral.crn)
+      Assertions.assertThat(response.interventionName).isEqualTo(savedReferral.interventionName)
+      Assertions.assertThat(response.personName).isEqualTo(nDeliusPersonalDetails.name.getNameAsString())
+      Assertions.assertThat(response.dateOfBirth).isEqualTo(nDeliusPersonalDetails.dateOfBirth)
+      Assertions.assertThat(response.createdAt).isEqualTo(savedReferral.createdAt.toLocalDate())
+      Assertions.assertThat(response.probationPractitionerName)
+        .isEqualTo(nDeliusPersonalDetails.probationPractitioner.name.getNameAsString())
+      Assertions.assertThat(response.probationPractitionerEmail)
+        .isEqualTo(nDeliusPersonalDetails.probationPractitioner.email)
+    }
+
+    @Test
+    fun `should return referral details object with personal details when access granted is true and no middle name`() {
+      val createdAt = LocalDateTime.now()
+      val referralEntity = ReferralEntityFactory().withCreatedAt(createdAt).produce()
+      testDataGenerator.createReferral(referralEntity)
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+      val fullName = FullName(
+        forename = "Jim",
+        middleNames = null,
+        surname = "Halbert",
+      )
+
+      val nDeliusPersonalDetails = NDeliusPersonalDetailsFactory().withName(fullName).produce()
 
       nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
       nDeliusApiStubs.stubPersonalDetailsResponse(nDeliusPersonalDetails)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/DataGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/DataGenerators.kt
@@ -39,10 +39,10 @@ fun randomDateOfBirth(
   return LocalDate.ofEpochDay(randomDays)
 }
 
-fun randomFullName(): FullName = FullName(
-  forename = randomCapitalisedWord(4..12).asString(),
-  middleNames = randomCapitalisedWord(4..10).asString(),
-  surname = randomCapitalisedWord(5..15).asString(),
+fun randomFullName(forename: String? = null, middleName: String? = null, surname: String? = null): FullName = FullName(
+  forename = forename ?: randomCapitalisedWord(4..12).asString(),
+  middleNames = middleName ?: randomCapitalisedWord(4..10).asString(),
+  surname = surname ?: randomCapitalisedWord(5..15).asString(),
 )
 
 fun randomPrisonNumber(): String = (upperCase(1) + digits(4) + upperCase(2)).asString()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusPersonalDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusPersonalDetailsFactory.kt
@@ -25,6 +25,7 @@ class NDeliusPersonalDetailsFactory {
 
   fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
   fun withDateOfBirth(dateOfBirth: LocalDate?) = apply { this.dateOfBirth = dateOfBirth.toString() }
+  fun withName(fullName: FullName) = apply { this.name = fullName }
 
   fun produce() = NDeliusPersonalDetails(
     name = this.name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
@@ -15,9 +15,9 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheck
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 
@@ -67,10 +67,7 @@ class ServiceUserServiceTest {
 
   @Test
   fun `getServiceUserByIdentifier should return service user when client call is successful and missing middle name`() {
-    val fullName = FullName(
-      forename = "Jim",
-      surname = "Halbert",
-    )
+    val fullName = randomFullName(middleName = null)
     val identifier = "X123456"
     val personalDetails = NDeliusPersonalDetailsFactory().withName(fullName).produce()
     val accessResponse = LimitedAccessOffenderCheckResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
@@ -69,7 +69,6 @@ class ServiceUserServiceTest {
   fun `getServiceUserByIdentifier should return service user when client call is successful and missing middle name`() {
     val fullName = FullName(
       forename = "Jim",
-      middleNames = null,
       surname = "Halbert",
     )
     val identifier = "X123456"

--- a/wiremock_mappings/nDeliusMock.json
+++ b/wiremock_mappings/nDeliusMock.json
@@ -14,7 +14,6 @@
           "crn": "X718255",
           "name": {
             "forename": "David",
-            "middleNames": "Alex",
             "surname": "Clarke"
           },
           "dateOfBirth": "1981-04-15",


### PR DESCRIPTION
Currently the nDelius personal details response expects middleName to be not null.

This PR fixes this as middle names can be null 