### PR TITLE
APG-1112: Create the DeliveryLocationPreference Form BFF endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/DeliveryLocationPreferencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/DeliveryLocationPreferencesController.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DeliveryLocationPreferencesFormData
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.DeliveryLocationPreferencesService
+import java.util.UUID
+
+@RestController
+@PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
+class DeliveryLocationPreferencesController(
+  private val deliveryLocationPreferencesService: DeliveryLocationPreferencesService,
+) {
+
+  @Operation(
+    tags = ["Delivery Location Preferences"],
+    summary = "A Backend-For-Frontend endpoint for the multi-page Delivery Location Preferences form",
+    operationId = "getDeliveryLocationPreferencesFormData",
+    description = """
+      Retrieves all the data needed for the multi-page Delivery Location Preferences form, for a Referral:
+      - Person on Probation summary information (from nDelius)
+      - Existing delivery location preferences (or `null`)
+      - Primary PDU delivery locations for the Manager associated with the Referral (from nDelius)
+      - Other PDUs in the same region (from nDelius)
+    """,
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Delivery Location Preferences form data",
+        content = [Content(schema = Schema(implementation = DeliveryLocationPreferencesFormData::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden. The client is not authorised to access this referral.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The referral does not exist or required data could not be found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
+  @GetMapping("/bff/referral-delivery-location-preferences-form/{referral_id}", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getDeliveryLocationPreferencesFormData(
+    @Parameter(description = "The id (UUID) of a referral", required = true)
+    @PathVariable("referral_id") referralId: UUID,
+  ): ResponseEntity<DeliveryLocationPreferencesFormData> {
+    val formData = deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(referralId)
+    return ResponseEntity.ok(formData)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DeliveryLocationPreferencesFormData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DeliveryLocationPreferencesFormData.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Form data for the multi-page DeliveryLocationPreferences form in the M&D UI")
+data class DeliveryLocationPreferencesFormData(
+  @field:Schema(description = "Person on Probation details (sourced freshly from nDelius)")
+  val personOnProbation: PersonOnProbationSummary,
+
+  @field:Schema(description = "Existing Delivery Location Preferences, if any")
+  val existingDeliveryLocationPreferences: ExistingDeliveryLocationPreferences?,
+
+  @field:Schema(description = "Primary PDU of the Manager of the Requirement or Licence Condition associated with a Referral")
+  val primaryPdu: ProbationDeliveryUnit,
+
+  @field:Schema(description = "Other PDUs in the same Region as the Manager")
+  val otherPdusInSameRegion: List<ProbationDeliveryUnit>,
+)
+
+@Schema(description = "Summary information about the Person on Probation")
+data class PersonOnProbationSummary(
+  @field:Schema(description = "Full name", example = "Alex River")
+  val name: String,
+
+  @field:Schema(description = "Case Reference Number", example = "ABC123")
+  val crn: String,
+
+  @field:Schema(description = "Risk tier", example = "C2")
+  val tier: String?,
+
+  @field:Schema(description = "Date of birth", example = "2000-01-01")
+  val dateOfBirth: LocalDate,
+)
+
+@Schema(description = "Existing Delivery Location Preferences")
+data class ExistingDeliveryLocationPreferences(
+  @field:Schema(description = "Locations (presently Offices) the person can attend")
+  val canAttendLocationsValues: List<DeliveryLocationOption>,
+
+  @field:Schema(description = "Rich text explaining locations the person cannot attend", example = "Locations in BN1")
+  val cannotAttendLocations: String?,
+)
+
+@Schema(description = "A delivery location (i.e. Office) with value and label, formatted for the UI")
+data class DeliveryLocationOption(
+  @field:Schema(description = "Office code", example = "OFFICE-CODE-123")
+  val value: String,
+
+  @field:Schema(description = "Human-readable office name", example = "Brighton and Hove: Probation Office")
+  val label: String,
+)
+
+@Schema(description = "Probation Delivery Unit with available delivery locations")
+data class ProbationDeliveryUnit(
+  @field:Schema(description = "PDU name", example = "East Sussex")
+  val name: String,
+
+  @field:Schema(description = "Available delivery locations within this PDU")
+  val deliveryLocations: List<DeliveryLocationOption>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DeliveryLocationOption
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DeliveryLocationPreferencesFormData
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ExistingDeliveryLocationPreferences
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PersonOnProbationSummary
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnitWithOfficeLocations
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.DeliveryLocationPreferenceRepository
+import java.util.UUID
+
+@Service
+class DeliveryLocationPreferencesService(
+  private val deliveryLocationPreferenceRepository: DeliveryLocationPreferenceRepository,
+  private val referralService: ReferralService,
+  private val serviceUserService: ServiceUserService,
+) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getDeliveryLocationPreferencesFormDataForReferral(referralId: UUID): DeliveryLocationPreferencesFormData {
+    log.info("Getting delivery location preferences form data for referral: $referralId")
+
+    val referral = referralService.getReferralById(referralId)
+      ?: throw NotFoundException("Referral not found id $referralId")
+
+    val personalDetails = serviceUserService.getPersonalDetailsByIdentifier(referral.crn)
+
+    val existingPreferences = deliveryLocationPreferenceRepository.findByReferralId(referralId).firstOrNull()
+
+    val managerDetails = referralService.attemptToFindManagerForReferral(referralId)
+      ?: throw NotFoundException("Could not retrieve manager details for referral $referralId")
+
+    val additionalPdusData = referralService.attemptToFindNonPrimaryPdusForReferal(referralId)
+      ?: throw NotFoundException("Could not find additional PDUS for referral $referralId")
+
+    return DeliveryLocationPreferencesFormData(
+      personOnProbation = PersonOnProbationSummary(
+        name = "${personalDetails.name.forename} ${personalDetails.name.surname}",
+        crn = personalDetails.crn,
+        tier = personalDetails.probationDeliveryUnit?.description, // Using PDU description as tier for now
+        dateOfBirth = java.time.LocalDate.parse(personalDetails.dateOfBirth),
+      ),
+      existingDeliveryLocationPreferences = existingPreferences?.let { preferences ->
+        ExistingDeliveryLocationPreferences(
+          canAttendLocationsValues = preferences.preferredDeliveryLocations.map { location ->
+            DeliveryLocationOption(
+              value = location.deliusCode,
+              label = location.deliusDescription,
+            )
+          },
+          cannotAttendLocations = preferences.locationsCannotAttendText,
+        )
+      },
+      primaryPdu = ProbationDeliveryUnit(
+        name = managerDetails.probationDeliveryUnit.description,
+        deliveryLocations = managerDetails.officeLocations.map { office ->
+          DeliveryLocationOption(
+            value = office.code,
+            label = office.description,
+          )
+        },
+      ),
+      otherPdusInSameRegion = additionalPdusData
+        .filter { pdu: NDeliusApiProbationDeliveryUnitWithOfficeLocations -> pdu.code != managerDetails.probationDeliveryUnit.code }
+        .map { pdu: NDeliusApiProbationDeliveryUnitWithOfficeLocations -> pdu.toProbationDeliveryUnit() },
+    )
+  }
+
+  private fun NDeliusApiProbationDeliveryUnitWithOfficeLocations.toProbationDeliveryUnit(): ProbationDeliveryUnit = ProbationDeliveryUnit(
+    name = this.description,
+    deliveryLocations = this.officeLocations.map { office ->
+      DeliveryLocationOption(
+        value = office.code,
+        label = office.description,
+      )
+    },
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -545,7 +545,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       )
 
       val requirementResponse = NDeliusCaseRequirementOrLicenceConditionResponse(manager = expectedManager)
-      nDeliusApiStubs.stubSuccessfulRequirementManagerResponse(savedReferral.id.toString(), "REQ001", requirementResponse)
+      nDeliusApiStubs.stubSuccessfulRequirementManagerResponse("X123456", "REQ001", requirementResponse)
 
       val response = performRequestAndExpectOk(
         httpMethod = HttpMethod.GET,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
@@ -65,6 +65,21 @@ class NDeliusApiStubs(
     )
   }
 
+  fun stubPersonalDetailsResponseForCrn(
+    crn: String,
+    personalDetails: NDeliusPersonalDetails,
+  ) {
+    wiremock.stubFor(
+      get(urlEqualTo("/case/$crn/personal-details"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(personalDetails)),
+        ),
+    )
+  }
+
   fun stubSuccessfulOffencesResponse(
     crn: String,
     eventNumber: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/DeliveryLocationPreferencesRepositoryIntegrationTest.kt
@@ -43,13 +43,13 @@ class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase
     val referralEntity = ReferralEntityFactory().produce()
     testDataGenerator.createReferral(referralEntity)
 
-    val preferredDeliveryLocationProbationDeliveryUnit = PreferredDeliveryLocationProbationDeliveryUnit(
+    val pdu = PreferredDeliveryLocationProbationDeliveryUnit(
       id = UUID.randomUUID(),
       deliusCode = "THE-PDU-CODE",
       deliusDescription = "The PDU Description",
     )
     testDataGenerator.createPreferredDeliveryLocationProbationDeliveryUnit(
-      preferredDeliveryLocationProbationDeliveryUnit,
+      pdu,
     )
 
     val deliveryLocationPreference = DeliveryLocationPreferenceEntity(
@@ -62,7 +62,7 @@ class DeliveryLocationPreferencesRepositoryIntegrationTest : IntegrationTestBase
       id = UUID.randomUUID(),
       deliusCode = "THE-PDL-CODE",
       deliusDescription = "The PreferredDeliveryLocation Description",
-      preferredDeliveryLocationProbationDeliveryUnit = preferredDeliveryLocationProbationDeliveryUnit,
+      preferredDeliveryLocationProbationDeliveryUnit = pdu,
     )
     testDataGenerator.createPreferredDeliveryLocation(preferredDeliveryLocation)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
@@ -1,0 +1,367 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import jakarta.persistence.EntityManager
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiOfficeLocation
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnitWithOfficeLocations
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementStaff
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataGenerator
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.DeliveryLocationPreferenceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PreferredDeliveryLocation
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PreferredDeliveryLocationProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.wiremock.stubs.NDeliusApiStubs
+import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
+import java.time.LocalDate
+import java.util.UUID
+
+@WithMockAuthUser("PROB_PRACTITIONER_1")
+class DeliveryLocationPreferencesServiceIntegrationTest : IntegrationTestBase() {
+
+  private lateinit var nDeliusApiStubs: NDeliusApiStubs
+
+  @Autowired
+  private lateinit var testDataGenerator: TestDataGenerator
+
+  @Autowired
+  private lateinit var testDataCleaner: TestDataCleaner
+
+  @Autowired
+  private lateinit var deliveryLocationPreferencesService: DeliveryLocationPreferencesService
+
+  @Autowired
+  private lateinit var entityManager: EntityManager
+
+  @BeforeEach
+  fun setup() {
+    testDataCleaner.cleanAllTables()
+    nDeliusApiStubs = NDeliusApiStubs(wiremock, objectMapper)
+    stubAuthTokenEndpoint()
+  }
+
+  @Test
+  @Transactional
+  fun `getDeliveryLocationPreferencesFormDataForReferral should return form data with all required information`() {
+    // Given
+    val crn = "X123456"
+    val eventId = "REQ001"
+    val referralEntity = ReferralEntityFactory()
+      .withCrn(crn)
+      .withEventId(eventId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT)
+      .withCohort(OffenceCohort.GENERAL_OFFENCE)
+      .produce()
+
+    testDataGenerator.createReferral(referralEntity)
+
+    // Create existing delivery location preferences
+    val pdu = PreferredDeliveryLocationProbationDeliveryUnit(
+      id = UUID.randomUUID(),
+      deliusCode = "PDU001",
+      deliusDescription = "Test PDU",
+    )
+    testDataGenerator.createPreferredDeliveryLocationProbationDeliveryUnit(pdu)
+
+    val deliveryLocationPreference = DeliveryLocationPreferenceEntity(
+      id = UUID.randomUUID(),
+      referral = referralEntity,
+      locationsCannotAttendText = "The cannot attend locations free text value",
+    )
+
+    val pdlId = UUID.randomUUID()
+    val preferredLocation = PreferredDeliveryLocation(
+      id = pdlId,
+      deliusCode = "OFFICE-001",
+      deliusDescription = "Test Office",
+      preferredDeliveryLocationProbationDeliveryUnit = pdu,
+    )
+    testDataGenerator.createPreferredDeliveryLocation(preferredLocation)
+
+    deliveryLocationPreference.addPreferredDeliveryLocations(preferredLocation)
+    testDataGenerator.createDeliveryLocationPreference(deliveryLocationPreference)
+
+    // Mock NDelius responses
+    val personalDetails = NDeliusPersonalDetails(
+      crn = crn,
+      name = FullName(forename = "John", surname = "Doe"),
+      dateOfBirth = "1980-01-01",
+      age = "44",
+      sex = CodeDescription("M", "Male"),
+      ethnicity = CodeDescription("WHITE", "White"),
+      probationPractitioner = null,
+      probationDeliveryUnit = CodeDescription("PDU001", "Primary PDU"),
+    )
+
+    val primaryPdu = NDeliusApiProbationDeliveryUnit(
+      code = "PDU001",
+      description = "Primary PDU",
+    )
+
+    val primaryOffices = listOf(
+      NDeliusApiOfficeLocation(
+        code = "OFFICE-001",
+        description = "Brighton and Hove: Probation Office",
+      ),
+      NDeliusApiOfficeLocation(
+        code = "OFFICE-002",
+        description = "Eastbourne: Probation Office",
+      ),
+    )
+
+    val managerDetails = RequirementOrLicenceConditionManager(
+      staff = RequirementStaff(
+        code = "STAFF001",
+        name = FullName(forename = "Jane", surname = "Smith"),
+      ),
+      team = CodeDescription("TEAM001", "Primary Team"),
+      probationDeliveryUnit = primaryPdu,
+      officeLocations = primaryOffices,
+    )
+
+    val additionalPdus = listOf(
+      NDeliusApiProbationDeliveryUnitWithOfficeLocations(
+        code = "PDU002",
+        description = "West Sussex",
+        officeLocations = listOf(
+          NDeliusApiOfficeLocation(
+            code = "OFFICE-003",
+            description = "Guildford: Office Name",
+          ),
+        ),
+      ),
+    )
+
+    val requirementResponse = NDeliusCaseRequirementOrLicenceConditionResponse(
+      manager = managerDetails,
+      probationDeliveryUnits = additionalPdus,
+    )
+
+    nDeliusApiStubs.stubAccessCheck(true, crn)
+    nDeliusApiStubs.stubPersonalDetailsResponseForCrn(crn, personalDetails)
+    nDeliusApiStubs.stubSuccessfulRequirementManagerResponse(crn, eventId, requirementResponse)
+
+    // When
+    val result = deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(referralEntity.id!!)
+
+    // Then
+    assertThat(result.personOnProbation.name).isEqualTo("John Doe")
+    assertThat(result.personOnProbation.crn).isEqualTo(crn)
+    assertThat(result.personOnProbation.dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
+    assertThat(result.personOnProbation.tier).isEqualTo("Primary PDU")
+
+    assertThat(result.existingDeliveryLocationPreferences).isNotNull
+    val existingPrefs = result.existingDeliveryLocationPreferences!!
+    assertThat(existingPrefs.canAttendLocationsValues).hasSize(1)
+    assertThat(existingPrefs.canAttendLocationsValues[0].value).isEqualTo("OFFICE-001")
+    assertThat(existingPrefs.canAttendLocationsValues[0].label).isEqualTo("Test Office")
+    assertThat(existingPrefs.cannotAttendLocations).isEqualTo("The cannot attend locations free text value")
+
+    assertThat(result.primaryPdu.name).isEqualTo("Primary PDU")
+    assertThat(result.primaryPdu.deliveryLocations).hasSize(2)
+    assertThat(result.primaryPdu.deliveryLocations[0].value).isEqualTo("OFFICE-001")
+    assertThat(result.primaryPdu.deliveryLocations[0].label).isEqualTo("Brighton and Hove: Probation Office")
+
+    assertThat(result.otherPdusInSameRegion).hasSize(1)
+    assertThat(result.otherPdusInSameRegion[0].name).isEqualTo("West Sussex")
+    assertThat(result.otherPdusInSameRegion[0].deliveryLocations).hasSize(1)
+    assertThat(result.otherPdusInSameRegion[0].deliveryLocations[0].value).isEqualTo("OFFICE-003")
+  }
+
+  @Test
+  fun `getDeliveryLocationPreferencesFormDataForReferral should return form data without existing preferences`() {
+    // Given
+    val crn = "X123456"
+    val eventId = "REQ001"
+    val referralEntity = ReferralEntityFactory()
+      .withCrn(crn)
+      .withEventId(eventId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT)
+      .withCohort(OffenceCohort.GENERAL_OFFENCE)
+      .produce()
+
+    testDataGenerator.createReferral(referralEntity)
+
+    // Mock NDelius responses
+    val personalDetails = NDeliusPersonalDetails(
+      crn = crn,
+      name = FullName(forename = "Alex", surname = "River"),
+      dateOfBirth = "2000-01-01",
+      age = "25",
+      sex = CodeDescription("F", "Female"),
+      ethnicity = null,
+      probationPractitioner = null,
+      probationDeliveryUnit = CodeDescription("C2", "C2"),
+    )
+
+    val primaryPdu = NDeliusApiProbationDeliveryUnit(
+      code = "PDU001",
+      description = "East Sussex",
+    )
+
+    val primaryOffices = listOf(
+      NDeliusApiOfficeLocation(
+        code = "OFFICE-CODE-123",
+        description = "Brighton and Hove: Probation Office",
+      ),
+    )
+
+    val managerDetails = RequirementOrLicenceConditionManager(
+      staff = RequirementStaff(
+        code = "STAFF001",
+        name = FullName(forename = "Jane", surname = "Smith"),
+      ),
+      team = CodeDescription("TEAM001", "Primary Team"),
+      probationDeliveryUnit = primaryPdu,
+      officeLocations = primaryOffices,
+    )
+
+    val requirementResponse = NDeliusCaseRequirementOrLicenceConditionResponse(
+      manager = managerDetails,
+      probationDeliveryUnits = emptyList(),
+    )
+
+    nDeliusApiStubs.stubAccessCheck(true, crn)
+    nDeliusApiStubs.stubPersonalDetailsResponseForCrn(crn, personalDetails)
+    nDeliusApiStubs.stubSuccessfulRequirementManagerResponse(crn, eventId, requirementResponse)
+
+    // When
+    val result = deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(referralEntity.id!!)
+
+    // Then
+    assertThat(result.personOnProbation.name).isEqualTo("Alex River")
+    assertThat(result.personOnProbation.crn).isEqualTo(crn)
+    assertThat(result.personOnProbation.dateOfBirth).isEqualTo(LocalDate.of(2000, 1, 1))
+    assertThat(result.personOnProbation.tier).isEqualTo("C2")
+
+    assertThat(result.existingDeliveryLocationPreferences).isNull()
+
+    assertThat(result.primaryPdu.name).isEqualTo("East Sussex")
+    assertThat(result.primaryPdu.deliveryLocations).hasSize(1)
+    assertThat(result.primaryPdu.deliveryLocations[0].value).isEqualTo("OFFICE-CODE-123")
+    assertThat(result.primaryPdu.deliveryLocations[0].label).isEqualTo("Brighton and Hove: Probation Office")
+
+    assertThat(result.otherPdusInSameRegion).hasSize(0)
+  }
+
+  @Test
+  fun `getDeliveryLocationPreferencesFormDataForReferral should handle licence condition referrals`() {
+    // Given
+    val crn = "X123456"
+    val eventId = "LIC001"
+    val referralEntity = ReferralEntityFactory()
+      .withCrn(crn)
+      .withEventId(eventId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.LICENSE_CONDITION)
+      .withCohort(OffenceCohort.SEXUAL_OFFENCE)
+      .produce()
+
+    testDataGenerator.createReferral(referralEntity)
+
+    // Mock NDelius responses
+    val personalDetails = NDeliusPersonalDetails(
+      crn = crn,
+      name = FullName(forename = "Test", surname = "Person"),
+      dateOfBirth = "1990-06-15",
+      age = "35",
+      sex = CodeDescription("M", "Male"),
+      ethnicity = CodeDescription("ASIAN", "Asian"),
+      probationPractitioner = null,
+      probationDeliveryUnit = CodeDescription("PDU002", "Test PDU"),
+    )
+
+    val primaryPdu = NDeliusApiProbationDeliveryUnit(
+      code = "PDU002",
+      description = "Test PDU",
+    )
+
+    val managerDetails = RequirementOrLicenceConditionManager(
+      staff = RequirementStaff(
+        code = "STAFF002",
+        name = FullName(forename = "Bob", surname = "Manager"),
+      ),
+      team = CodeDescription("TEAM002", "Licence Team"),
+      probationDeliveryUnit = primaryPdu,
+      officeLocations = emptyList(),
+    )
+
+    val licenceConditionResponse = NDeliusCaseRequirementOrLicenceConditionResponse(
+      manager = managerDetails,
+      probationDeliveryUnits = emptyList(),
+    )
+
+    nDeliusApiStubs.stubAccessCheck(true, crn)
+    nDeliusApiStubs.stubPersonalDetailsResponseForCrn(crn, personalDetails)
+    nDeliusApiStubs.stubSuccessfulLicenceConditionManagerResponse(crn, eventId, licenceConditionResponse)
+
+    // When
+    val result = deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(referralEntity.id!!)
+
+    // Then
+    assertThat(result.personOnProbation.name).isEqualTo("Test Person")
+    assertThat(result.primaryPdu.name).isEqualTo("Test PDU")
+    assertThat(result.primaryPdu.deliveryLocations).hasSize(0)
+  }
+
+  @Test
+  fun `getDeliveryLocationPreferencesFormDataForReferral should throw NotFoundException when referral not found`() {
+    // Given
+    val nonExistentReferralId = UUID.randomUUID()
+
+    // When/Then
+    assertThrows<NotFoundException> {
+      deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(nonExistentReferralId)
+    }
+  }
+
+  @Test
+  fun `getDeliveryLocationPreferencesFormDataForReferral should throw NotFoundException when manager details not found`() {
+    // Given
+    val crn = "X123456"
+    val eventId = "REQ001"
+    val referralEntity = ReferralEntityFactory()
+      .withCrn(crn)
+      .withEventId(eventId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT)
+      .withCohort(OffenceCohort.GENERAL_OFFENCE)
+      .produce()
+
+    testDataGenerator.createReferral(referralEntity)
+
+    val personalDetails = NDeliusPersonalDetails(
+      crn = crn,
+      name = FullName(forename = "John", surname = "Doe"),
+      dateOfBirth = "1980-01-01",
+      age = "44",
+      sex = CodeDescription("M", "Male"),
+      ethnicity = null,
+      probationPractitioner = null,
+      probationDeliveryUnit = null,
+    )
+
+    nDeliusApiStubs.stubAccessCheck(true, crn)
+    nDeliusApiStubs.stubPersonalDetailsResponseForCrn(crn, personalDetails)
+    nDeliusApiStubs.stubNotFoundRequirementManagerResponse(crn, eventId)
+    nDeliusApiStubs.stubNotFoundLicenceConditionManagerResponse(crn, eventId)
+
+    // When/Then
+    assertThrows<NotFoundException> {
+      deliveryLocationPreferencesService.getDeliveryLocationPreferencesFormDataForReferral(referralEntity.id!!)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -75,7 +75,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
     )
 
     val requirementResponse = NDeliusCaseRequirementOrLicenceConditionResponse(manager = expectedManager)
-    nDeliusApiStubs.stubSuccessfulRequirementManagerResponse(referralId, eventId, requirementResponse)
+    nDeliusApiStubs.stubSuccessfulRequirementManagerResponse("X123456", eventId, requirementResponse)
 
     // When
     val result = referralService.attemptToFindManagerForReferral(UUID.fromString(referralId))
@@ -127,9 +127,9 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
     val licenceConditionResponse = NDeliusCaseRequirementOrLicenceConditionResponse(manager = expectedManager)
 
     // Stub requirement endpoint to return 404
-    nDeliusApiStubs.stubNotFoundRequirementManagerResponse(referralId, eventId)
+    nDeliusApiStubs.stubNotFoundRequirementManagerResponse("X654321", eventId)
     // Stub licence condition endpoint to return 200
-    nDeliusApiStubs.stubSuccessfulLicenceConditionManagerResponse(referralId, eventId, licenceConditionResponse)
+    nDeliusApiStubs.stubSuccessfulLicenceConditionManagerResponse("X654321", eventId, licenceConditionResponse)
 
     // When
     val result = referralService.attemptToFindManagerForReferral(UUID.fromString(referralId))
@@ -162,17 +162,17 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
 
     testDataGenerator.createReferral(referralEntity)
     val savedReferral = referralRepository.findByCrn(crn)[0]
-    val referralId = savedReferral.id!!.toString()
 
     // Stub both endpoints to return 404
-    nDeliusApiStubs.stubNotFoundRequirementManagerResponse(referralId, eventId)
-    nDeliusApiStubs.stubNotFoundLicenceConditionManagerResponse(referralId, eventId)
+    nDeliusApiStubs.stubNotFoundRequirementManagerResponse("X999999", eventId)
+    nDeliusApiStubs.stubNotFoundLicenceConditionManagerResponse("X999999", eventId)
 
     // When
-    val result = referralService.attemptToFindManagerForReferral(savedReferral.id!!)
+    val exception = assertThrows<NotFoundException> {
+      referralService.attemptToFindManagerForReferral(savedReferral.id!!)
+    }
 
-    // Then
-    assertThat(result).isNull()
+    assertThat(exception.message).isEqualTo("No LicenceCondition or Requirement found with id UNKNOWN001")
   }
 
   @Test


### PR DESCRIPTION
## What

This PR introduces a new API endpoint at `GET /bff/referral-delivery-location-preferences-form/{referral_id}`, which returns all of the data necessary to display the multi-page form to submit (or update) DeliveryLocationPreferences against a Referral.

It adds OpenAPI / Swagger docs detailing this endpoint.

## Why

We are using the BFF pattern because we need to fetch data from a variety of places (multiple nDelius endpoints, and our own database), and this moves the complexity of the multi-step fetch into the API allowing the UI to remain simple, 

## How

The PR creates a new Service and Controller for the DeliveryLocationPreferences, using standard SpringBoot patterns.  There is nothing interesting or controversial here.

Using the refactored ReferralService (see below) to fetch both the manager and possible delivery locations is the main source of complexity.

Tests with various stubs have also been implemented, with a preference for not stubbing out data.

## Refactoring

This PR also contains some moderate strength refactoring to the ReferralService, which checks to see if a Referral has a relevant Requirement or Licence Condition (and also updates the entity in the database).

This needed extracting because the same flow is used for both the `.manager` and the `.probationDeliveryUnits` at the root of that `/case/{crn}/requirement|licence-condition/{event_id}`

The PR introduces a handful of tests to make sure this flows.

## Commits

- **refactor(nDelius Stubs) Add stubPersonalDetailsResponseForCrn helper method**
- **refactor(ReferralService): Extract various checker/helper methods to check the presence or absence of Requirements or Licence Conditions**
- **refactor(DLP Repository tests): Rename a variable probationDeliveryUnit -> PDU**
- **feature(DeliveryLocationPreferences) Create the GET /bff/referral-delivery-location-preferences-form/{referral_id} endpoint**
