### PR TITLE
APG-1299: Create db tables and entities for deliveryLocationPreferences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/JpaAuditConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/JpaAuditConfig.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetails
+import java.util.Optional
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+class JpaAuditConfig {
+  @Bean
+  fun auditorAware() = AuditorAware {
+    Optional.ofNullable(
+      when (val principal = SecurityContextHolder.getContext().authentication?.principal) {
+        is String -> principal
+        is UserDetails -> principal.username
+        is Map<*, *> -> principal["username"] as String
+        else -> null
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/DeliveryLocationPreferenceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/DeliveryLocationPreferenceEntity.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.annotation.Nullable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import org.springframework.data.annotation.CreatedDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "delivery_location_preferences")
+class DeliveryLocationPreferenceEntity(
+  @NotNull
+  @Id
+  @Column(name = "id")
+  val id: UUID,
+
+  @NotNull
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "referral_id")
+  val referral: ReferralEntity,
+
+  @NotNull
+  @Column(name = "created_by")
+  val createdBy: String,
+
+  @NotNull
+  @CreatedDate
+  var createdAt: LocalDateTime? = LocalDateTime.now(),
+
+  @Nullable
+  @Column(name = "locations_cannot_attend_text")
+  val locationsCannotAttendText: String? = null,
+
+  @ManyToMany
+  @JoinTable(
+    name = "delivery_location_office_mapping",
+    joinColumns = [JoinColumn(name = "delivery_location_id")],
+    inverseJoinColumns = [JoinColumn(name = "office_id")],
+  )
+  val offices: MutableSet<OfficeEntity> = mutableSetOf(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/DeliveryLocationPreferenceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/DeliveryLocationPreferenceEntity.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ent
 import jakarta.annotation.Nullable
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -11,12 +12,17 @@ import jakarta.persistence.ManyToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
+import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.springframework.security.core.context.SecurityContextHolder
 import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
 @Table(name = "delivery_location_preferences")
+@EntityListeners(AuditingEntityListener::class)
 class DeliveryLocationPreferenceEntity(
   @NotNull
   @Id
@@ -30,11 +36,17 @@ class DeliveryLocationPreferenceEntity(
 
   @NotNull
   @Column(name = "created_by")
-  val createdBy: String,
+  @CreatedBy
+  val createdBy: String? = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
 
   @NotNull
   @CreatedDate
-  var createdAt: LocalDateTime? = LocalDateTime.now(),
+  val createdAt: LocalDateTime? = LocalDateTime.now(),
+
+  @NotNull
+  @Column("last_updated_at")
+  @LastModifiedDate
+  val lastUpdatedAt: LocalDateTime? = LocalDateTime.now(),
 
   @Nullable
   @Column(name = "locations_cannot_attend_text")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferenceRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.repository.Repository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.DeliveryLocationPreferenceEntity
+import java.util.UUID
+
+interface DeliveryLocationPreferenceRepository : Repository<DeliveryLocationPreferenceEntity, UUID> {
+  fun findByReferralId(referralId: UUID): MutableList<DeliveryLocationPreferenceEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/OfficeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/OfficeRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.OfficeEntity
 
 @Repository
-interface OfficeRepository : JpaRepository<OfficeEntity, String>
+interface OfficeRepository : JpaRepository<OfficeEntity, String> {
+  fun findByPduId(pduId: Int): MutableList<OfficeEntity>
+}

--- a/src/main/resources/db/migration/V19__create_delivery_location_preferences_tables.sql
+++ b/src/main/resources/db/migration/V19__create_delivery_location_preferences_tables.sql
@@ -2,8 +2,9 @@ CREATE TABLE delivery_location_preferences
 (
     id                           UUID PRIMARY KEY                     NOT NULL,
     referral_id                  UUID references referral (id) UNIQUE NOT NULL,
-    created_by                   TEXT                                 NOT NULL,
+    created_by                   TEXT      DEFAULT current_user       NOT NULL,
     created_at                   TIMESTAMP DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    last_updated_at              TIMESTAMP DEFAULT CURRENT_TIMESTAMP  NOT NULL,
     locations_cannot_attend_text TEXT                                 NULL
 );
 
@@ -18,6 +19,7 @@ COMMENT ON COLUMN delivery_location_preferences.id IS 'Unique identifier for a r
 COMMENT ON COLUMN delivery_location_preferences.referral_id IS 'References the unique identifier for a referral';
 COMMENT ON COLUMN delivery_location_preferences.created_by IS 'The username of the person that submitted the delivery location preferences';
 COMMENT ON COLUMN delivery_location_preferences.created_at IS 'Timestamp of when the delivery location preferences were submitted';
+COMMENT ON COLUMN delivery_location_preferences.last_updated_at IS 'Timestamp of when the delivery location preferences were last updated';
 COMMENT ON COLUMN delivery_location_preferences.locations_cannot_attend_text IS 'Details of locations a person cannot attend';
 
 COMMENT ON TABLE delivery_location_office_mapping IS 'Contains the mapping between an office_id and a delivery location preference';

--- a/src/main/resources/db/migration/V19__create_delivery_location_preferences_tables.sql
+++ b/src/main/resources/db/migration/V19__create_delivery_location_preferences_tables.sql
@@ -1,0 +1,25 @@
+CREATE TABLE delivery_location_preferences
+(
+    id                           UUID PRIMARY KEY                     NOT NULL,
+    referral_id                  UUID references referral (id) UNIQUE NOT NULL,
+    created_by                   TEXT                                 NOT NULL,
+    created_at                   TIMESTAMP DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    locations_cannot_attend_text TEXT                                 NULL
+);
+
+CREATE TABLE delivery_location_office_mapping
+(
+    delivery_location_id UUID references delivery_location_preferences (id),
+    office_id            VARCHAR REFERENCES office (id) NOT NULL
+);
+
+COMMENT ON TABLE delivery_location_preferences IS 'Contains the delivery location preferences data for a referral';
+COMMENT ON COLUMN delivery_location_preferences.id IS 'Unique identifier for a referral''s delivery location preferences';
+COMMENT ON COLUMN delivery_location_preferences.referral_id IS 'References the unique identifier for a referral';
+COMMENT ON COLUMN delivery_location_preferences.created_by IS 'The username of the person that submitted the delivery location preferences';
+COMMENT ON COLUMN delivery_location_preferences.created_at IS 'Timestamp of when the delivery location preferences were submitted';
+COMMENT ON COLUMN delivery_location_preferences.locations_cannot_attend_text IS 'Details of locations a person cannot attend';
+
+COMMENT ON TABLE delivery_location_office_mapping IS 'Contains the mapping between an office_id and a delivery location preference';
+COMMENT ON COLUMN delivery_location_office_mapping.delivery_location_id IS 'The unique identifier of the delivery location preferences';
+COMMENT ON COLUMN delivery_location_office_mapping.office_id IS 'The unique identifier of the reference data office id';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataCleaner.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataCleaner.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 
 @Transactional
 @Component
-open class TestDataCleaner(
+class TestDataCleaner(
   @Autowired
   private val entityManager: EntityManager,
 ) {
@@ -19,6 +19,8 @@ open class TestDataCleaner(
       createNativeQuery("TRUNCATE TABLE referral CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE availability CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE availability_slot CASCADE").executeUpdate()
+      createNativeQuery("TRUNCATE TABLE delivery_location_office_mapping CASCADE").executeUpdate()
+      createNativeQuery("TRUNCATE TABLE delivery_location_preferences CASCADE").executeUpdate()
       // Add additional tables here as the data model grows
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.AvailabilityEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.DeliveryLocationPreferenceEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 
@@ -17,6 +18,10 @@ class TestDataGenerator {
 
   fun createReferral(referralEntity: ReferralEntity) {
     entityManager.persist(referralEntity)
+  }
+
+  fun createDeliveryLocationPreference(deliveryLocationPreferenceEntity: DeliveryLocationPreferenceEntity) {
+    entityManager.persist(deliveryLocationPreferenceEntity)
   }
 
   fun createAvailability(availabilityEntity: AvailabilityEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.DeliveryLocationPreferenceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import java.util.UUID
+
+class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var repository: DeliveryLocationPreferenceRepository
+
+  @Autowired
+  private lateinit var officeRepository: OfficeRepository
+
+  @Autowired
+  private lateinit var testDataGenerator: TestDataGenerator
+
+  @Autowired
+  private lateinit var testDataCleaner: TestDataCleaner
+
+  @BeforeEach
+  override fun beforeEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @Test
+  @Transactional
+  fun `should retrieve a delivery location preference for a referral`() {
+    val referralEntity = ReferralEntityFactory().produce()
+    testDataGenerator.createReferral(referralEntity)
+    val offices = officeRepository.findByPduId(1).toMutableSet()
+    val deliveryLocationPreference = DeliveryLocationPreferenceEntity(
+      id = UUID.randomUUID(),
+      referral = referralEntity,
+      createdBy = "USER",
+      offices = offices,
+      locationsCannotAttendText = "Alex cannot attend any locations in Postcode beginning NE1.",
+    )
+
+    testDataGenerator.createDeliveryLocationPreference(
+      deliveryLocationPreference,
+    )
+    val result = repository.findByReferralId(referralEntity.id!!).first()
+
+    assertThat(result.referral).isEqualTo(referralEntity)
+    assertThat(result.offices.size).isEqualTo(offices.size)
+    assertThat(result.createdAt).isNotNull
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.DeliveryLocationPreferenceEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.util.UUID
 
 class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase() {
@@ -32,6 +33,7 @@ class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase
 
   @Test
   @Transactional
+  @WithMockAuthUser("PROB_PRACTITIONER_1")
   fun `should retrieve a delivery location preference for a referral`() {
     val referralEntity = ReferralEntityFactory().produce()
     testDataGenerator.createReferral(referralEntity)
@@ -39,7 +41,6 @@ class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase
     val deliveryLocationPreference = DeliveryLocationPreferenceEntity(
       id = UUID.randomUUID(),
       referral = referralEntity,
-      createdBy = "USER",
       offices = offices,
       locationsCannotAttendText = "Alex cannot attend any locations in Postcode beginning NE1.",
     )
@@ -52,5 +53,6 @@ class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase
     assertThat(result.referral).isEqualTo(referralEntity)
     assertThat(result.offices.size).isEqualTo(offices.size)
     assertThat(result.createdAt).isNotNull
+    assertThat(result.createdBy).isEqualTo("PROB_PRACTITIONER_1")
   }
 }


### PR DESCRIPTION
Added the following tables:
* delivery_location_preferences
* deliver_location_office_mapping

This allows a mapping between a referral and preferred office locations.

<img width="740" height="725" alt="image" src="https://github.com/user-attachments/assets/03e5d3b1-c6f4-47a0-9ad0-aa531f77e1b4" />
