### PR TITLE
APG-941: Sentence Information endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
@@ -151,7 +151,6 @@ class ReferralController(
     return offenceService.getOffenceHistory(referral).let { ResponseEntity.ok(it) }
       ?: throw NotFoundException("Offence history not found for crn ${referral.crn} and referral with id $id")
   }
-
 
   @Operation(
     tags = ["Referrals"],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.SentenceService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ServiceUserService
 import java.util.UUID
 
@@ -30,6 +31,7 @@ class ReferralController(
   private val referralService: ReferralService,
   private val serviceUserService: ServiceUserService,
   private val offenceService: OffenceService,
+  private val sentenceService: SentenceService,
 ) {
 
   @Operation(
@@ -187,7 +189,7 @@ class ReferralController(
     @PathVariable("id") id: UUID,
   ): ResponseEntity<SentenceInformation> {
     val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
-    return serviceUserService.getSentenceInformationByIdentifier(referral.crn, referral.eventNumber).let {
+    return sentenceService.getSentenceInformationByIdentifier(referral.crn, referral.eventNumber).let {
       ResponseEntity.ok(it.toModel())
     } ?: throw NotFoundException("Sentence information not found for crn ${referral.crn} not found")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -152,6 +152,36 @@ class ReferralController(
       ?: throw NotFoundException("Offence history not found for crn ${referral.crn} and referral with id $id")
   }
 
+
+  @Operation(
+    tags = ["Referrals"],
+    summary = "Retrieve sentence information for a referral",
+    operationId = "getSentenceInformationByReferralId",
+    description = """""",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Information about the sentence",
+        content = [Content(schema = Schema(implementation = SentenceInformation::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden.  The client is not authorised to access this referral.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The referral does not exist",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
   @GetMapping("/referral-details/{id}/sentence-information", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getSentenceInformationByReferralId(
     @Parameter(description = "The id (UUID) of a referral", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
@@ -150,4 +151,16 @@ class ReferralController(
     return offenceService.getOffenceHistory(referral).let { ResponseEntity.ok(it) }
       ?: throw NotFoundException("Offence history not found for crn ${referral.crn} and referral with id $id")
   }
+
+  @GetMapping("/referral-details/{id}/sentence-information", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getSentenceInformationByReferralId(
+    @Parameter(description = "The id (UUID) of a referral", required = true)
+    @PathVariable("id") id: UUID,
+  ): ResponseEntity<SentenceInformation> {
+    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    return serviceUserService.getSentenceInformationByIdentifier(referral.crn).let {
+      ResponseEntity.ok(it.toModel(referral.setting))
+    } ?: throw NotFoundException("Personal details not found for crn ${referral.crn} not found")
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
@@ -158,9 +158,8 @@ class ReferralController(
     @PathVariable("id") id: UUID,
   ): ResponseEntity<SentenceInformation> {
     val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
-    return serviceUserService.getSentenceInformationByIdentifier(referral.crn).let {
-      ResponseEntity.ok(it.toModel(referral.setting))
-    } ?: throw NotFoundException("Personal details not found for crn ${referral.crn} not found")
+    return serviceUserService.getSentenceInformationByIdentifier(referral.crn, referral.eventNumber).let {
+      ResponseEntity.ok(it.toModel())
+    } ?: throw NotFoundException("Sentence information not found for crn ${referral.crn} not found")
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
@@ -101,12 +101,11 @@ fun NDeliusSentenceResponse.toModel() = SentenceInformation(
   releaseType = releaseType,
   licenceConditions = licenceConditions,
   licenceEndDate = licenceExpiryDate,
-  // TODO check this value
-  postSentenceSupervisionStartDate = LocalDate.now(),
+  // This is an inferred date that will be the day after the licence expires
+  postSentenceSupervisionStartDate = licenceExpiryDate?.plusDays(1),
   postSentenceSupervisionEndDate = postSentenceSupervisionEndDate,
   twoThirdsPoint = twoThirdsSupervisionDate,
   orderRequirements = requirements,
-  // TODO check this value
-  orderEndDate = LocalDate.now(),
+  orderEndDate = expectedEndDate,
   dateRetrieved = LocalDate.now(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
+import java.time.LocalDate
+
+data class SentenceInformation(
+//  @Schema(
+//    example = "X933590",
+//    required = true,
+//    description = "The crn associated with this referral.",
+//  )
+  @get:JsonProperty("description", required = true)
+  val description: String,
+
+
+  @get:JsonProperty("startDate", required = true)
+  val startDate: LocalDate,
+
+  @get:JsonProperty("licenceExpiryDate", required = true)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val licenceExpiryDate: LocalDate,
+
+  @get:JsonProperty("postSentenceSupervisionEndDate", required = true)
+  val postSentenceSupervisionEndDate: LocalDate? = null,
+
+  @get:JsonProperty("twoThirdsSupervisionDate", required = true)
+  val twoThirdsSupervisionDate: LocalDate,
+
+  @get:JsonProperty("custodial", required = true)
+  val custodial: Boolean,
+
+  @get:JsonProperty("releaseType", required = true)
+  val releaseType: String,
+
+  @get:JsonProperty("licenceConditions", required = true)
+  val licenceConditions: LicenseCondition? = null,
+
+  @get:JsonProperty("requirements", required = true)
+  val requirements: Requirements,
+
+  @get:JsonProperty("postSentenceSupervisionRequirements", required = true)
+  val postSentenceSupervisionRequirements: PostSentenceSupervisionRequirements,
+)
+
+fun NDeliusPersonalDetails.toModel(setting: String) = SentenceInformation(
+  crn = crn,
+  name = name.getNameAsString(),
+  dateOfBirth = LocalDate.parse(dateOfBirth),
+  ethnicity = ethnicity?.description,
+  age = age,
+  gender = sex.description,
+  setting = setting,
+  probationDeliveryUnit = probationDeliveryUnit?.description,
+  dateRetrieved = LocalDate.now(),
+)
+
+data class LicenseCondition(
+  @get:JsonProperty("code", required = true)
+  val code: String? = null,
+
+  @get:JsonProperty("description", required = true)
+  val description: String? = null,
+)
+
+data class Requirements(
+  @get:JsonProperty("code", required = true)
+  val code: String? = null,
+
+  @get:JsonProperty("description", required = true)
+  val description: String? = null,
+)
+
+data class PostSentenceSupervisionRequirements(
+  @get:JsonProperty("code", required = true)
+  val code: String? = null,
+
+  @get:JsonProperty("description", required = true)
+  val description: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
@@ -2,40 +2,86 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import java.time.LocalDate
 
 data class SentenceInformation(
 
+  @Schema(
+    example = "ORA community order",
+    required = false,
+    description = "The type of sentence.",
+  )
   @get:JsonProperty("sentenceType", required = false)
   val sentenceType: String? = null,
 
+  @Schema(
+    example = "Released on licence",
+    required = false,
+    description = "The release type.",
+  )
   @get:JsonProperty("releaseType", required = false)
   val releaseType: String? = null,
 
+  @Schema(
+    example = "['Accredited programme: Building Choices']",
+    required = false,
+    description = "A list of the licence conditions.",
+  )
   @get:JsonProperty("licenceConditions", required = false)
   val licenceConditions: List<CodeDescription>? = null,
 
+  @Schema(
+    example = "10 June 2025",
+    required = false,
+    description = "The end date of the licence.",
+  )
   @get:JsonProperty("licenceEndDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val licenceEndDate: LocalDate? = null,
 
+  @Schema(
+    example = "10 June 2025",
+    required = false,
+    description = "The start date of the post supervision.",
+  )
   @get:JsonProperty("postSentenceSupervisionStartDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val postSentenceSupervisionStartDate: LocalDate? = null,
 
+  @Schema(
+    example = "10 June 2025",
+    required = false,
+    description = "The end date of the post supervision.",
+  )
   @get:JsonProperty("postSentenceSupervisionEndDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val postSentenceSupervisionEndDate: LocalDate? = null,
 
+  @Schema(
+    example = "10 June 2025",
+    required = false,
+    description = "The date two thirds of the way to the end of the sentence.",
+  )
   @get:JsonProperty("twoThirdsPoint", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val twoThirdsPoint: LocalDate? = null,
 
+  @Schema(
+    example = "['Accredited programme: Building Choices']",
+    required = false,
+    description = "A list of the order requirements.",
+  )
   @get:JsonProperty("orderRequirements", required = false)
   val orderRequirements: List<CodeDescription>? = null,
 
+  @Schema(
+    example = "10 June 2025",
+    required = false,
+    description = "The end date of the order.",
+  )
   @get:JsonProperty("orderEndDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val orderEndDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
@@ -85,6 +85,15 @@ data class SentenceInformation(
   @get:JsonProperty("orderEndDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
   val orderEndDate: LocalDate? = null,
+
+  @Schema(
+    example = "1 August 2025",
+    required = true,
+    description = "The date this data was fetched from nDelius.",
+  )
+  @get:JsonProperty("dateRetrieved", required = true)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val dateRetrieved: LocalDate,
 )
 
 fun NDeliusSentenceResponse.toModel() = SentenceInformation(
@@ -99,4 +108,5 @@ fun NDeliusSentenceResponse.toModel() = SentenceInformation(
   orderRequirements = requirements,
   // TODO check this value
   orderEndDate = LocalDate.now(),
+  dateRetrieved = LocalDate.now(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/SentenceInformation.kt
@@ -2,82 +2,55 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import java.time.LocalDate
 
 data class SentenceInformation(
-//  @Schema(
-//    example = "X933590",
-//    required = true,
-//    description = "The crn associated with this referral.",
-//  )
-  @get:JsonProperty("description", required = true)
-  val description: String,
 
+  @get:JsonProperty("sentenceType", required = false)
+  val sentenceType: String? = null,
 
-  @get:JsonProperty("startDate", required = true)
-  val startDate: LocalDate,
+  @get:JsonProperty("releaseType", required = false)
+  val releaseType: String? = null,
 
-  @get:JsonProperty("licenceExpiryDate", required = true)
+  @get:JsonProperty("licenceConditions", required = false)
+  val licenceConditions: List<CodeDescription>? = null,
+
+  @get:JsonProperty("licenceEndDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")
-  val licenceExpiryDate: LocalDate,
+  val licenceEndDate: LocalDate? = null,
 
-  @get:JsonProperty("postSentenceSupervisionEndDate", required = true)
+  @get:JsonProperty("postSentenceSupervisionStartDate", required = false)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val postSentenceSupervisionStartDate: LocalDate? = null,
+
+  @get:JsonProperty("postSentenceSupervisionEndDate", required = false)
+  @JsonFormat(pattern = "d MMMM yyyy")
   val postSentenceSupervisionEndDate: LocalDate? = null,
 
-  @get:JsonProperty("twoThirdsSupervisionDate", required = true)
-  val twoThirdsSupervisionDate: LocalDate,
+  @get:JsonProperty("twoThirdsPoint", required = false)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val twoThirdsPoint: LocalDate? = null,
 
-  @get:JsonProperty("custodial", required = true)
-  val custodial: Boolean,
+  @get:JsonProperty("orderRequirements", required = false)
+  val orderRequirements: List<CodeDescription>? = null,
 
-  @get:JsonProperty("releaseType", required = true)
-  val releaseType: String,
-
-  @get:JsonProperty("licenceConditions", required = true)
-  val licenceConditions: LicenseCondition? = null,
-
-  @get:JsonProperty("requirements", required = true)
-  val requirements: Requirements,
-
-  @get:JsonProperty("postSentenceSupervisionRequirements", required = true)
-  val postSentenceSupervisionRequirements: PostSentenceSupervisionRequirements,
+  @get:JsonProperty("orderEndDate", required = false)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val orderEndDate: LocalDate? = null,
 )
 
-fun NDeliusPersonalDetails.toModel(setting: String) = SentenceInformation(
-  crn = crn,
-  name = name.getNameAsString(),
-  dateOfBirth = LocalDate.parse(dateOfBirth),
-  ethnicity = ethnicity?.description,
-  age = age,
-  gender = sex.description,
-  setting = setting,
-  probationDeliveryUnit = probationDeliveryUnit?.description,
-  dateRetrieved = LocalDate.now(),
-)
-
-data class LicenseCondition(
-  @get:JsonProperty("code", required = true)
-  val code: String? = null,
-
-  @get:JsonProperty("description", required = true)
-  val description: String? = null,
-)
-
-data class Requirements(
-  @get:JsonProperty("code", required = true)
-  val code: String? = null,
-
-  @get:JsonProperty("description", required = true)
-  val description: String? = null,
-)
-
-data class PostSentenceSupervisionRequirements(
-  @get:JsonProperty("code", required = true)
-  val code: String? = null,
-
-  @get:JsonProperty("description", required = true)
-  val description: String? = null,
+fun NDeliusSentenceResponse.toModel() = SentenceInformation(
+  sentenceType = description,
+  releaseType = releaseType,
+  licenceConditions = licenceConditions,
+  licenceEndDate = licenceExpiryDate,
+  // TODO check this value
+  postSentenceSupervisionStartDate = LocalDate.now(),
+  postSentenceSupervisionEndDate = postSentenceSupervisionEndDate,
+  twoThirdsPoint = twoThirdsSupervisionDate,
+  orderRequirements = requirements,
+  // TODO check this value
+  orderEndDate = LocalDate.now(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -7,6 +7,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.BaseHMPPSClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 
 private const val N_DELIUS_INTEGRATION_API = "NDelius Integration API"
@@ -21,7 +22,7 @@ class NDeliusIntegrationApiClient(
     path = "/case/$identifier/personal-details"
   }
 
-  fun getSentenceInformation(crn: String,  eventNumber: String) = getRequest<NDeliusPersonalDetails>("NDelius Integration API") {
+  fun getSentenceInformation(crn: String, eventNumber: Int?) = getRequest<NDeliusSentenceResponse>("NDelius Integration API") {
     path = "/case/$crn/sentence/$eventNumber"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -21,6 +21,10 @@ class NDeliusIntegrationApiClient(
     path = "/case/$identifier/personal-details"
   }
 
+  fun getSentenceInformation(crn: String,  eventNumber: String) = getRequest<NDeliusPersonalDetails>("NDelius Integration API") {
+    path = "/case/$crn/sentence/$eventNumber"
+  }
+
   fun verifyLimitedAccessOffenderCheck(username: String, identifiers: List<String>) = postRequest<LimitedAccessOffenderCheckResponse>(
     N_DELIUS_INTEGRATION_API,
   ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -22,7 +22,7 @@ class NDeliusIntegrationApiClient(
     path = "/case/$identifier/personal-details"
   }
 
-  fun getSentenceInformation(crn: String, eventNumber: Int?) = getRequest<NDeliusSentenceResponse>("NDelius Integration API") {
+  fun getSentenceInformation(crn: String, eventNumber: Int?) = getRequest<NDeliusSentenceResponse>(N_DELIUS_INTEGRATION_API) {
     path = "/case/$crn/sentence/$eventNumber"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/CodeDescription.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/CodeDescription.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
+
+data class CodeDescription(
+  val code: String,
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
@@ -20,11 +20,6 @@ data class FullName(
   val surname: String,
 )
 
-data class CodeDescription(
-  val code: String,
-  val description: String,
-)
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ProbationPractitioner(
   val name: FullName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class NDeliusSentenceResponse(
+//  @Schema(
+//    example = "X933590",
+//    required = true,
+//    description = "The crn associated with this referral.",
+//  )
+  @get:JsonProperty("description", required = false)
+  val description: String? = null,
+
+  @get:JsonProperty("startDate", required = true)
+  val startDate: LocalDate,
+
+  @get:JsonProperty("licenceExpiryDate", required = false)
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val licenceExpiryDate: LocalDate? = null,
+
+  @get:JsonProperty("postSentenceSupervisionEndDate", required = false)
+  val postSentenceSupervisionEndDate: LocalDate? = null,
+
+  @get:JsonProperty("twoThirdsSupervisionDate", required = false)
+  val twoThirdsSupervisionDate: LocalDate? = null,
+
+  @get:JsonProperty("custodial", required = true)
+  val custodial: Boolean,
+
+  @get:JsonProperty("releaseType", required = false)
+  val releaseType: String? = null,
+
+  @get:JsonProperty("licenceConditions", required = true)
+  val licenceConditions: List<CodeDescription>,
+
+  @get:JsonProperty("requirements", required = true)
+  val requirements: List<CodeDescription>,
+
+  @get:JsonProperty("postSentenceSupervisionRequirements", required = true)
+  val postSentenceSupervisionRequirements: List<CodeDescription>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
@@ -7,16 +7,14 @@ import java.time.LocalDate
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class NDeliusSentenceResponse(
-//  @Schema(
-//    example = "X933590",
-//    required = true,
-//    description = "The crn associated with this referral.",
-//  )
   @get:JsonProperty("description", required = false)
   val description: String? = null,
 
   @get:JsonProperty("startDate", required = true)
   val startDate: LocalDate,
+
+  @get:JsonProperty("expectedEndDate", required = false)
+  val expectedEndDate: LocalDate,
 
   @get:JsonProperty("licenceExpiryDate", required = false)
   @JsonFormat(pattern = "d MMMM yyyy")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
+import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
+
+@Service
+class SentenceService(
+  private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
+  private val authenticationHolder: HmppsAuthenticationHolder,
+) {
+
+  fun getSentenceInformationByIdentifier(crn: String, eventNumber: Int?): NDeliusSentenceResponse = when (val result = nDeliusIntegrationApiClient.getSentenceInformation(crn, eventNumber)) {
+    is ClientResult.Success -> result.body
+    is ClientResult.Failure -> result.throwException()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 
 @Service
@@ -26,18 +27,9 @@ class ServiceUserService(
     }
   }
 
-  fun getSentenceInformationByIdentifier(identifier: String): NDeliusPersonalDetails {
-//    val userName = authenticationHolder.username ?: "UNKNOWN_USER"
-//    if (!hasAccessToLimitedAccessOffender(userName, identifier)) {
-//      throw AccessDeniedException(
-//        "You are not authorized to view this person's details. Either contact your administrator or enter a different CRN or Prison Number",
-//      )
-//    }
-
-    return when (val result = nDeliusIntegrationApiClient.getSentenceInformation(identifier eventCode)) {
-      is ClientResult.Success -> result.body
-      is ClientResult.Failure -> result.throwException()
-    }
+  fun getSentenceInformationByIdentifier(crn: String, eventNumber: Int?): NDeliusSentenceResponse = when (val result = nDeliusIntegrationApiClient.getSentenceInformation(crn, eventNumber)) {
+    is ClientResult.Success -> result.body
+    is ClientResult.Failure -> result.throwException()
   }
 
   fun hasAccessToLimitedAccessOffender(username: String, identifier: String): Boolean = when (val result = nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(identifier))) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 
 @Service
@@ -25,11 +24,6 @@ class ServiceUserService(
       is ClientResult.Success -> result.body
       is ClientResult.Failure -> result.throwException()
     }
-  }
-
-  fun getSentenceInformationByIdentifier(crn: String, eventNumber: Int?): NDeliusSentenceResponse = when (val result = nDeliusIntegrationApiClient.getSentenceInformation(crn, eventNumber)) {
-    is ClientResult.Success -> result.body
-    is ClientResult.Failure -> result.throwException()
   }
 
   fun hasAccessToLimitedAccessOffender(username: String, identifier: String): Boolean = when (val result = nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(identifier))) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserService.kt
@@ -26,6 +26,20 @@ class ServiceUserService(
     }
   }
 
+  fun getSentenceInformationByIdentifier(identifier: String): NDeliusPersonalDetails {
+//    val userName = authenticationHolder.username ?: "UNKNOWN_USER"
+//    if (!hasAccessToLimitedAccessOffender(userName, identifier)) {
+//      throw AccessDeniedException(
+//        "You are not authorized to view this person's details. Either contact your administrator or enter a different CRN or Prison Number",
+//      )
+//    }
+
+    return when (val result = nDeliusIntegrationApiClient.getSentenceInformation(identifier eventCode)) {
+      is ClientResult.Success -> result.body
+      is ClientResult.Failure -> result.throwException()
+    }
+  }
+
   fun hasAccessToLimitedAccessOffender(username: String, identifier: String): Boolean = when (val result = nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(identifier))) {
     is ClientResult.Success -> {
       val response = result.body

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -16,11 +16,14 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffenceFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
@@ -29,7 +32,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.inte
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 class ReferralControllerIntegrationTest : IntegrationTestBase() {
 
@@ -132,7 +135,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
         httpMethod = HttpMethod.GET,
         uri = "/referral-details/${savedReferral.id}",
         returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
-        expectedResponseStatus = 403,
+        expectedResponseStatus = HttpStatus.FORBIDDEN.value(),
       )
     }
 
@@ -239,7 +242,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
         httpMethod = HttpMethod.GET,
         uri = "/referral-details/${savedReferral.id}/personal-details",
         returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
-        expectedResponseStatus = 403,
+        expectedResponseStatus = HttpStatus.FORBIDDEN.value(),
       )
     }
 
@@ -285,7 +288,11 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
           ),
         ).produce()
 
-      nDeliusApiStubs.stubSuccessfulOffencesResponse(referralEntity.crn, referralEntity.eventNumber.toString(), offences)
+      nDeliusApiStubs.stubSuccessfulOffencesResponse(
+        referralEntity.crn,
+        referralEntity.eventNumber.toString(),
+        offences,
+      )
 
       // When
       val response = performRequestAndExpectOk(
@@ -361,5 +368,73 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
         expectedResponseStatus = HttpStatus.NOT_FOUND.value(),
       )
     }
+  }
+
+  @Nested
+  @DisplayName("Get sentence information endpoint")
+  inner class GetSentenceInformation {
+    @Test
+    fun `should return sentence information for a referral`() {
+      val referralEntity = ReferralEntityFactory().produce()
+      testDataGenerator.createReferral(referralEntity)
+      val nDeliusSentenceResponse: NDeliusSentenceResponse = NDeliusSentenceResponseFactory().produce()
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referralEntity.crn,
+        referralEntity.eventNumber,
+        nDeliusSentenceResponse,
+      )
+
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${referralEntity.id}/sentence-information",
+        returnType = object : ParameterizedTypeReference<SentenceInformation>() {},
+      )
+
+      assertThat(response).hasFieldOrProperty("sentenceType")
+      assertThat(response).hasFieldOrProperty("releaseType")
+      assertThat(response).hasFieldOrProperty("licenceConditions")
+      assertThat(response).hasFieldOrProperty("licenceEndDate")
+      assertThat(response).hasFieldOrProperty("postSentenceSupervisionStartDate")
+      assertThat(response).hasFieldOrProperty("postSentenceSupervisionEndDate")
+      assertThat(response).hasFieldOrProperty("twoThirdsPoint")
+      assertThat(response).hasFieldOrProperty("orderRequirements")
+      assertThat(response).hasFieldOrProperty("orderEndDate")
+      assertThat(response).hasFieldOrProperty("dateRetrieved")
+
+      Assertions.assertThat(response.sentenceType).isEqualTo(nDeliusSentenceResponse.description)
+      Assertions.assertThat(response.releaseType).isEqualTo(nDeliusSentenceResponse.releaseType)
+    }
+
+    @Test
+    fun `should return forbidden when access denied`() {
+      nDeliusApiStubs.stubAccessCheck(granted = false)
+      val referralEntity = ReferralEntityFactory().produce()
+      testDataGenerator.createReferral(referralEntity)
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referralEntity.crn,
+        referralEntity.eventNumber,
+      )
+
+      webTestClient
+        .method(HttpMethod.GET)
+        .uri("/referral-details/${referralEntity.id}/sentence-information")
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_OTHER")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN)
+        .expectBody(object : ParameterizedTypeReference<ErrorResponse>() {})
+        .returnResult().responseBody!!
+    }
+  }
+
+  @Test
+  fun `should return 404 when referral is not found`() {
+    performRequestAndExpectStatus(
+      httpMethod = HttpMethod.GET,
+      uri = "/referral-details/${UUID.randomUUID()}/sentence-information",
+      object : ParameterizedTypeReference<ErrorResponse>() {},
+      HttpStatus.NOT_FOUND.value(),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SettingType
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -193,5 +195,145 @@ class EntityFactoriesTest {
       .produce()
 
     assertThat(offences.additionalOffences).isEmpty()
+  }
+
+  @Test
+  fun `NDeliusSentenceResponseFactory should create entity with default values`() {
+    val sentenceResponse = NDeliusSentenceResponseFactory().produce()
+
+    assertThat(sentenceResponse.description).isNotNull()
+    assertThat(sentenceResponse.startDate).isNotNull()
+    assertThat(sentenceResponse.licenceExpiryDate).isNotNull()
+    assertThat(sentenceResponse.postSentenceSupervisionEndDate).isNotNull()
+    assertThat(sentenceResponse.twoThirdsSupervisionDate).isNotNull()
+    assertThat(sentenceResponse.custodial).isNotNull()
+    assertThat(sentenceResponse.releaseType).isNotNull()
+    assertThat(sentenceResponse.licenceConditions).isNotEmpty
+    assertThat(sentenceResponse.requirements).isNotEmpty
+    assertThat(sentenceResponse.postSentenceSupervisionRequirements).isNotEmpty
+  }
+
+  @Test
+  fun `NDeliusSentenceResponseFactory should create entity with custom values`() {
+    val description = "Custom sentence description"
+    val startDate = LocalDate.of(2023, 6, 1)
+    val licenceExpiryDate = LocalDate.of(2025, 6, 1)
+    val postSentenceSupervisionEndDate = LocalDate.of(2026, 6, 1)
+    val twoThirdsSupervisionDate = LocalDate.of(2024, 12, 1)
+    val custodial = false
+    val releaseType = "Early Release"
+    val licenceConditions = listOf(CodeDescription("LC", "Custom licence condition"))
+    val requirements = listOf(
+      CodeDescription("REQ1", "Custom requirement 1"),
+      CodeDescription("REQ2", "Custom requirement 2"),
+    )
+    val postSentenceSupervisionRequirements = emptyList<CodeDescription>()
+
+    val sentenceResponse = NDeliusSentenceResponseFactory()
+      .withDescription(description)
+      .withStartDate(startDate)
+      .withLicenceExpiryDate(licenceExpiryDate)
+      .withPostSentenceSupervisionEndDate(postSentenceSupervisionEndDate)
+      .withTwoThirdsSupervisionDate(twoThirdsSupervisionDate)
+      .withCustodial(custodial)
+      .withReleaseType(releaseType)
+      .withLicenceConditions(licenceConditions)
+      .withRequirements(requirements)
+      .withPostSentenceSupervisionRequirements(postSentenceSupervisionRequirements)
+      .produce()
+
+    assertThat(sentenceResponse.description).isEqualTo(description)
+    assertThat(sentenceResponse.startDate).isEqualTo(startDate)
+    assertThat(sentenceResponse.licenceExpiryDate).isEqualTo(licenceExpiryDate)
+    assertThat(sentenceResponse.postSentenceSupervisionEndDate).isEqualTo(postSentenceSupervisionEndDate)
+    assertThat(sentenceResponse.twoThirdsSupervisionDate).isEqualTo(twoThirdsSupervisionDate)
+    assertThat(sentenceResponse.custodial).isEqualTo(custodial)
+    assertThat(sentenceResponse.releaseType).isEqualTo(releaseType)
+    assertThat(sentenceResponse.licenceConditions).isEqualTo(licenceConditions)
+    assertThat(sentenceResponse.requirements).isEqualTo(requirements)
+    assertThat(sentenceResponse.postSentenceSupervisionRequirements).isEqualTo(postSentenceSupervisionRequirements)
+  }
+
+  @Test
+  fun `SentenceInformationFactory should create entity with default values`() {
+    val sentenceInformation = SentenceInformationFactory().produce()
+
+    assertThat(sentenceInformation.sentenceType).isNotNull()
+    assertThat(sentenceInformation.releaseType).isNotNull()
+    assertThat(sentenceInformation.licenceConditions).isNotNull()
+    assertThat(sentenceInformation.licenceEndDate).isNotNull()
+    assertThat(sentenceInformation.postSentenceSupervisionStartDate).isNotNull()
+    assertThat(sentenceInformation.postSentenceSupervisionEndDate).isNotNull()
+    assertThat(sentenceInformation.twoThirdsPoint).isNotNull()
+    assertThat(sentenceInformation.orderRequirements).isNotNull()
+    assertThat(sentenceInformation.orderEndDate).isNotNull()
+    assertThat(sentenceInformation.dateRetrieved).isNotNull()
+  }
+
+  @Test
+  fun `SentenceInformationFactory should create entity with custom values`() {
+    val sentenceType = "ORA community order"
+    val releaseType = "Standard Release"
+    val licenceConditions = listOf(CodeDescription("OR1", "Custom order requirement 1"))
+    val licenceEndDate = LocalDate.of(2025, 6, 1)
+    val postSentenceSupervisionStartDate = LocalDate.of(2024, 6, 1)
+    val postSentenceSupervisionEndDate = LocalDate.of(2026, 6, 1)
+    val twoThirdsPoint = LocalDate.of(2024, 12, 1)
+    val orderRequirements = listOf(
+      CodeDescription("OR1", "Custom order requirement 1"),
+      CodeDescription("OR2", "Custom order requirement 2"),
+    )
+    val orderEndDate = LocalDate.of(2024, 12, 31)
+    val dateRetrieved = LocalDate.of(2024, 8, 1)
+
+    val sentenceInformation = SentenceInformationFactory()
+      .withSentenceType(sentenceType)
+      .withReleaseType(releaseType)
+      .withLicenceConditions(licenceConditions)
+      .withLicenceEndDate(licenceEndDate)
+      .withPostSentenceSupervisionStartDate(postSentenceSupervisionStartDate)
+      .withPostSentenceSupervisionEndDate(postSentenceSupervisionEndDate)
+      .withTwoThirdsPoint(twoThirdsPoint)
+      .withOrderRequirements(orderRequirements)
+      .withOrderEndDate(orderEndDate)
+      .withDateRetrieved(dateRetrieved)
+      .produce()
+
+    assertThat(sentenceInformation.sentenceType).isEqualTo(sentenceType)
+    assertThat(sentenceInformation.releaseType).isEqualTo(releaseType)
+    assertThat(sentenceInformation.licenceConditions).isEqualTo(licenceConditions)
+    assertThat(sentenceInformation.licenceEndDate).isEqualTo(licenceEndDate)
+    assertThat(sentenceInformation.postSentenceSupervisionStartDate).isEqualTo(postSentenceSupervisionStartDate)
+    assertThat(sentenceInformation.postSentenceSupervisionEndDate).isEqualTo(postSentenceSupervisionEndDate)
+    assertThat(sentenceInformation.twoThirdsPoint).isEqualTo(twoThirdsPoint)
+    assertThat(sentenceInformation.orderRequirements).isEqualTo(orderRequirements)
+    assertThat(sentenceInformation.orderEndDate).isEqualTo(orderEndDate)
+    assertThat(sentenceInformation.dateRetrieved).isEqualTo(dateRetrieved)
+  }
+
+  @Test
+  fun `SentenceInformationFactory should create entity with null optional values`() {
+    val sentenceInformation = SentenceInformationFactory()
+      .withSentenceType(null)
+      .withReleaseType(null)
+      .withLicenceConditions(null)
+      .withLicenceEndDate(null)
+      .withPostSentenceSupervisionStartDate(null)
+      .withPostSentenceSupervisionEndDate(null)
+      .withTwoThirdsPoint(null)
+      .withOrderRequirements(null)
+      .withOrderEndDate(null)
+      .produce()
+
+    assertThat(sentenceInformation.sentenceType).isNull()
+    assertThat(sentenceInformation.releaseType).isNull()
+    assertThat(sentenceInformation.licenceConditions).isNull()
+    assertThat(sentenceInformation.licenceEndDate).isNull()
+    assertThat(sentenceInformation.postSentenceSupervisionStartDate).isNull()
+    assertThat(sentenceInformation.postSentenceSupervisionEndDate).isNull()
+    assertThat(sentenceInformation.twoThirdsPoint).isNull()
+    assertThat(sentenceInformation.orderRequirements).isNull()
+    assertThat(sentenceInformation.orderEndDate).isNull()
+    assertThat(sentenceInformation.dateRetrieved).isNotNull() // This is required
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
@@ -3,32 +3,27 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.Utils.createCodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.Utils.createCodeDescriptionList
 import java.time.LocalDate
 
 class NDeliusSentenceResponseFactory {
   private var description: String? = randomSentence(wordRange = 2..5)
   private var startDate: LocalDate = LocalDate.now().minusYears(1)
+  private var expectedEndDate: LocalDate = LocalDate.now()
   private var licenceExpiryDate: LocalDate? = LocalDate.now().plusYears(2)
   private var postSentenceSupervisionEndDate: LocalDate? = LocalDate.now().plusYears(3)
   private var twoThirdsSupervisionDate: LocalDate? = LocalDate.now().plusMonths(18)
   private var custodial: Boolean = true
   private var releaseType: String? = "Standard Release"
-  fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
-  private var licenceConditions: List<CodeDescription> = listOf(
-    createCodeDescription(),
-    createCodeDescription(),
-  )
-  private var requirements: List<CodeDescription> = listOf(
-    createCodeDescription(),
-    createCodeDescription(),
-  )
-  private var postSentenceSupervisionRequirements: List<CodeDescription> = listOf(
-    createCodeDescription(),
-  )
+
+  private var licenceConditions: List<CodeDescription> = listOf(createCodeDescription(), createCodeDescription())
+  private var requirements: List<CodeDescription> = createCodeDescriptionList()
+  private var postSentenceSupervisionRequirements: List<CodeDescription> = createCodeDescriptionList()
 
   fun withDescription(description: String?) = apply { this.description = description }
   fun withStartDate(startDate: LocalDate) = apply { this.startDate = startDate }
+  fun withExpectedEndDate(expectedEndDate: LocalDate) = apply { this.expectedEndDate = startDate }
   fun withLicenceExpiryDate(licenceExpiryDate: LocalDate?) = apply { this.licenceExpiryDate = licenceExpiryDate }
   fun withPostSentenceSupervisionEndDate(postSentenceSupervisionEndDate: LocalDate?) = apply { this.postSentenceSupervisionEndDate = postSentenceSupervisionEndDate }
 
@@ -52,5 +47,6 @@ class NDeliusSentenceResponseFactory {
     licenceConditions = this.licenceConditions,
     requirements = this.requirements,
     postSentenceSupervisionRequirements = this.postSentenceSupervisionRequirements,
+    expectedEndDate = this.expectedEndDate,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import java.time.LocalDate
+
+class NDeliusSentenceResponseFactory {
+  private var description: String? = randomSentence(wordRange = 2..5)
+  private var startDate: LocalDate = LocalDate.now().minusYears(1)
+  private var licenceExpiryDate: LocalDate? = LocalDate.now().plusYears(2)
+  private var postSentenceSupervisionEndDate: LocalDate? = LocalDate.now().plusYears(3)
+  private var twoThirdsSupervisionDate: LocalDate? = LocalDate.now().plusMonths(18)
+  private var custodial: Boolean = true
+  private var releaseType: String? = "Standard Release"
+  fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
+  private var licenceConditions: List<CodeDescription> = listOf(
+    createCodeDescription(),
+    createCodeDescription(),
+  )
+  private var requirements: List<CodeDescription> = listOf(
+    createCodeDescription(),
+    createCodeDescription(),
+  )
+  private var postSentenceSupervisionRequirements: List<CodeDescription> = listOf(
+    createCodeDescription(),
+  )
+
+  fun withDescription(description: String?) = apply { this.description = description }
+  fun withStartDate(startDate: LocalDate) = apply { this.startDate = startDate }
+  fun withLicenceExpiryDate(licenceExpiryDate: LocalDate?) = apply { this.licenceExpiryDate = licenceExpiryDate }
+  fun withPostSentenceSupervisionEndDate(postSentenceSupervisionEndDate: LocalDate?) = apply { this.postSentenceSupervisionEndDate = postSentenceSupervisionEndDate }
+
+  fun withTwoThirdsSupervisionDate(twoThirdsSupervisionDate: LocalDate?) = apply { this.twoThirdsSupervisionDate = twoThirdsSupervisionDate }
+
+  fun withCustodial(custodial: Boolean) = apply { this.custodial = custodial }
+  fun withReleaseType(releaseType: String?) = apply { this.releaseType = releaseType }
+  fun withLicenceConditions(licenceConditions: List<CodeDescription>) = apply { this.licenceConditions = licenceConditions }
+
+  fun withRequirements(requirements: List<CodeDescription>) = apply { this.requirements = requirements }
+  fun withPostSentenceSupervisionRequirements(postSentenceSupervisionRequirements: List<CodeDescription>) = apply { this.postSentenceSupervisionRequirements = postSentenceSupervisionRequirements }
+
+  fun produce() = NDeliusSentenceResponse(
+    description = this.description,
+    startDate = this.startDate,
+    licenceExpiryDate = this.licenceExpiryDate,
+    postSentenceSupervisionEndDate = this.postSentenceSupervisionEndDate,
+    twoThirdsSupervisionDate = this.twoThirdsSupervisionDate,
+    custodial = this.custodial,
+    releaseType = this.releaseType,
+    licenceConditions = this.licenceConditions,
+    requirements = this.requirements,
+    postSentenceSupervisionRequirements = this.postSentenceSupervisionRequirements,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/SentenceInformationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/SentenceInformationFactory.kt
@@ -3,28 +3,21 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.Utils.createCodeDescriptionList
 import java.time.LocalDate
 
 class SentenceInformationFactory {
   private var sentenceType: String? = randomSentence(wordRange = 2..4)
   private var releaseType: String? = "Released on licence"
-  private var licenceConditions: List<CodeDescription>? = listOf(
-    createCodeDescription(),
-    createCodeDescription(),
-  )
+  private var licenceConditions: List<CodeDescription>? = createCodeDescriptionList(2)
   private var licenceEndDate: LocalDate? = LocalDate.now().plusYears(2)
-  private var postSentenceSupervisionStartDate: LocalDate? = LocalDate.now().plusMonths(18)
+  private var postSentenceSupervisionStartDate: LocalDate? = licenceEndDate?.plusDays(1)
   private var postSentenceSupervisionEndDate: LocalDate? = LocalDate.now().plusYears(3)
   private var twoThirdsPoint: LocalDate? = LocalDate.now().plusMonths(20)
-  private var orderRequirements: List<CodeDescription>? = listOf(
-    createCodeDescription(),
-    createCodeDescription(),
-  )
+  private var orderRequirements: List<CodeDescription>? = createCodeDescriptionList(2)
   private var orderEndDate: LocalDate? = LocalDate.now().plusYears(1)
   private var dateRetrieved: LocalDate = LocalDate.now()
 
-  fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
   fun withSentenceType(sentenceType: String?) = apply { this.sentenceType = sentenceType }
   fun withReleaseType(releaseType: String?) = apply { this.releaseType = releaseType }
   fun withLicenceConditions(licenceConditions: List<CodeDescription>?) = apply { this.licenceConditions = licenceConditions }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/SentenceInformationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/SentenceInformationFactory.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.SentenceInformation
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import java.time.LocalDate
+
+class SentenceInformationFactory {
+  private var sentenceType: String? = randomSentence(wordRange = 2..4)
+  private var releaseType: String? = "Released on licence"
+  private var licenceConditions: List<CodeDescription>? = listOf(
+    createCodeDescription(),
+    createCodeDescription(),
+  )
+  private var licenceEndDate: LocalDate? = LocalDate.now().plusYears(2)
+  private var postSentenceSupervisionStartDate: LocalDate? = LocalDate.now().plusMonths(18)
+  private var postSentenceSupervisionEndDate: LocalDate? = LocalDate.now().plusYears(3)
+  private var twoThirdsPoint: LocalDate? = LocalDate.now().plusMonths(20)
+  private var orderRequirements: List<CodeDescription>? = listOf(
+    createCodeDescription(),
+    createCodeDescription(),
+  )
+  private var orderEndDate: LocalDate? = LocalDate.now().plusYears(1)
+  private var dateRetrieved: LocalDate = LocalDate.now()
+
+  fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
+  fun withSentenceType(sentenceType: String?) = apply { this.sentenceType = sentenceType }
+  fun withReleaseType(releaseType: String?) = apply { this.releaseType = releaseType }
+  fun withLicenceConditions(licenceConditions: List<CodeDescription>?) = apply { this.licenceConditions = licenceConditions }
+
+  fun withLicenceEndDate(licenceEndDate: LocalDate?) = apply { this.licenceEndDate = licenceEndDate }
+  fun withPostSentenceSupervisionStartDate(postSentenceSupervisionStartDate: LocalDate?) = apply { this.postSentenceSupervisionStartDate = postSentenceSupervisionStartDate }
+
+  fun withPostSentenceSupervisionEndDate(postSentenceSupervisionEndDate: LocalDate?) = apply { this.postSentenceSupervisionEndDate = postSentenceSupervisionEndDate }
+
+  fun withTwoThirdsPoint(twoThirdsPoint: LocalDate?) = apply { this.twoThirdsPoint = twoThirdsPoint }
+  fun withOrderRequirements(orderRequirements: List<CodeDescription>?) = apply { this.orderRequirements = orderRequirements }
+
+  fun withOrderEndDate(orderEndDate: LocalDate?) = apply { this.orderEndDate = orderEndDate }
+  fun withDateRetrieved(dateRetrieved: LocalDate) = apply { this.dateRetrieved = dateRetrieved }
+
+  fun produce() = SentenceInformation(
+    sentenceType = this.sentenceType,
+    releaseType = this.releaseType,
+    licenceConditions = this.licenceConditions,
+    licenceEndDate = this.licenceEndDate,
+    postSentenceSupervisionStartDate = this.postSentenceSupervisionStartDate,
+    postSentenceSupervisionEndDate = this.postSentenceSupervisionEndDate,
+    twoThirdsPoint = this.twoThirdsPoint,
+    orderRequirements = this.orderRequirements,
+    orderEndDate = this.orderEndDate,
+    dateRetrieved = this.dateRetrieved,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
@@ -10,8 +10,10 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheck
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 
 class NDeliusApiStubs(
@@ -56,7 +58,11 @@ class NDeliusApiStubs(
     )
   }
 
-  fun stubSuccessfulOffencesResponse(crn: String, eventNumber: String, offences: Offences = OffencesFactory().produce()) {
+  fun stubSuccessfulOffencesResponse(
+    crn: String,
+    eventNumber: String,
+    offences: Offences = OffencesFactory().produce(),
+  ) {
     wiremock.stubFor(
       get(urlPathTemplate("/case/$crn/sentence/$eventNumber/offences"))
         .willReturn(
@@ -71,6 +77,36 @@ class NDeliusApiStubs(
   fun stubNotFoundOffencesResponse(crn: String, eventNumber: String) {
     wiremock.stubFor(
       get(urlEqualTo("/case/$crn/sentence/$eventNumber/offences"))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+
+  fun stubSuccessfulSentenceInformationResponse(
+    crn: String,
+    eventNumber: Int?,
+    nDeliusSentenceResponse: NDeliusSentenceResponse = NDeliusSentenceResponseFactory().produce(),
+  ) {
+    wiremock.stubFor(
+      get(urlPathTemplate("/case/$crn/sentence/$eventNumber"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(nDeliusSentenceResponse)),
+        ),
+    )
+  }
+
+  fun stubNotFoundSentenceInformationResponse(
+    crn: String,
+    eventNumber: String,
+  ) {
+    wiremock.stubFor(
+      get(urlPathTemplate("/case/$crn/sentence/$eventNumber"))
         .willReturn(
           aResponse()
             .withStatus(404)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/Utils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/Utils.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+
+object Utils {
+
+  fun createCodeDescription(): CodeDescription = CodeDescription(randomUppercaseString(2), randomSentence())
+  fun createCodeDescriptionList(listSize: Int = 1): List<CodeDescription> = (1..listSize).map { createCodeDescription() }
+}

--- a/wiremock_mappings/nDeliusMock.json
+++ b/wiremock_mappings/nDeliusMock.json
@@ -57,6 +57,43 @@
           "response-template"
         ]
       }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/case/.*/sentence/.*"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "description": "ORA Community Order (6 Months)",
+          "startDate": "2024-09-24",
+          "expectedEndDate": "2025-03-23",
+          "custodial": false,
+          "licenceConditions": [],
+          "requirements": [
+            {
+              "code": "RARREQ",
+              "description": "Rehabilitation Activity Requirement (RAR)"
+            },
+            {
+              "code": "724",
+              "description": "Building Skills for Recovery (BSR)"
+            },
+            {
+              "code": "CSPE06",
+              "description": "Curfew"
+            }
+          ],
+          "postSentenceSupervisionRequirements": []
+        },
+        "transformers": [
+          "response-template"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR returns the sentence information for a referral. A referral can either be on a `licence condition` or `community order` and returns different fields to the ui for each. We have set these fields to null and they will be filtered out on the ui to display the correct information.

```json
{
    "sentenceType": "ORA Community Order (6 Months)",
    "releaseType": null,
    "licenceConditions": [],
    "licenceEndDate": null,
    "postSentenceSupervisionStartDate": null,
    "postSentenceSupervisionEndDate": null,
    "twoThirdsPoint": null,
    "orderRequirements": [
        {
            "code": "RARREQ",
            "description": "Rehabilitation Activity Requirement (RAR)"
        },
        {
            "code": "724",
            "description": "Building Skills for Recovery (BSR)"
        },
        {
            "code": "CSPE06",
            "description": "Curfew"
        }
    ],
    "orderEndDate": "23 March 2025",
    "dateRetrieved": "8 August 2025"
}
```