### PR TITLE
[APG-1110] Add offence history retrieval via NDelius API integration and expose API endpoint in Referral controller

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -13,10 +13,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toModel
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ServiceUserService
 import java.util.UUID
@@ -26,6 +28,7 @@ import java.util.UUID
 class ReferralController(
   private val referralService: ReferralService,
   private val serviceUserService: ServiceUserService,
+  private val offenceService: OffenceService,
 ) {
 
   @Operation(
@@ -103,5 +106,49 @@ class ReferralController(
     return serviceUserService.getPersonalDetailsByIdentifier(referral.crn).let {
       ResponseEntity.ok(it.toModel(referral.setting))
     } ?: throw NotFoundException("Personal details not found for crn ${referral.crn} not found")
+  }
+
+  @Operation(
+    tags = ["Referrals"],
+    summary = "Retrieve offence history for a referral",
+    operationId = "getOffenceHistoryByReferralId",
+    description = """""",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Information about the offence history",
+        content = [Content(schema = Schema(implementation = OffenceHistory::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden.  The client is not authorised to access this referral.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The referral does not exist",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The offence history for the referral does not exist",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
+  @GetMapping("/referral-details/{id}/offence-history", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getOffenceHistoryByReferralId(
+    @Parameter(description = "The id (UUID) of a referral", required = true)
+    @PathVariable("id") id: UUID,
+  ): ResponseEntity<OffenceHistory> {
+    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    return offenceService.getOffenceHistory(referral).let { ResponseEntity.ok(it) }
+      ?: throw NotFoundException("Offence history not found for crn ${referral.crn} and referral with id $id")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -112,7 +112,6 @@ class ReferralController(
     tags = ["Referrals"],
     summary = "Retrieve offence history for a referral",
     operationId = "getOffenceHistoryByReferralId",
-    description = """""",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/Offence.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Details of an offence committed by an offender")
+data class Offence(
+  @Schema(description = "The date when the offence was committed", example = "2024-01-15")
+  val offenceDate: LocalDate,
+  @Schema(description = "The description of the offence", example = "Theft")
+  val offence: String,
+  @Schema(description = "The code identifying the offence", example = "68")
+  val offenceCode: String,
+  @Schema(description = "The category of the offence", example = "Theft and burglary offences")
+  val category: String,
+  @Schema(description = "The code identifying the offence category", example = "12")
+  val categoryCode: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/Offence.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 @Schema(description = "Details of an offence committed by an offender")
 data class Offence(
-  @Schema(description = "The date when the offence was committed", example = "2024-01-15")
+  @Schema(description = "The date when the offence was committed", example = "11 June 2020")
+  @JsonFormat(pattern = "d MMMM yyyy")
   val offenceDate: LocalDate,
   @Schema(description = "The description of the offence", example = "Theft")
   val offence: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offence as NDeliusOffence
+
+@Schema(description = "Represents a individuals history of offences, including their main offence and any additional offences")
+data class OffenceHistory(
+  @Schema(description = "The primary offence committed")
+  val mainOffence: Offence,
+  @Schema(description = "List of additional or secondary offences")
+  val additionalOffences: List<Offence>,
+)
+
+fun Offences.toApi() = OffenceHistory(
+  mainOffence = mainOffence.toApi(),
+  additionalOffences = additionalOffences.map { it.toApi() },
+)
+
+fun NDeliusOffence.toApi() = Offence(
+  offenceDate = date,
+  offence = mainCategoryDescription,
+  offenceCode = mainCategoryCode,
+  category = subCategoryDescription,
+  categoryCode = subCategoryCode,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offence as NDeliusOffence
 
-@Schema(description = "Represents a individuals history of offences, including their main offence and any additional offences")
+@Schema(description = "Represents an individual's history of offences, including their main offence and any additional offences")
 data class OffenceHistory(
   @Schema(description = "The primary offence committed")
   val mainOffence: Offence,
   @Schema(description = "List of additional or secondary offences")
-  val additionalOffences: List<Offence>,
+  val additionalOffences: List<Offence> = emptyList(),
 )
 
 fun Offences.toApi() = OffenceHistory(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -28,7 +28,7 @@ class NDeliusIntegrationApiClient(
     body = identifiers
   }
 
-  fun getOffences(crn: String, eventNumber: String) = getRequest<Offences>(N_DELIUS_INTEGRATION_API) {
+  fun getOffences(crn: String, eventNumber: Int) = getRequest<Offences>(N_DELIUS_INTEGRATION_API) {
     path = "/case/$crn/sentence/$eventNumber/offences"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -7,6 +7,9 @@ import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.BaseHMPPSClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
+
+private const val N_DELIUS_INTEGRATION_API = "NDelius Integration API"
 
 @Component
 class NDeliusIntegrationApiClient(
@@ -14,12 +17,18 @@ class NDeliusIntegrationApiClient(
   objectMapper: ObjectMapper,
 ) : BaseHMPPSClient(webClient, objectMapper) {
 
-  fun getPersonalDetails(identifier: String) = getRequest<NDeliusPersonalDetails>("NDelius Integration API") {
+  fun getPersonalDetails(identifier: String) = getRequest<NDeliusPersonalDetails>(N_DELIUS_INTEGRATION_API) {
     path = "/case/$identifier/personal-details"
   }
 
-  fun verifyLimitedAccessOffenderCheck(username: String, identifiers: List<String>) = postRequest<LimitedAccessOffenderCheckResponse>("NDelius Integration API") {
+  fun verifyLimitedAccessOffenderCheck(username: String, identifiers: List<String>) = postRequest<LimitedAccessOffenderCheckResponse>(
+    N_DELIUS_INTEGRATION_API,
+  ) {
     path = "/user/$username/access"
     body = identifiers
+  }
+
+  fun getOffences(crn: String, eventNumber: String) = getRequest<Offences>(N_DELIUS_INTEGRATION_API) {
+    path = "/case/$crn/sentence/$eventNumber/offences"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/Offence.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
+
+import java.time.LocalDate
+
+data class Offence(
+  val date: LocalDate,
+  val mainCategoryCode: String,
+  val mainCategoryDescription: String,
+  val subCategoryCode: String,
+  val subCategoryDescription: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/Offences.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/Offences.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
+
+data class Offences(
+  val mainOffence: Offence,
+  val additionalOffences: List<Offence>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -74,6 +74,7 @@ class ReferralEntity(
   @Column("event_id")
   val eventId: String? = null,
 
+  //  The Delius event number representing a specific court case event
   @Nullable
   @Column("event_number")
   val eventNumber: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toApi
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+
+@Service
+class OffenceService(
+  private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getOffenceHistory(referral: ReferralEntity): OffenceHistory = getOffences(referral.crn, referral.eventNumber.toString()).toApi()
+
+  fun getOffences(crn: String, eventNumber: String): Offences = when (val result = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
+    is ClientResult.Failure -> {
+      log.warn("Failure to retrieve offence details for crn : $crn and event number: $eventNumber")
+      throw NotFoundException("No Offences found for crn: $crn and event number: $eventNumber")
+    }
+    is ClientResult.Success -> result.body
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
@@ -18,9 +18,9 @@ class OffenceService(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getOffenceHistory(referral: ReferralEntity): OffenceHistory = getOffences(referral.crn, referral.eventNumber.toString()).toApi()
+  fun getOffenceHistory(referral: ReferralEntity): OffenceHistory = getOffences(referral.crn, referral.eventNumber!!).toApi()
 
-  fun getOffences(crn: String, eventNumber: String): Offences = when (val result = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
+  fun getOffences(crn: String, eventNumber: Int): Offences = when (val result = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
     is ClientResult.Failure -> {
       log.warn("Failure to retrieve offence details for crn : $crn and event number: $eventNumber")
       throw NotFoundException("No Offences found for crn: $crn and event number: $eventNumber")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -12,8 +12,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -270,6 +270,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
             .withSubCategoryCode("01")
             .withMainCategoryDescription("Stealing from shops and stalls")
             .withSubCategoryDescription("Not eating enough vegetables")
+            .withDate(LocalDate.of(2023, 1, 1))
             .produce(),
         )
         .withAdditionalOffences(
@@ -279,6 +280,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
               .withSubCategoryCode("13")
               .withMainCategoryDescription("Jaywalking")
               .withSubCategoryDescription("Steeple chase")
+              .withDate(LocalDate.of(2020, 6, 13))
               .produce(),
           ),
         ).produce()
@@ -298,6 +300,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response.mainOffence.offenceCode).isEqualTo("56")
       assertThat(response.mainOffence.categoryCode).isEqualTo("01")
       assertThat(response.mainOffence.category).isEqualTo("Not eating enough vegetables")
+      assertThat(response.mainOffence.offenceDate).isEqualTo(LocalDate.of(2023, 1, 1))
 
       assertThat(response.additionalOffences).hasSize(1)
       val additionalOffence = response.additionalOffences[0]
@@ -305,6 +308,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       assertThat(additionalOffence.offenceCode).isEqualTo("23")
       assertThat(additionalOffence.categoryCode).isEqualTo("13")
       assertThat(additionalOffence.category).isEqualTo("Steeple chase")
+      assertThat(additionalOffence.offenceDate).isEqualTo(LocalDate.of(2020, 6, 13))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -10,7 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonalDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
@@ -18,6 +20,8 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffenceFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.wiremock.stubs.NDeliusApiStubs
@@ -231,6 +235,111 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
         uri = "/referral-details/${UUID.randomUUID()}/personal-details",
         object : ParameterizedTypeReference<ErrorResponse>() {},
         HttpStatus.NOT_FOUND.value(),
+      )
+    }
+  }
+
+  @Nested
+  @DisplayName("Get offence history endpoint")
+  inner class GetOffenceHistory {
+    @Test
+    fun `should return offence history for existing referral with offence history`() {
+      // Given
+      val referralEntity = ReferralEntityFactory().produce()
+      testDataGenerator.createReferral(referralEntity)
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+      val offences = OffencesFactory()
+        .withMainOffence(
+          OffenceFactory()
+            .withMainCategoryCode("56")
+            .withSubCategoryCode("01")
+            .withMainCategoryDescription("Stealing from shops and stalls")
+            .withSubCategoryDescription("Not eating enough vegetables")
+            .produce(),
+        )
+        .withAdditionalOffences(
+          listOf(
+            OffenceFactory()
+              .withMainCategoryCode("23")
+              .withSubCategoryCode("13")
+              .withMainCategoryDescription("Jaywalking")
+              .withSubCategoryDescription("Steeple chase")
+              .produce(),
+          ),
+        ).produce()
+
+      nDeliusApiStubs.stubSuccessfulOffencesResponse(referralEntity.crn, referralEntity.eventNumber.toString(), offences)
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}/offence-history",
+        returnType = object : ParameterizedTypeReference<OffenceHistory>() {},
+      )
+
+      // Then
+      assertThat(response).isNotNull
+      assertThat(response.mainOffence.offence).isEqualTo("Stealing from shops and stalls")
+      assertThat(response.mainOffence.offenceCode).isEqualTo("56")
+      assertThat(response.mainOffence.categoryCode).isEqualTo("01")
+      assertThat(response.mainOffence.category).isEqualTo("Not eating enough vegetables")
+
+      assertThat(response.additionalOffences).hasSize(1)
+      val additionalOffence = response.additionalOffences[0]
+      assertThat(additionalOffence.offence).isEqualTo("Jaywalking")
+      assertThat(additionalOffence.offenceCode).isEqualTo("23")
+      assertThat(additionalOffence.categoryCode).isEqualTo("13")
+      assertThat(additionalOffence.category).isEqualTo("Steeple chase")
+    }
+
+    @Test
+    fun `should return forbidden when access denied`() {
+      // Given
+      val referralEntity = ReferralEntityFactory().produce()
+      testDataGenerator.createReferral(referralEntity)
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+
+      // When & Then
+      webTestClient
+        .method(HttpMethod.GET)
+        .uri("/referral-details/${savedReferral.id}/offence-history")
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_OTHER")))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN)
+        .expectBody(object : ParameterizedTypeReference<ErrorResponse>() {})
+        .returnResult().responseBody!!
+    }
+
+    @Test
+    fun `should return 404 when referral is not found`() {
+      // Given
+      val unknownReferralId = UUID.randomUUID()
+
+      // When & Then
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/$unknownReferralId/offence-history",
+        returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
+        expectedResponseStatus = HttpStatus.NOT_FOUND.value(),
+      )
+    }
+
+    @Test
+    fun `should return 404 when referral exists by not offence history exists for referral`() {
+      // Given
+      val referralEntity = ReferralEntityFactory().produce()
+      testDataGenerator.createReferral(referralEntity)
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+      nDeliusApiStubs.stubNotFoundOffencesResponse(savedReferral.crn, savedReferral.eventNumber.toString())
+
+      // When & Then
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}/offence-history",
+        returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
+        expectedResponseStatus = HttpStatus.NOT_FOUND.value(),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
@@ -157,7 +157,7 @@ class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
   fun `should return offences for known CRN and event number`() {
     stubAuthTokenEndpoint()
     val crn = "X123456"
-    val eventNumber = "1"
+    val eventNumber = 1
 
     val mainOffenceDate = LocalDate.of(2022, 5, 15)
 
@@ -239,7 +239,7 @@ class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
   fun `should return NOT FOUND for unknown CRN or event number when getting offences`() {
     stubAuthTokenEndpoint()
     val crn = "X123456"
-    val eventNumber = "999"
+    val eventNumber = 999
 
     wiremock.stubFor(
       get(urlEqualTo("/case/$crn/sentence/$eventNumber/offences"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
@@ -16,8 +16,12 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheck
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.ProbationPractitioner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffenceFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import java.time.LocalDate
 
 class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
 
@@ -36,9 +40,9 @@ class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
       sex = CodeDescription(code = "M", description = "Male"),
       ethnicity = CodeDescription(code = "W1", description = "White"),
       probationPractitioner = ProbationPractitioner(
-        name = FullName("Sam", "A", "Smith"),
+        name = FullName("Jane", "A", "Doe"),
         code = "X321",
-        email = "sam.smith@probation.gov.uk",
+        email = "jane.doe@probation.gov.uk",
       ),
       probationDeliveryUnit = CodeDescription(code = "PDU123", description = "North London"),
     )
@@ -145,6 +149,105 @@ class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
 
     when (val response = nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(crn))) {
       is ClientResult.Failure.StatusCode<*> -> assertThat(response.status).isEqualTo(HttpStatus.FORBIDDEN)
+      else -> fail("Unexpected result: ${response::class.simpleName}")
+    }
+  }
+
+  @Test
+  fun `should return offences for known CRN and event number`() {
+    stubAuthTokenEndpoint()
+    val crn = "X123456"
+    val eventNumber = "1"
+
+    val mainOffenceDate = LocalDate.of(2022, 5, 15)
+
+    val mainOffence = OffenceFactory()
+      .withDate(mainOffenceDate)
+      .withMainCategoryCode("63")
+      .withMainCategoryDescription("Theft from the person of another")
+      .withSubCategoryCode("01")
+      .withSubCategoryDescription("Theft from the person of another")
+      .produce()
+
+    val additionalOffenceDate1 = LocalDate.of(2021, 7, 23)
+    val additionalOffence1 = OffenceFactory()
+      .withDate(additionalOffenceDate1)
+      .withMainCategoryCode("05")
+      .withMainCategoryDescription("Criminal damage")
+      .withSubCategoryCode("10")
+      .withSubCategoryDescription("Criminal damage - value under £5000")
+      .produce()
+
+    val additionalOffenceDate2 = LocalDate.of(2021, 9, 5)
+    val additionalOffence2 = OffenceFactory()
+      .withDate(additionalOffenceDate2)
+      .withMainCategoryCode("04")
+      .withMainCategoryDescription("Assault")
+      .withSubCategoryCode("01")
+      .withSubCategoryDescription("Common assault and battery")
+      .produce()
+
+    val offences = OffencesFactory()
+      .withMainOffence(mainOffence)
+      .withAdditionalOffences(listOf(additionalOffence1, additionalOffence2))
+      .produce()
+
+    wiremock.stubFor(
+      get(urlEqualTo("/case/$crn/sentence/$eventNumber/offences"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(offences)),
+        ),
+    )
+
+    when (val response = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
+      is ClientResult.Success<*> -> {
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        val body = response.body as Offences
+
+        // Verify main offence
+        assertThat(body.mainOffence.date).isEqualTo(mainOffenceDate)
+        assertThat(body.mainOffence.mainCategoryCode).isEqualTo("63")
+        assertThat(body.mainOffence.mainCategoryDescription).isEqualTo("Theft from the person of another")
+        assertThat(body.mainOffence.subCategoryCode).isEqualTo("01")
+        assertThat(body.mainOffence.subCategoryDescription).isEqualTo("Theft from the person of another")
+
+        // Verify additional offences
+        assertThat(body.additionalOffences).hasSize(2)
+
+        // First additional offence
+        assertThat(body.additionalOffences[0].date).isEqualTo(additionalOffenceDate1)
+        assertThat(body.additionalOffences[0].mainCategoryCode).isEqualTo("05")
+        assertThat(body.additionalOffences[0].mainCategoryDescription).isEqualTo("Criminal damage")
+        assertThat(body.additionalOffences[0].subCategoryCode).isEqualTo("10")
+        assertThat(body.additionalOffences[0].subCategoryDescription).isEqualTo("Criminal damage - value under £5000")
+
+        // Second additional offence
+        assertThat(body.additionalOffences[1].date).isEqualTo(additionalOffenceDate2)
+        assertThat(body.additionalOffences[1].mainCategoryCode).isEqualTo("04")
+        assertThat(body.additionalOffences[1].mainCategoryDescription).isEqualTo("Assault")
+        assertThat(body.additionalOffences[1].subCategoryCode).isEqualTo("01")
+        assertThat(body.additionalOffences[1].subCategoryDescription).isEqualTo("Common assault and battery")
+      }
+      else -> fail("Unexpected result: ${response::class.simpleName}")
+    }
+  }
+
+  @Test
+  fun `should return NOT FOUND for unknown CRN or event number when getting offences`() {
+    stubAuthTokenEndpoint()
+    val crn = "X123456"
+    val eventNumber = "999"
+
+    wiremock.stubFor(
+      get(urlEqualTo("/case/$crn/sentence/$eventNumber/offences"))
+        .willReturn(aResponse().withStatus(404)),
+    )
+
+    when (val response = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
+      is ClientResult.Failure.StatusCode<*> -> assertThat(response.status).isEqualTo(HttpStatus.NOT_FOUND)
       else -> fail("Unexpected result: ${response::class.simpleName}")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -172,4 +172,26 @@ class EntityFactoriesTest {
     assertThat(referralDetails.referralId).isEqualTo(referralId)
     assertThat(referralDetails.setting).isEqualTo(setting)
   }
+
+  @Test
+  fun `OffencesFactory should create entity with default values`() {
+    val offences = OffencesFactory().produce()
+
+    assertThat(offences.mainOffence).isNotNull
+    assertThat(offences.mainOffence.date).isNotNull
+    assertThat(offences.mainOffence.mainCategoryCode).isNotNull
+    assertThat(offences.mainOffence.mainCategoryDescription).isNotNull
+    assertThat(offences.mainOffence.subCategoryCode).isNotNull
+    assertThat(offences.mainOffence.subCategoryDescription).isNotNull
+    assertThat(offences.additionalOffences).isNotEmpty
+  }
+
+  @Test
+  fun `OffencesFactory should create entity with no additional offences`() {
+    val offences = OffencesFactory()
+      .withNoAdditionalOffences()
+      .produce()
+
+    assertThat(offences.additionalOffences).isEmpty()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/OffenceFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/OffenceFactory.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumber
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
+import java.time.LocalDate
+
+class OffenceFactory {
+  private var date: LocalDate = LocalDate.now().minusMonths(3)
+  private var mainCategoryCode: String = randomNumber(2).toString()
+  private var mainCategoryDescription: String = randomSentence()
+  private var subCategoryCode: String = randomNumber(2).toString()
+  private var subCategoryDescription: String = randomSentence()
+
+  fun withDate(date: LocalDate) = apply { this.date = date }
+  fun withMainCategoryCode(mainCategoryCode: String) = apply { this.mainCategoryCode = mainCategoryCode }
+  fun withMainCategoryDescription(mainCategoryDescription: String) = apply { this.mainCategoryDescription = mainCategoryDescription }
+  fun withSubCategoryCode(subCategoryCode: String) = apply { this.subCategoryCode = subCategoryCode }
+  fun withSubCategoryDescription(subCategoryDescription: String) = apply { this.subCategoryDescription = subCategoryDescription }
+
+  fun produce() = Offence(
+    date = this.date,
+    mainCategoryCode = this.mainCategoryCode,
+    mainCategoryDescription = this.mainCategoryDescription,
+    subCategoryCode = this.subCategoryCode,
+    subCategoryDescription = this.subCategoryDescription,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/OffencesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/OffencesFactory.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offence
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
+
+class OffencesFactory {
+  private var mainOffence: Offence = OffenceFactory().produce()
+  private var additionalOffences: List<Offence> = listOf(OffenceFactory().produce(), OffenceFactory().produce())
+
+  fun withMainOffence(mainOffence: Offence) = apply { this.mainOffence = mainOffence }
+  fun withAdditionalOffences(additionalOffences: List<Offence>) = apply { this.additionalOffences = additionalOffences }
+  fun withNoAdditionalOffences() = apply { this.additionalOffences = emptyList() }
+
+  fun produce() = Offences(
+    mainOffence = this.mainOffence,
+    additionalOffences = this.additionalOffences,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheck
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 
 class NDeliusApiStubs(
   val wiremock: WireMockExtension,
@@ -49,6 +52,29 @@ class NDeliusApiStubs(
             .withStatus(200)
             .withHeader("Content-Type", "application/json")
             .withBody(objectMapper.writeValueAsString(nDeliusPersonalDetails)),
+        ),
+    )
+  }
+
+  fun stubSuccessfulOffencesResponse(crn: String, eventNumber: String, offences: Offences = OffencesFactory().produce()) {
+    wiremock.stubFor(
+      get(urlPathTemplate("/case/$crn/sentence/$eventNumber/offences"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(offences)),
+        ),
+    )
+  }
+
+  fun stubNotFoundOffencesResponse(crn: String, eventNumber: String) {
+    wiremock.stubFor(
+      get(urlEqualTo("/case/$crn/sentence/$eventNumber/offences"))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json"),
         ),
     )
   }


### PR DESCRIPTION

- Integrated with NDelius API to fetch offence data.
- Introduced new `Offence` and `OffenceHistory` models.
- Extended `ReferralController` with endpoint for offence history retrieval.

- Added supporting service, factories, and tests for offence-related functionality.