### PR TITLE
fix(DeliveryLocationPreferences): Add the '.code' field to PDU

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DeliveryLocationPreferencesFormData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/DeliveryLocationPreferencesFormData.kt
@@ -53,7 +53,10 @@ data class DeliveryLocationOption(
 
 @Schema(description = "Probation Delivery Unit with available delivery locations")
 data class ProbationDeliveryUnit(
-  @field:Schema(description = "PDU name", example = "East Sussex")
+  @field:Schema(description = "PDU Code (sourced from nDelius)", example = "N54DUR")
+  val code: String,
+
+  @field:Schema(description = "PDU name", example = "County Durham and Darlington")
   val name: String,
 
   @field:Schema(description = "Available delivery locations within this PDU")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
@@ -59,6 +59,7 @@ class DeliveryLocationPreferencesService(
       },
       primaryPdu = ProbationDeliveryUnit(
         name = managerDetails.probationDeliveryUnit.description,
+        code = managerDetails.probationDeliveryUnit.code,
         deliveryLocations = managerDetails.officeLocations.map { office ->
           DeliveryLocationOption(
             value = office.code,
@@ -74,6 +75,7 @@ class DeliveryLocationPreferencesService(
 
   private fun NDeliusApiProbationDeliveryUnitWithOfficeLocations.toProbationDeliveryUnit(): ProbationDeliveryUnit = ProbationDeliveryUnit(
     name = this.description,
+    code = this.code,
     deliveryLocations = this.officeLocations.map { office ->
       DeliveryLocationOption(
         value = office.code,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
@@ -173,12 +173,14 @@ class DeliveryLocationPreferencesServiceIntegrationTest : IntegrationTestBase() 
     assertThat(existingPrefs.cannotAttendLocations).isEqualTo("The cannot attend locations free text value")
 
     assertThat(result.primaryPdu.name).isEqualTo("Primary PDU")
+    assertThat(result.primaryPdu.code).isEqualTo("PDU001")
     assertThat(result.primaryPdu.deliveryLocations).hasSize(2)
     assertThat(result.primaryPdu.deliveryLocations[0].value).isEqualTo("OFFICE-001")
     assertThat(result.primaryPdu.deliveryLocations[0].label).isEqualTo("Brighton and Hove: Probation Office")
 
     assertThat(result.otherPdusInSameRegion).hasSize(1)
     assertThat(result.otherPdusInSameRegion[0].name).isEqualTo("West Sussex")
+    assertThat(result.otherPdusInSameRegion[0].code).isEqualTo("PDU002")
     assertThat(result.otherPdusInSameRegion[0].deliveryLocations).hasSize(1)
     assertThat(result.otherPdusInSameRegion[0].deliveryLocations[0].value).isEqualTo("OFFICE-003")
   }


### PR DESCRIPTION
**WHAT**

This commit adds the missing `.code` field (String) to the PDU being
returned for the DeliveryLocationPreferencesFormData

**WHY**

This code is necessary to save the PDU into the database when
creating/updating the DeliveryLocationPreferences in the Repository.

Without it, there would be un-necessary re-fetching of data and matching
based on `name` or `description` which feels unnecessarily complex and
risky.
