### PR TITLE
Refine URL patterns for offence details mocks in WireMock

### DIFF
--- a/wiremock_mappings/nDeliusMock.json
+++ b/wiremock_mappings/nDeliusMock.json
@@ -61,7 +61,7 @@
     {
       "request": {
         "method": "GET",
-        "urlPathPattern": "/case/.*/sentence/.*"
+        "urlPathPattern": "/case/[^/]+/sentence/[^/]+$"
       },
       "response": {
         "status": 200,
@@ -98,7 +98,7 @@
     {
       "request": {
         "method": "GET",
-        "urlPathPattern": "/case/.*/sentence/.*/offences"
+        "urlPathPattern": "/case/[^/]+/sentence/[^/]+/offences$"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
- **What has been changed?**
  Adjusted the URL path patterns to use regex anchors in WireMock to improve mock handling for offence details retrieval within the NDelius API integration.

`/case/.*/sentence/.*` was also mocking `/case/.*/sentence/.*/offences `

- **Why is this change necessary?**
  The offence history URL was never being match due to the earlier sentence url definition

