### PR TITLE
APG-1125 Add priorities to NDelius WireMock sentence and offence mocks

### DIFF
--- a/wiremock_mappings/nDeliusMock.json
+++ b/wiremock_mappings/nDeliusMock.json
@@ -63,6 +63,7 @@
         "method": "GET",
         "urlPathPattern": "/case/[^/]+/sentence/[^/]+$"
       },
+      "priority": 2,
       "response": {
         "status": 200,
         "headers": {
@@ -100,6 +101,7 @@
         "method": "GET",
         "urlPathPattern": "/case/[^/]+/sentence/[^/]+/offences$"
       },
+      "priority": 1,
       "response": {
         "status": 200,
         "headers": {


### PR DESCRIPTION
Added priorities to WireMock mappings for sentence and offence retrieval in NDelius, ensuring more predictable and accurate response handling during testing.