### PR TITLE
Update find and refer details model to accept sourcedFromReference

### DIFF
--- a/.run/Local - Run.run.xml
+++ b/.run/Local - Run.run.xml
@@ -2,6 +2,9 @@
   <configuration default="false" name="Local - Run" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <option name="ACTIVE_PROFILES" value="LOCAL" />
     <module name="hmpps-accredited-programmes-manage-and-deliver-api.main" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
     <option name="SPRING_BOOT_MAIN_CLASS" value="uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.AccreditedProgrammesManageAndDeliverApi" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ awslocal sqs list-queues
 To send test events to our queues we can run the following command:
 
 ```zsh
-awslocal sqs send-message --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/hmppsdomainevent --message-body file://src/test/resources/events/interventions/communityReferralCreatedEvent.json
+awslocal sqs send-message --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/hmpps_domain_events_queue --message-body file://src/test/resources/events/interventions/communityReferralCreatedEvent.json
 ```
 
 ### Authorization

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ To send test events to our queues we can run the following command:
 awslocal sqs send-message --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/hmpps_domain_events_queue --message-body file://src/test/resources/events/interventions/communityReferralCreatedEvent.json
 ```
 
+## Connecting to dev instances of External Services
+
+For local development purposes the service currently calls out to the dev instances of the `Find and Refer Service` and
+the `nDelius service`. This is done by using our api client credentials to get a token from `HMPPS Auth` and then
+calling the dev instances of those services.
+
+The `$API_CLIENT_SECRET` defined in the [application-local.yml](./src/main/resources/application-local.yml) corresponds
+to the API_CLIENT_SECRET that is stored in kubernetes in the dev environment. Follow the guide below to get the details
+required for this secret.
+
+There is a guide on how to configure your postman client to be able to call endpoints in the Test environments
+(Dev) [here](https://dsdmoj.atlassian.net/wiki/spaces/IC/pages/5784142235/Connecting+Postman+to+test+environments).
+
 ### Authorization
 
 The service uses an OAuth 2.0 setup managed through the HMPPS Auth project. To call any endpoints locally a bearer token
@@ -296,11 +309,6 @@ $ kubectl logs $POD_NAME --$NAMESPACE hmpps-accredited-programmes-manage-and-del
 
 Where `$POD_NAME` is the full string Pod name given in the `get pods` response.
 AND `$NAMESPACE` is the namespace which you are running the command against
-
-## Connecting Postman to Test Environments
-
-There is a guide on how to configure your postman client to be able to call endpoints in the Test environments (
-Dev) [here](https://dsdmoj.atlassian.net/wiki/spaces/IC/pages/5784142235/Connecting+Postman+to+test+environments).
 
 ## Security
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,37 @@
 services:
 
-  hmpps-auth:
-    image: quay.io/hmpps/hmpps-auth:latest
-    networks:
-      - hmpps
-    depends_on:
-      - auth-db
-    container_name: hmpps-auth-api
-    ports:
-      - "8090:8080"
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
-    environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
-      - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
-      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
-      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
-
-  auth-db:
-    image: postgres:15
-    networks:
-      - hmpps
-    restart: always
-    ports:
-      - "5434:5432"
-    environment:
-      - POSTGRES_PASSWORD=admin_password
-      - POSTGRES_USER=admin
-      - POSTGRES_DB=auth-db
-    healthcheck:
-      test: pg_isready -d auth-db
+  #  hmpps-auth:
+  #    image: quay.io/hmpps/hmpps-auth:latest
+  #    networks:
+  #      - hmpps
+  #    depends_on:
+  #      - auth-db
+  #    container_name: hmpps-auth-api
+  #    ports:
+  #      - "8090:8080"
+  #    healthcheck:
+  #      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
+  #    environment:
+  #      - SERVER_PORT=8080
+  #      - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
+  #      - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
+  #      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
+  #      - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
+  #      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+  #
+  #  auth-db:
+  #    image: postgres:15
+  #    networks:
+  #      - hmpps
+  #    restart: always
+  #    ports:
+  #      - "5434:5432"
+  #    environment:
+  #      - POSTGRES_PASSWORD=admin_password
+  #      - POSTGRES_USER=admin
+  #      - POSTGRES_DB=auth-db
+  #    healthcheck:
+  #      test: pg_isready -d auth-db
 
   postgresql:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,5 @@
 services:
 
-  #  hmpps-auth:
-  #    image: quay.io/hmpps/hmpps-auth:latest
-  #    networks:
-  #      - hmpps
-  #    depends_on:
-  #      - auth-db
-  #    container_name: hmpps-auth-api
-  #    ports:
-  #      - "8090:8080"
-  #    healthcheck:
-  #      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
-  #    environment:
-  #      - SERVER_PORT=8080
-  #      - SPRING_PROFILES_ACTIVE=dev,delius,local-postgres
-  #      - SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL=false
-  #      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
-  #      - SPRING_DATASOURCE_URL=jdbc:postgresql://auth-db:5432/auth-db
-  #      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
-  #
-  #  auth-db:
-  #    image: postgres:15
-  #    networks:
-  #      - hmpps
-  #    restart: always
-  #    ports:
-  #      - "5434:5432"
-  #    environment:
-  #      - POSTGRES_PASSWORD=admin_password
-  #      - POSTGRES_USER=admin
-  #      - POSTGRES_DB=auth-db
-  #    healthcheck:
-  #      test: pg_isready -d auth-db
-
   postgresql:
     image: postgres
     container_name: postgres
@@ -57,7 +24,7 @@ services:
     container_name: hmpps-mandd-localstack-api
     ports:
       - "4566:4566"
-      - 8999:8080
+      - "8999:8080"
     environment:
       - SERVICES=sns,sqs
       - DEBUG=${DEBUG- }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PersonalDetails.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
 import java.time.LocalDate
 
 data class PersonalDetails(
@@ -63,7 +64,7 @@ data class PersonalDetails(
     description = "The setting where the referral will be delivered.",
   )
   @get:JsonProperty("setting", required = true)
-  val setting: String,
+  val setting: SettingType,
 
   @Schema(
     example = "North London PDU",
@@ -83,7 +84,7 @@ data class PersonalDetails(
   val dateRetrieved: LocalDate,
 )
 
-fun NDeliusPersonalDetails.toModel(setting: String) = PersonalDetails(
+fun NDeliusPersonalDetails.toModel(setting: SettingType) = PersonalDetails(
   crn = crn,
   name = name.getNameAsString(),
   dateOfBirth = LocalDate.parse(dateOfBirth),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/PersonalDetails.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import java.time.LocalDate
 
 data class PersonalDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model
 
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SourcedFromReferenceType
 import java.util.UUID
 
 data class FindAndReferReferralDetails(
@@ -17,6 +17,7 @@ data class FindAndReferReferralDetails(
   val setting: SettingType,
   val sourcedFromReference: String,
   val sourcedFromReferenceType: SourcedFromReferenceType,
+  val eventNumber: String,
 )
 
 fun FindAndReferReferralDetails.toReferralEntity(statusHistories: MutableList<ReferralStatusHistoryEntity>) = ReferralEntity(
@@ -27,4 +28,5 @@ fun FindAndReferReferralDetails.toReferralEntity(statusHistories: MutableList<Re
   personName = "UNKNOWN",
   statusHistories = statusHistories,
   eventNumber = sourcedFromReference,
+  eventId = eventNumber,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
@@ -1,23 +1,30 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model
 
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
 import java.util.UUID
 
 data class FindAndReferReferralDetails(
-  val interventionType: String,
+  val interventionType: InterventionType,
   val interventionName: String,
   val personReference: String,
-  val personReferenceType: String,
+  val personReferenceType: PersonReferenceType,
   val referralId: UUID,
-  val setting: String,
+  val setting: SettingType,
+  val sourcedFromReference: String,
+  val sourcedFromReferenceType: SourcedFromReferenceType,
 )
 
 fun FindAndReferReferralDetails.toReferralEntity(statusHistories: MutableList<ReferralStatusHistoryEntity>) = ReferralEntity(
-  crn = if (personReferenceType == "CRN") personReference else "UNKNOWN",
+  crn = if (personReferenceType == PersonReferenceType.CRN) personReference else "UNKNOWN",
   interventionType = interventionType,
   interventionName = interventionName,
   setting = setting,
   personName = "UNKNOWN",
   statusHistories = statusHistories,
+  eventNumber = sourcedFromReference,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/model/FindAndReferReferralDetails.kt
@@ -17,7 +17,7 @@ data class FindAndReferReferralDetails(
   val setting: SettingType,
   val sourcedFromReference: String,
   val sourcedFromReferenceType: SourcedFromReferenceType,
-  val eventNumber: String,
+  val eventNumber: Int,
 )
 
 fun FindAndReferReferralDetails.toReferralEntity(statusHistories: MutableList<ReferralStatusHistoryEntity>) = ReferralEntity(
@@ -27,6 +27,6 @@ fun FindAndReferReferralDetails.toReferralEntity(statusHistories: MutableList<Re
   setting = setting,
   personName = "UNKNOWN",
   statusHistories = statusHistories,
-  eventNumber = sourcedFromReference,
-  eventId = eventNumber,
+  eventId = sourcedFromReference,
+  eventNumber = eventNumber,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -13,9 +13,9 @@ import jakarta.persistence.JoinTable
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
-import org.hibernate.annotations.JdbcType
-import org.hibernate.dialect.PostgreSQLEnumJdbcType
 import org.springframework.data.annotation.CreatedDate
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -37,7 +37,6 @@ class ReferralEntity(
   @NotNull
   @Column(name = "intervention_type")
   @Enumerated(EnumType.STRING)
-  @JdbcType(PostgreSQLEnumJdbcType::class)
   var interventionType: InterventionType,
 
   @Column(name = "intervention_name")
@@ -46,7 +45,6 @@ class ReferralEntity(
   @NotNull
   @Column(name = "setting")
   @Enumerated(EnumType.STRING)
-  @JdbcType(PostgreSQLEnumJdbcType::class)
   var setting: SettingType,
 
   @Column(name = "created_at")
@@ -66,30 +64,10 @@ class ReferralEntity(
   var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf(),
 
   @NotNull
-  @Column("eventNumber")
+  @Column("event_id")
+  val eventId: String,
+
+  @NotNull
+  @Column("event_number")
   val eventNumber: String,
 )
-
-enum class PersonReferenceType {
-  CRN,
-  NOMS,
-}
-
-enum class SourcedFromReferenceType {
-  LICENCE_CONDITION,
-  REQUIREMENT,
-}
-
-enum class SettingType {
-  COMMUNITY,
-  CUSTODY,
-  REMAND,
-  PRE_RELEASE,
-}
-
-enum class InterventionType {
-  SI,
-  ACP,
-  CRS,
-  TOOLKITS,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ent
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -10,7 +12,9 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinTable
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
-import org.jetbrains.annotations.NotNull
+import jakarta.validation.constraints.NotNull
+import org.hibernate.annotations.JdbcType
+import org.hibernate.dialect.PostgreSQLEnumJdbcType
 import org.springframework.data.annotation.CreatedDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -26,18 +30,24 @@ class ReferralEntity(
   @Column(name = "person_name")
   var personName: String,
 
+  @NotNull
   @Column(name = "crn")
   var crn: String,
 
+  @NotNull
   @Column(name = "intervention_type")
-  var interventionType: String? = null,
+  @Enumerated(EnumType.STRING)
+  @JdbcType(PostgreSQLEnumJdbcType::class)
+  var interventionType: InterventionType,
 
   @Column(name = "intervention_name")
   var interventionName: String? = null,
 
   @NotNull
   @Column(name = "setting")
-  var setting: String,
+  @Enumerated(EnumType.STRING)
+  @JdbcType(PostgreSQLEnumJdbcType::class)
+  var setting: SettingType,
 
   @Column(name = "created_at")
   @CreatedDate
@@ -54,4 +64,32 @@ class ReferralEntity(
     inverseJoinColumns = [JoinColumn(name = "referral_status_history_id")],
   )
   var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf(),
+
+  @NotNull
+  @Column("eventNumber")
+  val eventNumber: String,
 )
+
+enum class PersonReferenceType {
+  CRN,
+  NOMS,
+}
+
+enum class SourcedFromReferenceType {
+  LICENCE_CONDITION,
+  REQUIREMENT,
+}
+
+enum class SettingType {
+  COMMUNITY,
+  CUSTODY,
+  REMAND,
+  PRE_RELEASE,
+}
+
+enum class InterventionType {
+  SI,
+  ACP,
+  CRS,
+  TOOLKITS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -69,5 +69,5 @@ class ReferralEntity(
 
   @NotNull
   @Column("event_number")
-  val eventNumber: String,
+  val eventNumber: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
 
+import jakarta.annotation.Nullable
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -63,11 +64,11 @@ class ReferralEntity(
   )
   var statusHistories: MutableList<ReferralStatusHistoryEntity> = mutableListOf(),
 
-  @NotNull
+  @Nullable
   @Column("event_id")
-  val eventId: String,
+  val eventId: String? = null,
 
-  @NotNull
+  @Nullable
   @Column("event_number")
-  val eventNumber: Int,
+  val eventNumber: Int? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/InterventionType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/InterventionType.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type
+
+enum class InterventionType {
+  SI,
+  ACP,
+  CRS,
+  TOOLKITS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/PersonReferenceType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/PersonReferenceType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type
+
+enum class PersonReferenceType {
+  CRN,
+  NOMS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/SettingType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/SettingType.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type
+
+enum class SettingType {
+  COMMUNITY,
+  CUSTODY,
+  REMAND,
+  PRE_RELEASE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/SourcedFromReferenceType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/type/SourcedFromReferenceType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type
+
+enum class SourcedFromReferenceType {
+  LICENCE_CONDITION,
+  REQUIREMENT,
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
           manage-and-deliver-api-client:
             provider: hmpps-auth
             client-id: hmpps-accredited-programmes-manage-and-deliver-api-client-1
-            client-secret: ${API_CLIENT_SECRET:clientsecret}
+            client-secret: clientsecret
             authorization-grant-type: client_credentials
         provider:
           hmpps-auth:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,8 +7,24 @@ spring:
     locations: classpath:db/migration,classpath:db/local
     clean-disabled: false
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${hmpps-auth.url}/.well-known/jwks.json
+      client:
+        registration:
+          manage-and-deliver-api-client:
+            provider: hmpps-auth
+            client-id: hmpps-accredited-programmes-manage-and-deliver-api-client-1
+            client-secret: ${API_CLIENT_SECRET:clientsecret}
+            authorization-grant-type: client_credentials
+        provider:
+          hmpps-auth:
+            token-uri: ${hmpps-auth.url}/oauth/token
+
 hmpps-auth:
-  url: "http://localhost:8090/auth"
+  url: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
 
 manage-and-deliver-ndelius:
   locations:
@@ -32,8 +48,8 @@ hmpps:
 
 services:
   find-and-refer-intervention-api:
-    base-url: http://localhost:9095
+    base-url: https://find-and-refer-intervention-api-dev.hmpps.service.justice.gov.uk
   ndelius-integration-api:
-    base-url: http://localhost:9095
+    base-url: https://accredited-programmes-and-delius-dev.hmpps.service.justice.gov.uk
   oasys-api:
     base-url: http://localhost:9095

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
           manage-and-deliver-api-client:
             provider: hmpps-auth
             client-id: hmpps-accredited-programmes-manage-and-deliver-api-client-1
-            client-secret: clientsecret
+            client-secret: ${API_CLIENT_SECRET:clientsecret}
             authorization-grant-type: client_credentials
         provider:
           hmpps-auth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
         registration:
           manage-and-deliver-api-client:
             provider: hmpps-auth
-            client-id: hmpps-accredited-programmes-manage-and-deliver-ui-client-1
+            client-id: hmpps-accredited-programmes-manage-and-deliver-api-client-1
             client-secret: clientsecret
             authorization-grant-type: client_credentials
         provider:

--- a/src/main/resources/db/local/V99_1__add_local_referral_data.sql
+++ b/src/main/resources/db/local/V99_1__add_local_referral_data.sql
@@ -1,16 +1,16 @@
-insert into referral (id, person_name, crn, created_at, intervention_type, intervention_name, setting)
+insert into referral (id, person_name, crn, created_at, intervention_type, intervention_name, setting, event_number)
 values ('39fde7e8-d2e3-472b-8364-5848bf673aa6', 'Edgar Schiller', 'X718250', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY'),
+        'Building Choices', 'COMMUNITY', '2500828798'),
        ('54b1a0ac-ab67-4dde-871f-b59b675cbc8c', 'Omar Pfeffer', 'X718252', '2025-07-30 14:51:22.086567', 'ACP',
-        'New Me', 'COMMUNITY'),
+        'New Me', 'COMMUNITY', '2500828798'),
        ('6885d1f6-5958-40e0-9448-1ff8cc37e643', 'Karen Puckett', 'D002399', '2025-07-30 14:51:22.086567', 'ACP',
-        'Horizon', 'COMMUNITY'),
+        'Horizon', 'COMMUNITY', '2500828798'),
        ('81229aaa-bb3a-4705-8015-99052bafab58', 'Valerie Wyman', 'X718255', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY'),
+        'Building Choices', 'COMMUNITY', '2500828798'),
        ('a8a83c3e-d779-47d5-849f-bb2635666344', 'Sadie Borer', 'X718253', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY'),
+        'Building Choices', 'COMMUNITY', '2500828798'),
        ('aabbadf7-a427-436e-b1a4-f27dd5893c24', 'Mr Joye Hatto', 'D007523', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY');
+        'Building Choices', 'COMMUNITY', '2500828798');
 
 INSERT INTO referral_status_history(id, status, created_at, created_by, start_date, end_date)
 VALUES ('85b59ec2-bd8f-43c4-90f5-3d55b39331b2', 'CREATED', now(), 'USER_ID_12345', now(), null),

--- a/src/main/resources/db/local/V99_1__add_local_referral_data.sql
+++ b/src/main/resources/db/local/V99_1__add_local_referral_data.sql
@@ -1,16 +1,17 @@
-insert into referral (id, person_name, crn, created_at, intervention_type, intervention_name, setting, event_number)
+insert into referral (id, person_name, crn, created_at, intervention_type, intervention_name, setting, event_id,
+                      event_number)
 values ('39fde7e8-d2e3-472b-8364-5848bf673aa6', 'Edgar Schiller', 'X718250', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY', '2500828798'),
+        'Building Choices', 'COMMUNITY', '2500828798', 1),
        ('54b1a0ac-ab67-4dde-871f-b59b675cbc8c', 'Omar Pfeffer', 'X718252', '2025-07-30 14:51:22.086567', 'ACP',
-        'New Me', 'COMMUNITY', '2500828798'),
+        'New Me', 'COMMUNITY', '2500828799', 1),
        ('6885d1f6-5958-40e0-9448-1ff8cc37e643', 'Karen Puckett', 'D002399', '2025-07-30 14:51:22.086567', 'ACP',
-        'Horizon', 'COMMUNITY', '2500828798'),
+        'Horizon', 'COMMUNITY', '2500825678', 1),
        ('81229aaa-bb3a-4705-8015-99052bafab58', 'Valerie Wyman', 'X718255', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY', '2500828798'),
+        'Building Choices', 'COMMUNITY', '3457828798', 1),
        ('a8a83c3e-d779-47d5-849f-bb2635666344', 'Sadie Borer', 'X718253', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY', '2500828798'),
+        'Building Choices', 'COMMUNITY', '7619828798', 1),
        ('aabbadf7-a427-436e-b1a4-f27dd5893c24', 'Mr Joye Hatto', 'D007523', '2025-07-30 14:51:22.086567', 'ACP',
-        'Building Choices', 'COMMUNITY', '2500828798');
+        'Building Choices', 'COMMUNITY', '0987628798', 1);
 
 INSERT INTO referral_status_history(id, status, created_at, created_by, start_date, end_date)
 VALUES ('85b59ec2-bd8f-43c4-90f5-3d55b39331b2', 'CREATED', now(), 'USER_ID_12345', now(), null),

--- a/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
+++ b/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
@@ -1,6 +1,6 @@
 ALTER TABLE referral
-    ADD COLUMN event_id     TEXT NOT NULL DEFAULT 'UNKNOWN',
-    ADD COLUMN event_number INT  NOT NULL DEFAULT 0;
+    ADD COLUMN event_id     TEXT NULL,
+    ADD COLUMN event_number INT  NULL;
 
 COMMENT ON COLUMN referral.event_id IS 'This contains the unique identifier for a licence condition or requirement created event from nDelius.';
 COMMENT ON COLUMN referral.event_number IS 'This is the number of the event that has been sent from nDelius which starts at 1 and increments for subsequent events.'

--- a/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
+++ b/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
@@ -1,0 +1,7 @@
+DELETE
+FROM referral;
+
+ALTER TABLE referral
+    ADD COLUMN event_number TEXT NOT NULL DEFAULT 'UNKNOWN';
+
+COMMENT ON COLUMN referral.event_number IS 'This contains the unique identifier for a licence condition or requirement created event from nDelius.'

--- a/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
+++ b/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
@@ -1,7 +1,6 @@
-DELETE
-FROM referral;
-
 ALTER TABLE referral
-    ADD COLUMN event_number TEXT NOT NULL DEFAULT 'UNKNOWN';
+    ADD COLUMN event_id     TEXT NOT NULL DEFAULT 'UNKNOWN',
+    ADD COLUMN event_number TEXT NOT NULL DEFAULT 0;
 
-COMMENT ON COLUMN referral.event_number IS 'This contains the unique identifier for a licence condition or requirement created event from nDelius.'
+COMMENT ON COLUMN referral.event_id IS 'This contains the unique identifier for a licence condition or requirement created event from nDelius.';
+COMMENT ON COLUMN referral.event_number IS 'This is the number of the event that has been sent from nDelius which starts at 1 and increments for subsequent events.'

--- a/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
+++ b/src/main/resources/db/migration/V10__Add_event_number_column_to_referral_table.sql
@@ -1,6 +1,6 @@
 ALTER TABLE referral
     ADD COLUMN event_id     TEXT NOT NULL DEFAULT 'UNKNOWN',
-    ADD COLUMN event_number TEXT NOT NULL DEFAULT 0;
+    ADD COLUMN event_number INT  NOT NULL DEFAULT 0;
 
 COMMENT ON COLUMN referral.event_id IS 'This contains the unique identifier for a licence condition or requirement created event from nDelius.';
 COMMENT ON COLUMN referral.event_number IS 'This is the number of the event that has been sent from nDelius which starts at 1 and increments for subsequent events.'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
@@ -31,7 +31,7 @@ internal class ReferralTest {
       setting = setting,
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
-      eventNumber = "2",
+      eventNumber = 1,
       eventId = "2500828798",
     )
 
@@ -66,7 +66,7 @@ internal class ReferralTest {
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
       eventId = "2500828798",
-      eventNumber = "1",
+      eventNumber = 1,
     )
 
     // Act
@@ -99,7 +99,7 @@ internal class ReferralTest {
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
       eventId = "2500828798",
-      eventNumber = "1",
+      eventNumber = 1,
     )
 
     // Act

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -31,7 +31,8 @@ internal class ReferralTest {
       setting = setting,
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
-      eventNumber = "2500828798",
+      eventNumber = "2",
+      eventId = "2500828798",
     )
 
     // Act
@@ -64,7 +65,8 @@ internal class ReferralTest {
       setting = setting,
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
-      eventNumber = "2500828798",
+      eventId = "2500828798",
+      eventNumber = "1",
     )
 
     // Act
@@ -96,7 +98,8 @@ internal class ReferralTest {
       setting = setting,
       interventionType = InterventionType.ACP,
       interventionName = "Building Choices",
-      eventNumber = "2500828798",
+      eventId = "2500828798",
+      eventNumber = "1",
     )
 
     // Act

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralTest.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -17,7 +19,7 @@ internal class ReferralTest {
     val crn = "X12345"
     val createdAt = LocalDateTime.now()
     val activeStatus = "Created"
-    val setting = "COMMUNITY"
+    val setting = SettingType.COMMUNITY
 
     val statusHistory = ReferralStatusHistoryEntity(status = activeStatus, endDate = null)
     val referralEntity = ReferralEntity(
@@ -27,6 +29,9 @@ internal class ReferralTest {
       createdAt = createdAt,
       statusHistories = mutableListOf(statusHistory),
       setting = setting,
+      interventionType = InterventionType.ACP,
+      interventionName = "Building Choices",
+      eventNumber = "2500828798",
     )
 
     // Act
@@ -47,7 +52,7 @@ internal class ReferralTest {
     val personName = "Jane Doe"
     val crn = "Y67890"
     val createdAt = LocalDateTime.now()
-    val setting = "COMMUNITY"
+    val setting = SettingType.COMMUNITY
 
     val statusHistory = ReferralStatusHistoryEntity(status = "Withdrawn", endDate = LocalDateTime.now())
     val referralEntity = ReferralEntity(
@@ -57,6 +62,9 @@ internal class ReferralTest {
       createdAt = createdAt,
       statusHistories = mutableListOf(statusHistory),
       setting = setting,
+      interventionType = InterventionType.ACP,
+      interventionName = "Building Choices",
+      eventNumber = "2500828798",
     )
 
     // Act
@@ -77,7 +85,7 @@ internal class ReferralTest {
     val personName = "Mark Smith"
     val crn = "Z12345"
     val createdAt = LocalDateTime.now()
-    val setting = "COMMUNITY"
+    val setting = SettingType.COMMUNITY
 
     val referralEntity = ReferralEntity(
       id = id,
@@ -86,6 +94,9 @@ internal class ReferralTest {
       createdAt = createdAt,
       statusHistories = mutableListOf(),
       setting = setting,
+      interventionType = InterventionType.ACP,
+      interventionName = "Building Choices",
+      eventNumber = "2500828798",
     )
 
     // Act

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
@@ -35,7 +35,7 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
       setting = SettingType.COMMUNITY,
       sourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT,
       sourcedFromReference = "2500828798",
-      eventNumber = "1",
+      eventNumber = 1,
     )
 
     wiremock.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
@@ -10,10 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SourcedFromReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import java.util.UUID
 
@@ -35,6 +35,7 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
       setting = SettingType.COMMUNITY,
       sourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT,
       sourcedFromReference = "2500828798",
+      eventNumber = "1",
     )
 
     wiremock.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
@@ -10,6 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import java.util.UUID
 
@@ -24,11 +28,13 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
     val referralId = UUID.randomUUID()
     val findAndReferReferralDetails = FindAndReferReferralDetails(
       interventionName = "Test Intervention",
-      interventionType = "ACP",
+      interventionType = InterventionType.ACP,
       referralId = referralId,
       personReference = "X123456",
-      personReferenceType = "CRN",
-      setting = "Community",
+      personReferenceType = PersonReferenceType.CRN,
+      setting = SettingType.COMMUNITY,
+      sourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT,
+      sourcedFromReference = "2500828798",
     )
 
     wiremock.stubFor(
@@ -49,7 +55,8 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
         val findAndReferReferralDetails = response.body as FindAndReferReferralDetails
         assertThat(findAndReferReferralDetails).isNotNull()
         assertThat(findAndReferReferralDetails.personReference).isEqualTo("X123456")
-        assertThat(findAndReferReferralDetails.personReferenceType).isEqualTo("CRN")
+        assertThat(findAndReferReferralDetails.personReferenceType).isEqualTo(PersonReferenceType.CRN)
+        assertThat(findAndReferReferralDetails.sourcedFromReference).isEqualTo("2500828798")
       }
 
       is ClientResult.Failure.Other<*> -> fail("Unexpected client result: ${response::class.simpleName}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/DataGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/DataGenerators.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.com
 
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
 import java.time.LocalDate
+import kotlin.random.Random
 
 private val upperCase = ('A'..'Z').toList()
 private val lowerCase = ('a'..'z').toList()
@@ -23,6 +24,7 @@ fun randomSentence(wordRange: IntRange = 1..20, wordLength: IntRange = 3..10): S
   .asString()
 
 fun randomNumber(length: Int = 2) = digits(length)
+fun randomNumberAsInt(length: Int = 2) = Random.nextInt()
 fun randomEmailAddress() = (lowerCase(5) + ".".asSequence() + lowerCase(8) + "@".asSequence() + lowerCase(6) + ".com".asSequence()).asString()
 
 fun randomDateOfBirth(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -146,12 +149,12 @@ class EntityFactoriesTest {
 
   @Test
   fun `ReferralDetailsFactory should create entity with custom values`() {
-    val interventionType = "Custom Intervention Type"
+    val interventionType = InterventionType.CRS
     val interventionName = "Custom Intervention Name"
     val personReference = "CUSTOM123"
-    val personReferenceType = "CUSTOM_TYPE"
+    val personReferenceType = PersonReferenceType.NOMS
     val referralId = UUID.randomUUID()
-    val setting = "CUSTOM_SETTING"
+    val setting = SettingType.CUSTODY
 
     val referralDetails = FindAndReferReferralDetailsFactory()
       .withInterventionType(interventionType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
 
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumber
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SourcedFromReferenceType
 import java.util.UUID
 
 class FindAndReferReferralDetailsFactory {
@@ -18,6 +19,7 @@ class FindAndReferReferralDetailsFactory {
   private var setting: SettingType = SettingType.COMMUNITY
   private var sourcedFromReferenceType: SourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT
   private var sourcedFromReference = randomUppercaseString(6)
+  private var eventNumber = randomNumber(1).toString()
 
   fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
   fun withInterventionName(interventionName: String) = apply { this.interventionName = interventionName }
@@ -28,6 +30,8 @@ class FindAndReferReferralDetailsFactory {
   fun withSetting(setting: SettingType) = apply { this.setting = setting }
   fun withSourceFromReferenceType(sourcedFromReferenceType: SourcedFromReferenceType) = apply { this.sourcedFromReferenceType = sourcedFromReferenceType }
 
+  fun withEventNumber(eventNumber: String) = apply { this.eventNumber = eventNumber }
+
   fun produce() = FindAndReferReferralDetails(
     interventionType = this.interventionType,
     interventionName = this.interventionName,
@@ -37,5 +41,6 @@ class FindAndReferReferralDetailsFactory {
     setting = this.setting,
     sourcedFromReferenceType = this.sourcedFromReferenceType,
     sourcedFromReference = this.sourcedFromReference,
+    eventNumber = this.eventNumber,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
 
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumber
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumberAsInt
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
@@ -19,7 +19,7 @@ class FindAndReferReferralDetailsFactory {
   private var setting: SettingType = SettingType.COMMUNITY
   private var sourcedFromReferenceType: SourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT
   private var sourcedFromReference = randomUppercaseString(6)
-  private var eventNumber = randomNumber(1).toString()
+  private var eventNumber: Int = randomNumberAsInt(1)
 
   fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
   fun withInterventionName(interventionName: String) = apply { this.interventionName = interventionName }
@@ -30,7 +30,7 @@ class FindAndReferReferralDetailsFactory {
   fun withSetting(setting: SettingType) = apply { this.setting = setting }
   fun withSourceFromReferenceType(sourcedFromReferenceType: SourcedFromReferenceType) = apply { this.sourcedFromReferenceType = sourcedFromReferenceType }
 
-  fun withEventNumber(eventNumber: String) = apply { this.eventNumber = eventNumber }
+  fun withEventNumber(eventNumber: Int) = apply { this.eventNumber = eventNumber }
 
   fun produce() = FindAndReferReferralDetails(
     interventionType = this.interventionType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/FindAndReferReferralDetailsFactory.kt
@@ -3,22 +3,30 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SourcedFromReferenceType
 import java.util.UUID
 
 class FindAndReferReferralDetailsFactory {
-  private var interventionType: String = randomUppercaseString(10)
+  private var interventionType: InterventionType = InterventionType.ACP
   private var interventionName: String = randomSentence(wordRange = 1..3)
   private var personReference: String = randomUppercaseString(6)
-  private var personReferenceType: String = "CRN"
+  private var personReferenceType: PersonReferenceType = PersonReferenceType.CRN
   private var referralId: UUID = UUID.randomUUID()
-  private var setting: String = randomUppercaseString(8)
+  private var setting: SettingType = SettingType.COMMUNITY
+  private var sourcedFromReferenceType: SourcedFromReferenceType = SourcedFromReferenceType.REQUIREMENT
+  private var sourcedFromReference = randomUppercaseString(6)
 
-  fun withInterventionType(interventionType: String) = apply { this.interventionType = interventionType }
+  fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
   fun withInterventionName(interventionName: String) = apply { this.interventionName = interventionName }
   fun withPersonReference(personReference: String) = apply { this.personReference = personReference }
-  fun withPersonReferenceType(personReferenceType: String) = apply { this.personReferenceType = personReferenceType }
+  fun withPersonReferenceType(personReferenceType: PersonReferenceType) = apply { this.personReferenceType = personReferenceType }
+
   fun withReferralId(referralId: UUID) = apply { this.referralId = referralId }
-  fun withSetting(setting: String) = apply { this.setting = setting }
+  fun withSetting(setting: SettingType) = apply { this.setting = setting }
+  fun withSourceFromReferenceType(sourcedFromReferenceType: SourcedFromReferenceType) = apply { this.sourcedFromReferenceType = sourcedFromReferenceType }
 
   fun produce() = FindAndReferReferralDetails(
     interventionType = this.interventionType,
@@ -27,5 +35,7 @@ class FindAndReferReferralDetailsFactory {
     personReferenceType = this.personReferenceType,
     referralId = this.referralId,
     setting = this.setting,
+    sourcedFromReferenceType = this.sourcedFromReferenceType,
+    sourcedFromReference = this.sourcedFromReference,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
 
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumber
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumberAsInt
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
@@ -22,7 +22,7 @@ class ReferralEntityFactory {
     mutableListOf(referralStatusHistoryEntityFactory.withStatus("Assessment started").produce())
   private var setting: SettingType = SettingType.COMMUNITY
   private var eventId: String = randomUppercaseString(6)
-  private var eventNumber: String = randomNumber(1).toString()
+  private var eventNumber: Int = randomNumberAsInt(1)
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withPersonName(personName: String?) = apply { this.personName = personName }
@@ -31,7 +31,7 @@ class ReferralEntityFactory {
   fun withStatusHistories(statusHistories: MutableList<ReferralStatusHistoryEntity>) = apply { this.statusHistories = statusHistories }
 
   fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
-  fun withEventNumber(eventNumber: String) = apply { this.eventNumber = eventNumber }
+  fun withEventNumber(eventNumber: Int) = apply { this.eventNumber = eventNumber }
   fun withEventId(eventId: String) = apply { this.eventId = eventId }
   fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
 
@@ -44,7 +44,7 @@ class ReferralEntityFactory {
     statusHistories = this.statusHistories,
     setting = this.setting,
     interventionType = this.interventionType,
-    eventNumber = this.eventNumber,
     eventId = this.eventId,
+    eventNumber = this.eventNumber,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -12,11 +14,13 @@ class ReferralEntityFactory {
   private var id: UUID? = null
   private var personName: String? = randomSentence(wordRange = 1..3)
   private var interventionName: String? = "Building Choices"
+  private var interventionType: InterventionType = InterventionType.ACP
   private var crn: String? = randomUppercaseString(6)
   private var createdAt: LocalDateTime = LocalDateTime.now()
   private var statusHistories: MutableList<ReferralStatusHistoryEntity> =
     mutableListOf(referralStatusHistoryEntityFactory.withStatus("Assessment started").produce())
-  private var setting: String = "COMMUNITY"
+  private var setting: SettingType = SettingType.COMMUNITY
+  private var eventNumber: String = randomUppercaseString(6)
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withPersonName(personName: String?) = apply { this.personName = personName }
@@ -24,6 +28,8 @@ class ReferralEntityFactory {
   fun withCreatedAt(createdAt: LocalDateTime) = apply { this.createdAt = createdAt }
   fun withStatusHistories(statusHistories: MutableList<ReferralStatusHistoryEntity>) = apply { this.statusHistories = statusHistories }
 
+  fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
+  fun withEventNumber(eventNumber: String) = apply { this.eventNumber = eventNumber }
   fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
 
   fun produce() = ReferralEntity(
@@ -33,6 +39,8 @@ class ReferralEntityFactory {
     createdAt = this.createdAt,
     interventionName = this.interventionName,
     statusHistories = this.statusHistories,
-    setting = setting,
+    setting = this.setting,
+    interventionType = this.interventionType,
+    eventNumber = this.eventNumber,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -1,11 +1,12 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
 
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumber
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -20,7 +21,8 @@ class ReferralEntityFactory {
   private var statusHistories: MutableList<ReferralStatusHistoryEntity> =
     mutableListOf(referralStatusHistoryEntityFactory.withStatus("Assessment started").produce())
   private var setting: SettingType = SettingType.COMMUNITY
-  private var eventNumber: String = randomUppercaseString(6)
+  private var eventId: String = randomUppercaseString(6)
+  private var eventNumber: String = randomNumber(1).toString()
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withPersonName(personName: String?) = apply { this.personName = personName }
@@ -30,6 +32,7 @@ class ReferralEntityFactory {
 
   fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
   fun withEventNumber(eventNumber: String) = apply { this.eventNumber = eventNumber }
+  fun withEventId(eventId: String) = apply { this.eventId = eventId }
   fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
 
   fun produce() = ReferralEntity(
@@ -42,5 +45,6 @@ class ReferralEntityFactory {
     setting = this.setting,
     interventionType = this.interventionType,
     eventNumber = this.eventNumber,
+    eventId = this.eventId,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.findAndReferInterventionApi.model.FindAndReferReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.DomainEventsMessageFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FindAndReferReferralDetailsFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.MessageHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
@@ -48,14 +51,13 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     stubAuthTokenEndpoint()
     log.info("Setting up ReferralDetails with id: $sourceReferralId")
 
-    val findAndReferReferralDetails = FindAndReferReferralDetails(
-      interventionName = "Test Intervention",
-      interventionType = "ACP",
-      referralId = sourceReferralId,
-      personReference = "X123456",
-      personReferenceType = "CRN",
-      setting = "Community",
-    )
+    val findAndReferReferralDetails = FindAndReferReferralDetailsFactory()
+      .withInterventionName("Test Intervention")
+      .withInterventionType(InterventionType.ACP)
+      .withReferralId(sourceReferralId)
+      .withPersonReference("X123456")
+      .withPersonReferenceType(PersonReferenceType.CRN)
+      .produce()
 
     wiremock.stubFor(
       get(urlEqualTo("/referral/$sourceReferralId"))
@@ -138,10 +140,10 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     await untilCallTo {
       referralRepository.findAll().firstOrNull()
     } matches {
-      it?.setting == "Community"
+      it?.setting == SettingType.COMMUNITY
       it?.crn == "X123456"
       it?.interventionName == "Test Intervention"
-      it?.interventionType == "ACP"
+      it?.interventionType == InterventionType.ACP
       it?.statusHistories!!.first().status == "Created"
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.InterventionType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PersonReferenceType
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SettingType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.DomainEventsMessageFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FindAndReferReferralDetailsFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase

--- a/src/test/resources/events/interventions/communityReferralCreatedEvent.json
+++ b/src/test/resources/events/interventions/communityReferralCreatedEvent.json
@@ -3,7 +3,7 @@
   "MessageId": "ba0cd0f0-887b-4a97-b502-41bdf32aa27c",
   "Token": null,
   "TopicArn": "arn:aws:sns:eu-west-2:000000000000:hmpps-domain",
-  "Message": "{\"eventType\":\"interventions.community-referral.created\",\"version\":1,\"detailUrl\":\"http://localhost:8080/referral/773888f1-d658-49cb-8d73-1d79862aaae8\",\"occurredAt\":\"2025-07-02T14:14:17.51815+01:00\",\"description\":\"An Interventions referral in community has been created.\",\"additionalInformation\":{},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X928972\"}]}}",
+  "Message": "{\"eventType\":\"interventions.community-referral.created\",\"version\":1,\"detailUrl\":\"https://find-and-refer-intervention-api-dev.hmpps.service.justice.gov.uk/referral/3e759ff8-d2f1-43cb-9e19-bd2006e841d8\",\"occurredAt\":\"2025-07-02T14:14:17.51815+01:00\",\"description\":\"An Interventions referral in community has been created.\",\"additionalInformation\":{},\"personReference\":{\"identifiers\":[{\"type\":\"CRN\",\"value\":\"X928972\"}]}}",
   "SubscribeURL": null,
   "Timestamp": "2021-10-21T06:27:57.028Z",
   "SignatureVersion": "1",


### PR DESCRIPTION
This PR updates the Find and Refer referral details model to accept the `sourcedFromReference` field we need to store in Manage and Deliver.

It also enables connection to the dev instances of Find and Refer and NDelius for local development so we do not have to mock these services any more.