### PR TITLE
Ignore unknown properties in nDelius personal details response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusPersonalDetails.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.cli
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class NDeliusPersonalDetails(
   val crn: String,
   val name: FullName,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,7 +18,7 @@ spring:
             provider: hmpps-auth
             client-id: ${API_CLIENT_ID:hmpps-accredited-programmes-manage-and-deliver-ui-client-1}
             client-secret: ${API_CLIENT_SECRET:clientsecret}
-            authorization-grant-type: ${API_CLIENT_ID:client_credentials}
+            authorization-grant-type: client_credentials
         provider:
           hmpps-auth:
             token-uri: ${hmpps-auth.url}/oauth/token


### PR DESCRIPTION
The schema for the `nDeliusPersonalDetails` response has been updated by an external team and we are not quite ready to implement the use of these new fields. We will ignore unknown fields for now with the option to expose these fields later.

New schema listed below with new properties such as `team`;
<img width="340" height="274" alt="image" src="https://github.com/user-attachments/assets/327a7891-3556-4aec-9d3a-4bb2d5ef9b1a" />
