### PR TITLE
Refactor referralService.getReferralById to throw NotFoundException if null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -117,7 +117,7 @@ class ReferralController(
     @Parameter(description = "The id (UUID) of a referral", required = true)
     @PathVariable("id") id: UUID,
   ): ResponseEntity<PersonalDetails> {
-    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    val referral = referralService.getReferralById(id)
     return serviceUserService.getPersonalDetailsByIdentifier(referral.crn).let {
       ResponseEntity.ok(it.toModel(referral.setting))
     } ?: throw NotFoundException("Personal details not found for crn ${referral.crn} not found")
@@ -166,7 +166,7 @@ class ReferralController(
     @Parameter(description = "The id (UUID) of a referral", required = true)
     @PathVariable("id") id: UUID,
   ): ResponseEntity<OffenceHistory> {
-    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    val referral = referralService.getReferralById(id)
     return offenceService.getOffenceHistory(referral).let { ResponseEntity.ok(it) }
       ?: throw NotFoundException("Offence history not found for crn ${referral.crn} and referral with id $id")
   }
@@ -205,7 +205,7 @@ class ReferralController(
     @Parameter(description = "The id (UUID) of a referral", required = true)
     @PathVariable("id") id: UUID,
   ): ResponseEntity<SentenceInformation> {
-    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    val referral = referralService.getReferralById(id)
     if (referral.eventNumber == null) {
       log.error("Referral with id $id has null eventNumber")
       throw BusinessException("Referral with id $id has null eventNumber")
@@ -255,7 +255,7 @@ class ReferralController(
       required = true,
     ) @RequestBody updateCohort: UpdateCohort,
   ): ResponseEntity<Referral?> {
-    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+    val referral = referralService.getReferralById(id)
     val updateCohort = referralService.updateCohort(referral, updateCohort.cohort)
     return ResponseEntity.ok(updateCohort)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ser
 
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DeliveryLocationOption
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.DeliveryLocationPreferences
@@ -51,8 +50,7 @@ class DeliveryLocationPreferencesService(
           "A DeliveryLocationPreferences for this referral with id: $referralId already exists",
         )
       }
-    val referral =
-      referralRepository.findByIdOrNull(referralId) ?: throw NotFoundException("No referral found with id: $referralId")
+    val referral = referralService.getReferralById(referralId)
     val preferredDeliveryLocations =
       createOrUpdateDeliveryLocations(createDeliveryLocationPreferences, referralId)
 
@@ -111,7 +109,6 @@ class DeliveryLocationPreferencesService(
     log.info("Getting delivery location preferences form data for referral: $referralId")
 
     val referral = referralService.getReferralById(referralId)
-      ?: throw NotFoundException("Referral not found id $referralId")
 
     val personalDetails = serviceUserService.getPersonalDetailsByIdentifier(referral.crn)
 
@@ -159,7 +156,6 @@ class DeliveryLocationPreferencesService(
 
   fun getPreferredDeliveryLocationsForReferral(referralId: UUID): DeliveryLocationPreferences {
     val referral = referralService.getReferralById(referralId)
-      ?: throw NotFoundException("Referral with referralId $referralId not found")
     // Create empty delivery location preferences if there is no existing preferences
     return referral.deliveryLocationPreferences?.toModel() ?: DeliveryLocationPreferences()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -95,19 +95,19 @@ class ReferralService(
 
     log.info("Inserting referral for Intervention: '${referralEntity.interventionName}' and Crn: '${referralEntity.crn}' with cohort: $cohort and Ldc status: '$hasLdc'")
     referralRepository.save(referralEntity)
-    return referralRepository.findByIdOrNull(referral.id!!) ?: throw NotFoundException("Referral with id $referral.id")
+    return getReferralById(referral.id!!)
   }
 
-  fun getReferralById(id: UUID): ReferralEntity? = referralRepository.findByIdOrNull(id)
+  fun getReferralById(referralId: UUID): ReferralEntity = referralRepository.findByIdOrNull(referralId) ?: let {
+    log.error("Referral with id $referralId does not exist in database")
+    throw NotFoundException("No Referral found for id: $referralId")
+  }
 
   private fun getReferralAndEnsureSourcedFrom(referralId: UUID): ReferralEntity {
     log.info("getReferralAndEnsureSourcedFrom for $referralId")
     val referral = getReferralById(referralId)
 
-    if (referral == null) {
-      log.error("Referral with id $referralId does not exist in database")
-      throw NotFoundException("No Referral found for id: $referralId")
-    } else if (referral.eventId.isNullOrEmpty()) {
+    if (referral.eventId.isNullOrEmpty()) {
       log.error("Referral with id $referralId does not have an eventId")
       throw NotFoundException("Referral with id: $referralId exists, but has no eventId")
     }


### PR DESCRIPTION
This PR refactors the `referralService.getReferralById` call that is made in several places throughout the service. Currently we are always throwing an exception if this function returns null so this pr moves that exception into the service call and removes the duplicated code across the service.