### PR TITLE
Add accommodation retrieval from OASys service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/risksAndNeeds/LearningNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/risksAndNeeds/LearningNeeds.kt
@@ -1,41 +1,54 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.risksAndNeeds
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAccommodation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysLearning
+import java.time.LocalDate
 
 /**
  * API-facing representation of Learning Needs derived from OASYS section 4 (Education, Training & Employment).
  */
 data class LearningNeeds(
-  @Schema(example = "Limited recent work history")
+
+  @Schema(example = "1 August 2023")
+  @JsonFormat(pattern = "d MMMM yyyy")
+  @get:JsonProperty("assessmentCompleted") val assessmentCompleted: LocalDate? = null,
+
+  @Schema(example = "true", description = "Whether the person has a fixed abode or is living at a temporary address")
+  @get:JsonProperty("noFixedAbodeOrTransient") val noFixedAbodeOrTransient: Boolean? = false,
+
+  @Schema(example = "1-Some problems")
   @get:JsonProperty("workRelatedSkills") val workRelatedSkills: String? = null,
 
-  @Schema(example = "Difficulty with numeracy")
+  @Schema(example = "0-No problems")
   @get:JsonProperty("problemsReadWriteNum") val problemsReadWriteNum: String? = null,
 
-  @Schema(example = "ADHD")
+  @Schema(example = "2-Significant problems")
   @get:JsonProperty("learningDifficulties") val learningDifficulties: String? = null,
 
   @Schema(example = "[\"Difficulty with concentration\"]")
   @get:JsonProperty("problemAreas") val problemAreas: List<String>? = null,
 
-  @Schema(example = "NVQ Level 2")
+  @Schema(example = "0 - Any qualifications")
   @get:JsonProperty("qualifications") val qualifications: String? = null,
 
   @Schema(example = "3")
   @get:JsonProperty("basicSkillsScore") val basicSkillsScore: String? = null,
 
-  @Schema(example = "Issues with ETE engagement")
-  @get:JsonProperty("eTEIssuesDetails") val eTEIssuesDetails: String? = null,
+  @Schema(example = "Ms Puckett spoke of wanting to secure suitable employment although she knows that she will first need to fully address her drug issues.")
+  @get:JsonProperty("basicSkillsScoreDescription") val basicSkillsScoreDescription: String? = null,
 )
 
-fun buildLearningNeeds(oasysLearning: OasysLearning?): LearningNeeds = LearningNeeds(
+fun buildLearningNeeds(assessmentCompleted: LocalDate?, oasysLearning: OasysLearning?, oasysAccommodation: OasysAccommodation): LearningNeeds = LearningNeeds(
+  noFixedAbodeOrTransient = oasysAccommodation.noFixedAbodeOrTransient == "Yes",
+  assessmentCompleted = assessmentCompleted,
   workRelatedSkills = oasysLearning?.workRelatedSkills,
   problemsReadWriteNum = oasysLearning?.problemsReadWriteNum,
   learningDifficulties = oasysLearning?.learningDifficulties,
   problemAreas = oasysLearning?.problemAreas,
   qualifications = oasysLearning?.qualifications,
   basicSkillsScore = oasysLearning?.basicSkillsScore,
-  eTEIssuesDetails = oasysLearning?.eTEIssuesDetails,
+  basicSkillsScoreDescription = oasysLearning?.eTEIssuesDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/OasysApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/OasysApiClient.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.BaseHMPPSClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.PniResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAccommodation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAssessmentTimeline
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysHealth
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysLearning
@@ -34,6 +35,10 @@ class OasysApiClient(
 
   fun getOffendingInfo(assessmentPk: Long) = getRequest<OasysOffendingInfo>(OASYS_API) {
     path = "/assessments/$assessmentPk/section/section1"
+  }
+
+  fun getAccommodation(assessmentPk: Long) = getRequest<OasysAccommodation>(OASYS_API) {
+    path = "/assessments/$assessmentPk/section/section3"
   }
 
   fun getLearning(assessmentPk: Long) = getRequest<OasysLearning>(OASYS_API) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/risksAndNeeds/OasysAccommodation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/oasysApi/model/risksAndNeeds/OasysAccommodation.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class OasysAccommodation(
+  val noFixedAbodeOrTransient: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/RisksAndNeedsService.kt
@@ -40,9 +40,13 @@ class RisksAndNeedsService(
   }
 
   fun getLearningNeedsForCrn(crn: String): LearningNeeds {
-    val assessmentId = getAssessmentIdAndDate(crn)?.first
+    val (assessmentId, assessmentCompletedDate) = getAssessmentIdAndDate(crn)
       ?: throw NotFoundException("No assessment found for crn: $crn")
-    return buildLearningNeeds(getDetails(assessmentId, oasysApiClient::getLearning, "LearningNeeds"))
+    return buildLearningNeeds(
+      assessmentCompletedDate?.toLocalDate(),
+      getDetails(assessmentId, oasysApiClient::getLearning, "LearningNeeds"),
+      getDetails(assessmentId, oasysApiClient::getAccommodation, "OasysAccommodation"),
+    )
   }
 
   fun getHealth(crn: String): Health? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/RisksAndNeedsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/RisksAndNeedsControllerIntegrationTest.kt
@@ -222,10 +222,12 @@ class RisksAndNeedsControllerIntegrationTest : IntegrationTestBase() {
       val referralEntity = ReferralEntityFactory().produce()
       testDataGenerator.createReferral(referralEntity)
       val assessment = OasysAssessmentTimelineFactory().withCrn(referralEntity.crn).produce()
+
       val assessmentId = assessment.getLatestCompletedLayerThreeAssessment()!!.id
       oasysApiStubs.stubSuccessfulAssessmentsResponse(referralEntity.crn, assessment)
       val oasysLearning = OasysLearningFactory().withCrn(referralEntity.crn).produce()
       oasysApiStubs.stubSuccessfulOasysLearningResponse(assessmentId, oasysLearning)
+      oasysApiStubs.stubSuccessfulOasysAccommodationResponse(assessmentId)
 
       // When
       val response = performRequestAndExpectOk(
@@ -236,21 +238,25 @@ class RisksAndNeedsControllerIntegrationTest : IntegrationTestBase() {
 
       // Then
       assertThat(response).isNotNull
+      assertThat(response).hasFieldOrProperty("assessmentCompleted")
+      assertThat(response).hasFieldOrProperty("noFixedAbodeOrTransient")
       assertThat(response).hasFieldOrProperty("workRelatedSkills")
       assertThat(response).hasFieldOrProperty("problemsReadWriteNum")
       assertThat(response).hasFieldOrProperty("learningDifficulties")
       assertThat(response).hasFieldOrProperty("problemAreas")
       assertThat(response).hasFieldOrProperty("qualifications")
       assertThat(response).hasFieldOrProperty("basicSkillsScore")
-      assertThat(response).hasFieldOrProperty("eTEIssuesDetails")
+      assertThat(response).hasFieldOrProperty("basicSkillsScoreDescription")
 
+      assertThat(response.assessmentCompleted).isEqualTo(assessment.getLatestCompletedLayerThreeAssessment()?.completedAt?.toLocalDate())
+      assertThat(response.noFixedAbodeOrTransient).isTrue
       assertThat(response.workRelatedSkills).isEqualTo("Limited recent work history")
       assertThat(response.problemsReadWriteNum).isEqualTo("Difficulty with numeracy")
       assertThat(response.learningDifficulties).isEqualTo("ADHD")
       assertThat(response.problemAreas).contains("Difficulty with concentration")
       assertThat(response.qualifications).isEqualTo("NVQ Level 2")
       assertThat(response.basicSkillsScore).isEqualTo("3")
-      assertThat(response.eTEIssuesDetails).isEqualTo("ete issues")
+      assertThat(response.basicSkillsScoreDescription).isEqualTo("ete issues")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/oasys/OasysAccommodationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/oasys/OasysAccommodationFactory.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAccommodation
+
+class OasysAccommodationFactory {
+  private var noFixedAbodeOrTransient: String? = "Yes"
+
+  fun withNoFixedAbodeOrTransient(noFixedAbodeOrTransient: String?) = apply { this.noFixedAbodeOrTransient = noFixedAbodeOrTransient }
+
+  fun produce() = OasysAccommodation(
+    noFixedAbodeOrTransient = this.noFixedAbodeOrTransient,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/OasysApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/OasysApiStubs.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.PniResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAccommodation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAssessmentTimeline
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysHealth
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysLearning
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysRoshFull
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysRoshSummary
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.PniResponseFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys.OasysAccommodationFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys.OasysAssessmentTimelineFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys.OasysHealthFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys.OasysLearningFactory
@@ -269,6 +271,34 @@ class OasysApiStubs(
   ) {
     wiremock.stubFor(
       get(urlEqualTo("/assessments/$assessmentId/section/sectionroshfull"))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+
+  fun stubSuccessfulOasysAccommodationResponse(
+    assessmentId: Long,
+    oasysAccommodation: OasysAccommodation = OasysAccommodationFactory().produce(),
+  ) {
+    wiremock.stubFor(
+      get(urlEqualTo("/assessments/$assessmentId/section/section3"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(oasysAccommodation)),
+        ),
+    )
+  }
+
+  fun stubNotFoundOasysAccommodationResponse(
+    assessmentId: Long,
+  ) {
+    wiremock.stubFor(
+      get(urlEqualTo("/assessments/$assessmentId/section/section3"))
         .willReturn(
           aResponse()
             .withStatus(404)


### PR DESCRIPTION
### Overview

A few additional fields have been added to the LearningNeeds API model object that are needed in the UI.

This pull request therefore introduces functionality to retrieve accommodation details from OASys, including integration with the service layer and updated tests.