### PR TITLE
APG-1182: Add POST endpoint to update LDC status for a referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/ApiExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -112,4 +113,18 @@ class ApiExceptionHandler {
         developerMessage = exception.localizedMessage,
       ),
     )
+
+  @ExceptionHandler(HttpMessageNotReadableException::class)
+  fun handleHttpMessageNotReadableException(exception: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+    log.warn("Bad request", exception)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST.value(),
+          userMessage = "Bad request: ${exception.message}",
+          developerMessage = exception.message,
+        ),
+      )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/LdcController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/LdcController.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import io.swagger.v3.oas.annotations.Parameter
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc.UpdateLdc
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.LdcService
+import java.util.UUID
+
+@RestController
+@PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
+class LdcController(private val ldcService: LdcService) {
+
+  @PostMapping(
+    "/referral/{referralId}/update-ldc",
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  fun updateLdcStatusForReferral(
+    @Parameter(
+      description = "The referralId (UUID) of a referral",
+      required = true,
+    )
+    @PathVariable("referralId") referralId: UUID,
+    @Parameter(
+      description = "Does the person associated with the referral have LDC needs.",
+      required = true,
+    )
+    @Valid
+    @RequestBody updateLdc: UpdateLdc,
+  ): ResponseEntity<Void> {
+    ldcService.updateLdcStatusForReferral(referralId, updateLdc)
+    return ResponseEntity.status(HttpStatus.OK).build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ldc/UpdateLdc.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ldc/UpdateLdc.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+data class UpdateLdc(
+  @NotNull(message = "hasLdc must not be null")
+  @get:JsonProperty("hasLdc", required = true)
+  @Schema(
+    example = "true",
+    description = "The updated LDC status of the referral",
+    allowableValues = ["true", "false"],
+  )
+  var hasLdc: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralLdcHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralLdcHistoryEntity.kt
@@ -15,6 +15,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc.UpdateLdc
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -45,4 +46,9 @@ open class ReferralLdcHistoryEntity(
   @NotNull
   @CreatedDate
   open var createdAt: LocalDateTime? = LocalDateTime.now(),
+)
+
+fun UpdateLdc.toEntity(referralEntity: ReferralEntity): ReferralLdcHistoryEntity = ReferralLdcHistoryEntity(
+  referral = referralEntity,
+  hasLdc = hasLdc,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LdcService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LdcService.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc.UpdateLdc
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.toEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralLdcHistoryRepository
+import java.util.UUID
+
+@Service
+class LdcService(
+  private val ldcHistoryRepository: ReferralLdcHistoryRepository,
+  private val referralService: ReferralService,
+) {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  fun updateLdcStatusForReferral(referralId: UUID, updateLdc: UpdateLdc) {
+    val referralEntity = referralService.getReferralById(referralId)
+    log.info("Updating LDC status to '${updateLdc.hasLdc}' for referral with Id: '$referralId'")
+    ldcHistoryRepository.save(updateLdc.toEntity(referralEntity))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/LdcControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/LdcControllerIntegrationTest.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc.UpdateLdc
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralLdcHistoryRepository
+
+class LdcControllerIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var referralLdcHistoryRepository: ReferralLdcHistoryRepository
+
+  @BeforeEach
+  fun setup() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @Test
+  fun `update the LDC status for a referral when valid request sent and no existing ldc status`() {
+    val referralEntity = ReferralEntityFactory().produce()
+    testDataGenerator.createReferral(referralEntity)
+
+    val updateLdc = UpdateLdc(
+      hasLdc = true,
+    )
+
+    assertThat(referralLdcHistoryRepository.count()).isZero
+
+    performRequestAndExpectStatus(
+      httpMethod = HttpMethod.POST,
+      uri = "/referral/${referralEntity.id}/update-ldc",
+      body = updateLdc,
+      expectedResponseStatus = HttpStatus.OK.value(),
+    )
+
+    assertThat(referralLdcHistoryRepository.count()).isOne
+    val savedHistory =
+      referralLdcHistoryRepository.findAll().first()
+    assertThat(savedHistory.hasLdc).isTrue
+    assertThat(savedHistory.referral.id).isEqualTo(referralEntity.id)
+  }
+
+  @Test
+  fun `should return bad request if missing hasLdc property`() {
+    val referralEntity = ReferralEntityFactory().produce()
+    testDataGenerator.createReferral(referralEntity)
+
+    assertThat(referralLdcHistoryRepository.count()).isZero
+
+    performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.POST,
+      uri = "/referral/${referralEntity.id}/update-ldc",
+      returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
+      body = """{}""",
+      expectedResponseStatus = HttpStatus.BAD_REQUEST.value(),
+    )
+
+    assertThat(referralLdcHistoryRepository.count()).isZero
+  }
+}


### PR DESCRIPTION
## WHAT

* Adds a POST endpoint for Updating LDC status for a referral

## HOW

* When a request to update ldc status comes through and `hasLdc` property in the body is not null then add entry into LDC history table and with LDC status True or False.