### PR TITLE
APG-1340 - Re-create referral status history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusDescriptionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusDescriptionEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -21,4 +22,13 @@ class ReferralStatusDescriptionEntity(
 
   @Column(name = "label_colour")
   val labelColour: String? = null,
+
+  @Column(name = "created_at")
+  val createdAt: LocalDateTime? = null,
+
+  @Column(name = "updated_at")
+  val updatedAt: LocalDateTime? = null,
+
+  @Column(name = "deleted_at")
+  val deletedAt: LocalDateTime? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusDescriptionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusDescriptionEntity.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "referral_status_description")
+class ReferralStatusDescriptionEntity(
+  @Id
+  @Column(name = "id")
+  val id: UUID,
+
+  @Column(name = "description_text")
+  val description: String,
+
+  @Column(name = "is_closed")
+  val isClosed: Boolean,
+
+  @Column(name = "label_colour")
+  val labelColour: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
@@ -2,8 +2,11 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ent
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
@@ -19,7 +22,11 @@ class ReferralStatusHistoryEntity(
   var id: UUID? = null,
 
   @Column(name = "status")
-  var status: String? = null,
+  var status: String? = null, // TODO is this redundant post introduction of the referralStatusDescription below?
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "referral_status_description_id")
+  val referralStatusDescription: ReferralStatusDescriptionEntity? = null, // TODO this should not be nullable - refactor post population of table
 
   @Column(name = "created_at")
   @CreatedDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "referral_status_transition")
+class ReferralStatusTransitionEntity(
+  @Id
+  @Column(name = "referral_status_transition_id")
+  val id: UUID,
+
+  @ManyToOne
+  @JoinColumn(name = "transition_from_status")
+  val fromStatus: ReferralStatusDescriptionEntity,
+
+  @ManyToOne
+  @JoinColumn(name = "transition_to_status")
+  val toStatus: ReferralStatusDescriptionEntity,
+
+  @Column(name = "description")
+  val description: String?,
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -25,5 +26,14 @@ class ReferralStatusTransitionEntity(
 
   @Column(name = "description")
   val description: String?,
+
+  @Column(name = "created_at")
+  val createdAt: LocalDateTime? = null,
+
+  @Column(name = "updated_at")
+  val updatedAt: LocalDateTime? = null,
+
+  @Column(name = "deleted_at")
+  val deletedAt: LocalDateTime? = null,
 
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusTransitionEntity.kt
@@ -13,15 +13,15 @@ import java.util.UUID
 @Table(name = "referral_status_transition")
 class ReferralStatusTransitionEntity(
   @Id
-  @Column(name = "referral_status_transition_id")
+  @Column(name = "id")
   val id: UUID,
 
   @ManyToOne
-  @JoinColumn(name = "transition_from_status")
+  @JoinColumn(name = "from_status")
   val fromStatus: ReferralStatusDescriptionEntity,
 
   @ManyToOne
-  @JoinColumn(name = "transition_to_status")
+  @JoinColumn(name = "to_status")
   val toStatus: ReferralStatusDescriptionEntity,
 
   @Column(name = "description")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import java.util.UUID
+
+interface ReferralStatusDescriptionRepository : JpaRepository<ReferralStatusDescriptionEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
 import java.util.UUID
 
-interface ReferralStatusDescriptionRepository : JpaRepository<ReferralStatusDescriptionEntity, UUID>
+interface ReferralStatusDescriptionRepository : JpaRepository<ReferralStatusDescriptionEntity, UUID> {
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Awaiting Assessment'")
+  fun getAwaitingAssessmentStatusDescription(): ReferralStatusDescriptionEntity
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusTransitionEntity
+import java.util.UUID
+
+interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTransitionEntity, UUID>

--- a/src/main/resources/db/migration/V22__create_referral_status_description_table.sql
+++ b/src/main/resources/db/migration/V22__create_referral_status_description_table.sql
@@ -3,7 +3,10 @@ CREATE TABLE referral_status_description
     id                  UUID        PRIMARY KEY NOT NULL,
     description_text    TEXT        NOT NULL,
     is_closed           BOOLEAN     NOT NULL DEFAULT FALSE,
-    label_colour        TEXT        NULL
+    label_colour        TEXT        NULL,
+    created_at          TIMESTAMP   NULL,
+    updated_at          TIMESTAMP   NULL,
+    deleted_at          TIMESTAMP   NULL
 );
 
 COMMENT ON TABLE referral_status_description IS 'Contains the status descriptions for referrals';
@@ -11,3 +14,6 @@ COMMENT ON COLUMN referral_status_description.id IS 'Unique identifier for a ref
 COMMENT ON COLUMN referral_status_description.description_text IS 'The human-readable description of the status';
 COMMENT ON COLUMN referral_status_description.is_closed IS 'Flag indicating whether this status represents a closed state';
 COMMENT ON COLUMN referral_status_description.label_colour IS 'Optional colour code for UI display of the status label';
+COMMENT ON COLUMN referral_status_description.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN referral_status_description.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN referral_status_description.deleted_at IS 'Timestamp when the record was deleted (soft delete)';

--- a/src/main/resources/db/migration/V22__create_referral_status_description_table.sql
+++ b/src/main/resources/db/migration/V22__create_referral_status_description_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE referral_status_description
+(
+    id                  UUID        PRIMARY KEY NOT NULL,
+    description_text    TEXT        NOT NULL,
+    is_closed           BOOLEAN     NOT NULL DEFAULT FALSE,
+    label_colour        TEXT        NULL
+);
+
+COMMENT ON TABLE referral_status_description IS 'Contains the status descriptions for referrals';
+COMMENT ON COLUMN referral_status_description.id IS 'Unique identifier for a referral status description';
+COMMENT ON COLUMN referral_status_description.description_text IS 'The human-readable description of the status';
+COMMENT ON COLUMN referral_status_description.is_closed IS 'Flag indicating whether this status represents a closed state';
+COMMENT ON COLUMN referral_status_description.label_colour IS 'Optional colour code for UI display of the status label';

--- a/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
+++ b/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
@@ -1,8 +1,8 @@
 CREATE TABLE referral_status_transition
 (
-    referral_status_transition_id UUID PRIMARY KEY                                       NOT NULL,
-    transition_from_status        UUID REFERENCES referral_status_description (id)       NOT NULL,
-    transition_to_status          UUID REFERENCES referral_status_description (id)       NOT NULL,
+    id                            UUID PRIMARY KEY                                       NOT NULL,
+    from_status                   UUID REFERENCES referral_status_description (id)       NOT NULL,
+    to_status                     UUID REFERENCES referral_status_description (id)       NOT NULL,
     description                   TEXT                                                   NULL,
     created_at                    TIMESTAMP                                              NULL,
     updated_at                    TIMESTAMP                                              NULL,
@@ -10,13 +10,13 @@ CREATE TABLE referral_status_transition
 );
 
 -- Create indexes for performance
-CREATE INDEX idx_referral_status_transition_from ON referral_status_transition (transition_from_status);
-CREATE INDEX idx_referral_status_transition_to ON referral_status_transition (transition_to_status);
+CREATE INDEX idx_referral_status_transition_from ON referral_status_transition (from_status);
+CREATE INDEX idx_referral_status_transition_to ON referral_status_transition (to_status);
 
 COMMENT ON TABLE referral_status_transition IS 'Contains available valid transitions between referral statuses';
-COMMENT ON COLUMN referral_status_transition.referral_status_transition_id IS 'Unique identifier for a status transition';
-COMMENT ON COLUMN referral_status_transition.transition_from_status IS 'References the source status description';
-COMMENT ON COLUMN referral_status_transition.transition_to_status IS 'References the target status description';
+COMMENT ON COLUMN referral_status_transition.id IS 'Unique identifier for a status transition';
+COMMENT ON COLUMN referral_status_transition.from_status IS 'References the source status description';
+COMMENT ON COLUMN referral_status_transition.to_status IS 'References the target status description';
 COMMENT ON COLUMN referral_status_transition.description IS 'Optional description of the transition';
 COMMENT ON COLUMN referral_status_transition.created_at IS 'Timestamp when the record was created';
 COMMENT ON COLUMN referral_status_transition.updated_at IS 'Timestamp when the record was last updated';

--- a/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
+++ b/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE referral_status_transition
+(
+    referral_status_transition_id UUID PRIMARY KEY                                       NOT NULL,
+    transition_from_status        UUID REFERENCES referral_status_description (id)       NOT NULL,
+    transition_to_status          UUID REFERENCES referral_status_description (id)       NOT NULL,
+    description                   TEXT                                                   NULL
+);
+
+-- Create indexes for performance
+CREATE INDEX idx_referral_status_transition_from ON referral_status_transition (transition_from_status);
+CREATE INDEX idx_referral_status_transition_to ON referral_status_transition (transition_to_status);
+
+COMMENT ON TABLE referral_status_transition IS 'Contains available valid transitions between referral statuses';
+COMMENT ON COLUMN referral_status_transition.referral_status_transition_id IS 'Unique identifier for a status transition';
+COMMENT ON COLUMN referral_status_transition.transition_from_status IS 'References the source status description';
+COMMENT ON COLUMN referral_status_transition.transition_to_status IS 'References the target status description';
+COMMENT ON COLUMN referral_status_transition.description IS 'Optional description of the transition';

--- a/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
+++ b/src/main/resources/db/migration/V23__create_referral_status_transition_table.sql
@@ -3,7 +3,10 @@ CREATE TABLE referral_status_transition
     referral_status_transition_id UUID PRIMARY KEY                                       NOT NULL,
     transition_from_status        UUID REFERENCES referral_status_description (id)       NOT NULL,
     transition_to_status          UUID REFERENCES referral_status_description (id)       NOT NULL,
-    description                   TEXT                                                   NULL
+    description                   TEXT                                                   NULL,
+    created_at                    TIMESTAMP                                              NULL,
+    updated_at                    TIMESTAMP                                              NULL,
+    deleted_at                    TIMESTAMP                                              NULL
 );
 
 -- Create indexes for performance
@@ -15,3 +18,6 @@ COMMENT ON COLUMN referral_status_transition.referral_status_transition_id IS 'U
 COMMENT ON COLUMN referral_status_transition.transition_from_status IS 'References the source status description';
 COMMENT ON COLUMN referral_status_transition.transition_to_status IS 'References the target status description';
 COMMENT ON COLUMN referral_status_transition.description IS 'Optional description of the transition';
+COMMENT ON COLUMN referral_status_transition.created_at IS 'Timestamp when the record was created';
+COMMENT ON COLUMN referral_status_transition.updated_at IS 'Timestamp when the record was last updated';
+COMMENT ON COLUMN referral_status_transition.deleted_at IS 'Timestamp when the record was deleted (soft delete)';

--- a/src/main/resources/db/migration/V24__update_referral_status_history_table.sql
+++ b/src/main/resources/db/migration/V24__update_referral_status_history_table.sql
@@ -1,0 +1,6 @@
+ALTER TABLE referral_status_history 
+ADD COLUMN referral_status_description_id UUID REFERENCES referral_status_description (id);
+
+CREATE INDEX idx_referral_status_history_description_id ON referral_status_history (referral_status_description_id);
+
+COMMENT ON COLUMN referral_status_history.referral_status_description_id IS 'References the status description for this history entry';

--- a/src/main/resources/db/migration/V25__create_awaiting_assessment_status_description.sql
+++ b/src/main/resources/db/migration/V25__create_awaiting_assessment_status_description.sql
@@ -1,0 +1,7 @@
+INSERT INTO referral_status_description
+    (id, description_text,
+     is_closed,
+     label_colour,
+     created_at,
+     updated_at, deleted_at)
+VALUES ('76b2f8d8-260c-4766-a716-de9325292609', 'Awaiting Assessment', false, null, now(), now(), null);

--- a/src/main/resources/db/migration/V27__update_status_history_to_awaiting_asessment.sql
+++ b/src/main/resources/db/migration/V27__update_status_history_to_awaiting_asessment.sql
@@ -1,0 +1,14 @@
+-- Clear the referral status history
+DELETE FROM referral_status_history;
+
+-- For each existing referral create a new status history entry with a linked referral status description of "Awaiting Assessment"
+INSERT INTO referral_status_history (id, referral_status_description_id, status, created_at, created_by, start_date, end_date)
+SELECT
+    r.id,
+    '76b2f8d8-260c-4766-a716-de9325292609',
+    null,
+    NOW(),
+    'SYSTEM',
+    NOW(),
+    null
+FROM referral r;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AvailabilityControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AvailabilityControllerIntegrationTest.kt
@@ -165,7 +165,6 @@ class AvailabilityControllerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `create availability returns conflict if availability already exists`() {
     val otherDetails = "Available remotely"
-    val lastModifiedBy = "AUTH_ADM"
     val startDate: LocalDate = LocalDate.now()
     val endDate: LocalDate = LocalDate.now().plusDays(10)
 
@@ -174,7 +173,7 @@ class AvailabilityControllerIntegrationTest : IntegrationTestBase() {
 
     val createdAvailability = createAvailability(referralEntity, startDate, endDate, otherDetails)
 
-    // assert that its a conflict
+    // assert that it's a conflict
     val duplicateAvailability =
       createAvailability(referralEntity, startDate, endDate, otherDetails, HttpStatus.CONFLICT.value())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PreferredDeliveryLocationEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.PreferredDeliveryLocationProbationDeliveryUnitEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import java.util.UUID
 
@@ -72,5 +73,9 @@ class TestDataGenerator {
 
   fun refreshReferralCaseListItemView() {
     entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW referral_caselist_item_view").executeUpdate()
+  }
+
+  fun createReferralStatusDescription(referralStatusDescription: ReferralStatusDescriptionEntity) {
+    entityManager.persist(referralStatusDescription)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusDescriptionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusDescriptionEntityFactory.kt
@@ -7,7 +7,7 @@ class ReferralStatusDescriptionEntityFactory {
   private var id: UUID = UUID.randomUUID()
   private var description: String = "Test Status Description"
   private var isClosed: Boolean = false
-  private var labelColour: String? = "yellow"
+  private var labelColour: String? = null
 
   fun withId(id: UUID) = apply { this.id = id }
   fun withDescription(description: String) = apply { this.description = description }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusDescriptionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusDescriptionEntityFactory.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import java.util.UUID
+
+class ReferralStatusDescriptionEntityFactory {
+  private var id: UUID = UUID.randomUUID()
+  private var description: String = "Test Status Description"
+  private var isClosed: Boolean = false
+  private var labelColour: String? = "yellow"
+
+  fun withId(id: UUID) = apply { this.id = id }
+  fun withDescription(description: String) = apply { this.description = description }
+  fun withIsClosed(isClosed: Boolean) = apply { this.isClosed = isClosed }
+  fun withLabelColour(labelColour: String?) = apply { this.labelColour = labelColour }
+
+  fun produce() = ReferralStatusDescriptionEntity(
+    id = this.id,
+    description = this.description,
+    isClosed = this.isClosed,
+    labelColour = this.labelColour,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusHistoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusHistoryEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fac
 
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomSentence
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import java.time.LocalDateTime
 import java.util.UUID
@@ -13,6 +14,7 @@ class ReferralStatusHistoryEntityFactory {
   private var createdBy: String? = randomSentence(wordRange = 1..2)
   private var startDate: LocalDateTime? = LocalDateTime.now()
   private var endDate: LocalDateTime? = null
+  private var referralStatusDescription: ReferralStatusDescriptionEntity? = null
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withStatus(status: String?) = apply { this.status = status }
@@ -20,6 +22,7 @@ class ReferralStatusHistoryEntityFactory {
   fun withCreatedBy(createdBy: String?) = apply { this.createdBy = createdBy }
   fun withStartDate(startDate: LocalDateTime?) = apply { this.startDate = startDate }
   fun withEndDate(endDate: LocalDateTime?) = apply { this.endDate = endDate }
+  fun withReferralStatusDescription(referralStatusDescription: ReferralStatusDescriptionEntity) = apply { this.referralStatusDescription = referralStatusDescription }
 
   fun produce() = ReferralStatusHistoryEntity(
     id = this.id,
@@ -28,5 +31,6 @@ class ReferralStatusHistoryEntityFactory {
     createdBy = this.createdBy,
     startDate = this.startDate,
     endDate = this.endDate,
+    referralStatusDescription = this.referralStatusDescription,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusTransitionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/ReferralStatusTransitionEntityFactory.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusTransitionEntity
+import java.util.UUID
+
+class ReferralStatusTransitionEntityFactory {
+  private val referralStatusDescriptionEntityFactory = ReferralStatusDescriptionEntityFactory()
+  private var id: UUID = UUID.randomUUID()
+  private var fromStatus: ReferralStatusDescriptionEntity = referralStatusDescriptionEntityFactory
+    .withDescription("Awaiting Assessment")
+    .produce()
+  private var toStatus: ReferralStatusDescriptionEntity = referralStatusDescriptionEntityFactory
+    .withDescription("Not Eligible")
+    .produce()
+  private var description: String? = "Test Transition Description"
+
+  fun withId(id: UUID) = apply { this.id = id }
+  fun withFromStatus(fromStatus: ReferralStatusDescriptionEntity) = apply { this.fromStatus = fromStatus }
+  fun withToStatus(toStatus: ReferralStatusDescriptionEntity) = apply { this.toStatus = toStatus }
+  fun withDescription(description: String?) = apply { this.description = description }
+
+  fun produce() = ReferralStatusTransitionEntity(
+    id = this.id,
+    fromStatus = this.fromStatus,
+    toStatus = this.toStatus,
+    description = this.description,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
@@ -1,0 +1,109 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusDescriptionEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusHistoryEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import java.util.*
+
+class ReferralStatusDescriptionRepositoryIntegrationTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var statusDescriptionRepository: ReferralStatusDescriptionRepository
+
+  @Autowired
+  private lateinit var statusHistoryRepository: ReferralStatusHistoryRepository
+
+  @Autowired
+  private lateinit var testDataCleaner: TestDataCleaner
+
+  @BeforeEach
+  override fun beforeEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @AfterEach
+  fun afterEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @Test
+  @Transactional
+  fun `should save and retrieve a referral status description`() {
+    // Given
+    val statusId = UUID.randomUUID()
+    val statusDescription = ReferralStatusDescriptionEntityFactory()
+      .withId(statusId)
+      .withDescription("Test Status Description")
+      .withIsClosed(false)
+      .withLabelColour("Grey")
+      .produce()
+
+    statusDescriptionRepository.save(statusDescription)
+
+    // When
+    val retrieved = statusDescriptionRepository.findById(statusId)
+
+    // Then
+    assertThat(retrieved).isPresent
+    assertThat(retrieved.get().description).isEqualTo("Test Status Description")
+    assertThat(retrieved.get().isClosed).isFalse()
+    assertThat(retrieved.get().labelColour).isEqualTo("Grey")
+  }
+
+  @Test
+  @Transactional
+  fun `should find all referral status descriptions`() {
+    // Given
+    val status1 = ReferralStatusDescriptionEntityFactory()
+      .withId(UUID.randomUUID())
+      .withDescription("Status 1")
+      .withIsClosed(false)
+      .produce()
+    val status2 = ReferralStatusDescriptionEntityFactory()
+      .withId(UUID.randomUUID())
+      .withDescription("Status 2")
+      .withIsClosed(true)
+      .produce()
+
+    statusDescriptionRepository.saveAll(listOf(status1, status2))
+
+    // When
+    val allStatuses = statusDescriptionRepository.findAll()
+
+    // Then
+    assertThat(allStatuses).hasSize(2)
+    assertThat(allStatuses.map { it.description }).containsExactlyInAnyOrder("Status 1", "Status 2")
+  }
+
+  @Test
+  @Transactional
+  fun `should retrieve the associated referral status description for a status history entity`() {
+    // Given
+    val status = ReferralStatusDescriptionEntityFactory()
+      .withId(UUID.randomUUID())
+      .withDescription("Awaiting Assessment")
+      .withIsClosed(false)
+      .produce()
+
+    val savedStatusDescription = statusDescriptionRepository.save(status)
+
+    val statusHistory = ReferralStatusHistoryEntityFactory()
+      .withReferralStatusDescription(savedStatusDescription)
+      .produce()
+    statusHistoryRepository.save(statusHistory)
+
+    // When
+    val retrievedStatusHistory = statusHistoryRepository.findById(statusHistory.id!!)
+
+    // Then
+    assertThat(retrievedStatusHistory).isPresent
+    assertThat(retrievedStatusHistory.get().referralStatusDescription?.description).isEqualTo("Awaiting Assessment")
+    assertThat(retrievedStatusHistory.get().referralStatusDescription?.isClosed).isFalse
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
@@ -77,8 +77,7 @@ class ReferralStatusDescriptionRepositoryIntegrationTest : IntegrationTestBase()
     val allStatuses = statusDescriptionRepository.findAll()
 
     // Then
-    assertThat(allStatuses).hasSize(2)
-    assertThat(allStatuses.map { it.description }).containsExactlyInAnyOrder("Status 1", "Status 2")
+    assertThat(allStatuses.map { it.description }).containsExactlyInAnyOrder("Status 1", "Status 2", "Awaiting Assessment")
   }
 
   @Test
@@ -105,5 +104,15 @@ class ReferralStatusDescriptionRepositoryIntegrationTest : IntegrationTestBase()
     assertThat(retrievedStatusHistory).isPresent
     assertThat(retrievedStatusHistory.get().referralStatusDescription?.description).isEqualTo("Awaiting Assessment")
     assertThat(retrievedStatusHistory.get().referralStatusDescription?.isClosed).isFalse
+  }
+
+  @Test
+  fun `should retrieve awaiting assessment status description`() {
+    // When
+    val awaitingAssessmentStatusDescription = statusDescriptionRepository.getAwaitingAssessmentStatusDescription()
+
+    // Then
+    assertThat(awaitingAssessmentStatusDescription).isNotNull
+    assertThat(awaitingAssessmentStatusDescription.description).isEqualTo("Awaiting Assessment")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepositoryIntegrationTest.kt
@@ -1,0 +1,111 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusDescriptionEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusTransitionEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import java.util.*
+
+class ReferralStatusTransitionRepositoryIntegrationTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var statusTransitionRepository: ReferralStatusTransitionRepository
+
+  @Autowired
+  private lateinit var statusDescriptionRepository: ReferralStatusDescriptionRepository
+
+  @Autowired
+  private lateinit var testDataCleaner: TestDataCleaner
+
+  @BeforeEach
+  override fun beforeEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @AfterEach
+  fun afterEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @Test
+  @Transactional
+  fun `should save and retrieve a referral status transitions with associated status descriptions`() {
+    // Given
+    val fromStatusId = UUID.randomUUID()
+    val fromStatus = ReferralStatusDescriptionEntityFactory()
+      .withId(fromStatusId)
+      .withDescription("Awaiting Assessment")
+      .withIsClosed(false)
+      .withLabelColour("grey")
+      .produce()
+    statusDescriptionRepository.save(fromStatus)
+
+    // Create the to statuses
+    val toStatusId1 = UUID.randomUUID()
+    val toStatus1 = ReferralStatusDescriptionEntityFactory()
+      .withId(toStatusId1)
+      .withDescription("Assessment Started")
+      .withIsClosed(false)
+      .withLabelColour("light-blue")
+      .produce()
+    statusDescriptionRepository.save(toStatus1)
+    val toStatusId2 = UUID.randomUUID()
+    val toStatus2 = ReferralStatusDescriptionEntityFactory()
+      .withId(toStatusId2)
+      .withDescription("Withdrawn")
+      .withIsClosed(true)
+      .withLabelColour("yellow")
+      .produce()
+    statusDescriptionRepository.save(toStatus2)
+
+    // Create transitions
+    val transitionId1 = UUID.randomUUID()
+    val transition1 = ReferralStatusTransitionEntityFactory()
+      .withId(transitionId1)
+      .withFromStatus(fromStatus)
+      .withToStatus(toStatus1)
+      .withDescription("Awaiting Assessment to Assessment Started")
+      .produce()
+    val transitionId2 = UUID.randomUUID()
+    val transition2 = ReferralStatusTransitionEntityFactory()
+      .withId(transitionId2)
+      .withFromStatus(fromStatus)
+      .withToStatus(toStatus2)
+      .withDescription("Awaiting Assessment to Withdrawn")
+      .produce()
+
+    // When
+    statusTransitionRepository.saveAll(listOf(transition1, transition2))
+
+    // Then
+    val availableTransitions = statusTransitionRepository.findAll()
+    assertThat(availableTransitions.size).isEqualTo(2)
+
+    val retrieved1 = statusTransitionRepository.findById(transitionId1)
+    assertThat(retrieved1).isPresent
+
+    val statusTransition1 = retrieved1.get()
+    assertThat(statusTransition1.fromStatus.description).isEqualTo("Awaiting Assessment")
+    assertThat(statusTransition1.fromStatus.isClosed).isFalse()
+    assertThat(statusTransition1.toStatus.description).isEqualTo("Assessment Started")
+    assertThat(statusTransition1.toStatus.isClosed).isFalse()
+    assertThat(statusTransition1.toStatus.labelColour).isEqualTo("light-blue")
+    assertThat(statusTransition1.description).isEqualTo("Awaiting Assessment to Assessment Started")
+
+    val retrieved2 = statusTransitionRepository.findById(transitionId2)
+    assertThat(retrieved2).isPresent
+
+    val statusTransition2 = retrieved2.get()
+    assertThat(statusTransition2.fromStatus.description).isEqualTo("Awaiting Assessment")
+    assertThat(statusTransition2.fromStatus.isClosed).isFalse()
+    assertThat(statusTransition2.toStatus.description).isEqualTo("Withdrawn")
+    assertThat(statusTransition2.toStatus.isClosed).isTrue()
+    assertThat(statusTransition2.toStatus.labelColour).isEqualTo("yellow")
+    assertThat(statusTransition2.description).isEqualTo("Awaiting Assessment to Withdrawn")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fact
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusHistoryEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
 import java.util.Optional
 import java.util.UUID
@@ -41,6 +42,9 @@ class ReferralServiceTest {
 
   @Mock
   private lateinit var referralRepository: ReferralRepository
+
+  @Mock
+  private lateinit var referralStatusDescriptionRepository: ReferralStatusDescriptionRepository
 
   @Mock
   private lateinit var referralStatusHistoryRepository: ReferralStatusHistoryRepository


### PR DESCRIPTION

* Cleared `referral_status_history` table.
* Added migration to insert default "Awaiting Assessment" status for all existing referrals.