### PR TITLE
Handle missing event numbers in offence history retrieval

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/ApiExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 
 @RestControllerAdvice
 class ApiExceptionHandler {
@@ -62,6 +63,20 @@ class ApiExceptionHandler {
 
   @ExceptionHandler(HandlerMethodValidationException::class)
   fun handleHandlerMethodValidationException(exception: HandlerMethodValidationException): ResponseEntity<ErrorResponse> {
+    log.warn("Bad request", exception)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST.value(),
+          userMessage = "Bad request: ${exception.message}",
+          developerMessage = exception.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(BusinessException::class)
+  fun handleBusinessExceptionException(exception: BusinessException): ResponseEntity<ErrorResponse> {
     log.warn("Bad request", exception)
     return ResponseEntity
       .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -119,6 +119,11 @@ class ReferralController(
         content = [Content(schema = Schema(implementation = OffenceHistory::class))],
       ),
       ApiResponse(
+        responseCode = "400",
+        description = "The offence history could not be retrieved due to missing data on the referral",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
         responseCode = "401",
         description = "The request was unauthorised",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/OffenceHistory.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
+import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offence as NDeliusOffence
 
 @Schema(description = "Represents an individual's history of offences, including their main offence and any additional offences")
@@ -10,6 +12,9 @@ data class OffenceHistory(
   val mainOffence: Offence,
   @Schema(description = "List of additional or secondary offences")
   val additionalOffences: List<Offence> = emptyList(),
+  @Schema(description = "The date the offence history was imported from NDelius", example = "11 June 2020")
+  @JsonFormat(pattern = "d MMMM yyyy")
+  val importedDate: LocalDate = LocalDate.now(),
 )
 
 fun Offences.toApi() = OffenceHistory(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/OffenceService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.Offences
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 
 @Service
 class OffenceService(
@@ -18,7 +19,14 @@ class OffenceService(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getOffenceHistory(referral: ReferralEntity): OffenceHistory = getOffences(referral.crn, referral.eventNumber!!).toApi()
+  fun getOffenceHistory(referral: ReferralEntity): OffenceHistory {
+    if (referral.eventNumber == null) {
+      log.warn("Referral event number is null for referral id: ${referral.id}")
+      throw BusinessException("Failure to retrieve offence history for crn: ${referral.crn} due to missing event number")
+    }
+
+    return getOffences(referral.crn, referral.eventNumber!!).toApi()
+  }
 
   fun getOffences(crn: String, eventNumber: Int): Offences = when (val result = nDeliusIntegrationApiClient.getOffences(crn, eventNumber)) {
     is ClientResult.Failure -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralEntityFactory.kt
@@ -23,7 +23,7 @@ class ReferralEntityFactory {
     mutableListOf(referralStatusHistoryEntityFactory.withStatus("Assessment started").produce())
   private var setting: SettingType = SettingType.COMMUNITY
   private var eventId: String = randomUppercaseString(6)
-  private var eventNumber: Int = randomNumberAsInt(1)
+  private var eventNumber: Int? = randomNumberAsInt(1)
   private var cohort: OffenceCohort = OffenceCohort.GENERAL_OFFENCE
 
   fun withId(id: UUID?) = apply { this.id = id }
@@ -35,7 +35,7 @@ class ReferralEntityFactory {
   fun withInterventionName(interventionName: String?) = apply { this.interventionName = interventionName }
 
   fun withInterventionType(interventionType: InterventionType) = apply { this.interventionType = interventionType }
-  fun withEventNumber(eventNumber: Int) = apply { this.eventNumber = eventNumber }
+  fun withEventNumber(eventNumber: Int?) = apply { this.eventNumber = eventNumber }
   fun withEventId(eventId: String) = apply { this.eventId = eventId }
   fun addStatusHistory(statusHistory: ReferralStatusHistoryEntity) = apply { this.statusHistories.add(statusHistory) }
 


### PR DESCRIPTION
### Description

- Return NDelius imported by date as part of offence history
- Added error handling for missing event numbers in offence history retrieval.
- Ensured proper fallback mechanisms to avoid operation failures when event numbers are missing.

