### PR TITLE
[APG-1365] Rename `LICENSE_CONDITION` to `LICENCE_CONDITION` across the codebase

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -97,5 +97,5 @@ class ReferralEntity(
 
 enum class ReferralEntitySourcedFrom {
   REQUIREMENT,
-  LICENSE_CONDITION,
+  LICENCE_CONDITION,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -133,7 +133,7 @@ class ReferralService(
     when (ndeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, referral.eventId!!)) {
       is ClientResult.Success -> {
         log.info("Referral with id ${referral.id} appears to be sourced from a LicenceCondition, saving Entity and continuing...")
-        referral.sourcedFrom = ReferralEntitySourcedFrom.LICENSE_CONDITION
+        referral.sourcedFrom = ReferralEntitySourcedFrom.LICENCE_CONDITION
         referralRepository.save(referral)
         return referral
       }
@@ -165,7 +165,7 @@ class ReferralService(
           throw NotFoundException("Could not fetch a Requirement with ID $referralIdString, for Referral with ID: $referralIdString")
         }
       }
-    } else if (referralSourcedFrom == ReferralEntitySourcedFrom.LICENSE_CONDITION) {
+    } else if (referralSourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION) {
       log.info("...attempting to retrieve a Licence Condition for Referral with ID: $referralIdString")
 
       when (val response = ndeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, eventId)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/findAndReferInterventionApi/FindAndReferInterventionApiClientIntegrationTest.kt
@@ -33,7 +33,7 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
       personReference = "X123456",
       personReferenceType = PersonReferenceType.CRN,
       setting = SettingType.COMMUNITY,
-      sourcedFromReferenceType = ReferralEntitySourcedFrom.LICENSE_CONDITION,
+      sourcedFromReferenceType = ReferralEntitySourcedFrom.LICENCE_CONDITION,
       sourcedFromReference = "licence-id-12345",
       eventNumber = 1,
     )
@@ -58,7 +58,7 @@ class FindAndReferInterventionApiClientIntegrationTest : IntegrationTestBase() {
         assertThat(findAndReferReferralDetails.personReference).isEqualTo("X123456")
         assertThat(findAndReferReferralDetails.personReferenceType).isEqualTo(PersonReferenceType.CRN)
         assertThat(findAndReferReferralDetails.sourcedFromReference).isEqualTo("licence-id-12345")
-        assertThat(findAndReferReferralDetails.sourcedFromReferenceType).isEqualTo(ReferralEntitySourcedFrom.LICENSE_CONDITION)
+        assertThat(findAndReferReferralDetails.sourcedFromReferenceType).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
       }
 
       is ClientResult.Failure.Other<*> -> fail("Unexpected client result: ${response::class.simpleName}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/listener/DomainEventsListenerIntegrationTest.kt
@@ -57,7 +57,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       .withReferralId(sourceReferralId)
       .withPersonReference("X123456")
       .withPersonReferenceType(PersonReferenceType.CRN)
-      .withSourcedFromReferenceType(ReferralEntitySourcedFrom.LICENSE_CONDITION)
+      .withSourcedFromReferenceType(ReferralEntitySourcedFrom.LICENCE_CONDITION)
       .withSourcedFromReference("LIC-12345")
       .produce()
 
@@ -151,7 +151,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       it.crn == "X123456"
       it.interventionName == "Test Intervention"
       it.interventionType == InterventionType.ACP
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENSE_CONDITION
+      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
       it.eventId == "LIC-12345"
     }
 
@@ -199,7 +199,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       it.interventionName == "Test Intervention"
       it.interventionType == InterventionType.ACP
       it.statusHistories.first().referralStatusDescription.description == "Awaiting assessment"
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENSE_CONDITION
+      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
       it.eventId == "LIC-12345"
       it.referralLdcHistories.first().hasLdc
     }
@@ -248,7 +248,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       it.interventionName == "Test Intervention"
       it.interventionType == InterventionType.ACP
       it.statusHistories.first().referralStatusDescription.description == "Awaiting assessment"
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENSE_CONDITION
+      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
       it.eventId == "LIC-12345"
       !it.referralLdcHistories.first().hasLdc
       it.referralLdcHistories.first().createdBy == "SYSTEM"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/DeliveryLocationPreferencesServiceIntegrationTest.kt
@@ -254,7 +254,7 @@ class DeliveryLocationPreferencesServiceIntegrationTest : IntegrationTestBase() 
     val referralEntity = ReferralEntityFactory()
       .withCrn(crn)
       .withEventId(eventId)
-      .withSourcedFrom(ReferralEntitySourcedFrom.LICENSE_CONDITION)
+      .withSourcedFrom(ReferralEntitySourcedFrom.LICENCE_CONDITION)
       .withCohort(OffenceCohort.SEXUAL_OFFENCE)
       .produce()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -247,7 +247,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
           personReferenceType = PersonReferenceType.CRN,
           referralId = UUID.randomUUID(),
           setting = SettingType.COMMUNITY,
-          sourcedFromReferenceType = ReferralEntitySourcedFrom.LICENSE_CONDITION,
+          sourcedFromReferenceType = ReferralEntitySourcedFrom.LICENCE_CONDITION,
           sourcedFromReference = "LICENCE-12345",
           eventNumber = 1,
         ),


### PR DESCRIPTION
## WHAT
Rename the  Licence condition value in the `ReferralEntitySourcedFrom` Enumeration.

## WHY
When calling the FindAndRefer API, it is returning LICENCE_CONDITION not LICENSE_CONDITION.

The following error was found in the API dev logs:

`Exception occurred whilst processing request: Cannot deserialize value of type uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom from String "LICENCE_CONDITION": not one of the values accepted for Enum class: [REQUIREMENT, LICENSE_CONDITION]`