### PR TITLE
[APG-1354] Add retrieval of referral status transitions API (#173)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralStatusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralStatusController.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralStatusService
+import java.util.UUID
+
+@RestController
+@PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
+class ReferralStatusController(
+  private val referralStatusService: ReferralStatusService,
+) {
+
+  @Operation(
+    tags = ["Referral Status"],
+    summary = "Retrieve possible referral status transitions",
+    operationId = "getPossibleTransitions",
+    description = "Returns all possible referral status transitions for a given referral status description ID",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "List of possible referral status transitions",
+        content = [Content(array = ArraySchema(schema = Schema(implementation = ReferralStatus::class)))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden. The client is not authorised to access this resource.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
+  @GetMapping("/referral-status/{id}/transitions", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getPossibleTransitions(
+    @Parameter(description = "The id (UUID) of a referral status description", required = true)
+    @PathVariable id: UUID,
+  ): List<ReferralStatus> = referralStatusService.getReferralStatusTransitionsForReferralStatusDescriptionId(id)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatus.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import java.util.UUID
+
+data class ReferralStatus(
+  @Schema(
+    example = "c98151f4-4081-4c65-9f98-54e63a328c8d",
+    required = true,
+    description = "The unique id of this referral status.",
+  )
+  @get:JsonProperty("id", required = true)
+  val id: UUID,
+
+  @Schema(
+    example = "Awaiting assessment",
+    required = true,
+    description = "The status description text.",
+  )
+  @get:JsonProperty("status", required = true)
+  val status: String,
+
+  @Schema(
+    example = "The person has completed the programme. The referral will be closed.",
+    required = true,
+    description = "The description text for this particular status transition",
+  )
+  @get:JsonProperty("transitionDescription", required = true)
+  val transitionDescription: String,
+
+  @Schema(
+    example = "false",
+    required = true,
+    description = "Whether this status represents a closed status for the referral.",
+  )
+  @get:JsonProperty("isClosed", required = true)
+  val isClosed: Boolean,
+
+  @Schema(
+    example = "orange",
+    required = false,
+    description = "The color to be used for displaying this status label.",
+  )
+  @get:JsonProperty("labelColour", required = false)
+  val labelColour: String?,
+)
+
+fun ReferralStatusDescriptionEntity.toApi(transitionDescription: String) = ReferralStatus(
+  id = id,
+  status = description,
+  isClosed = isClosed,
+  labelColour = labelColour,
+  transitionDescription = transitionDescription,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusTransitionRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusTransitionEntity
 import java.util.UUID
 
-interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTransitionEntity, UUID>
+interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTransitionEntity, UUID> {
+  fun findByFromStatusId(fromStatusId: UUID): List<ReferralStatusTransitionEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toApi
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
+import java.util.UUID
+
+@Service
+@Transactional
+class ReferralStatusService(
+  private val referralStatusTransitionRepository: ReferralStatusTransitionRepository,
+) {
+
+  fun getReferralStatusTransitionsForReferralStatusDescriptionId(fromStatusId: UUID): List<ReferralStatus> = referralStatusTransitionRepository.findByFromStatusId(fromStatusId)
+    .map { it.toStatus.toApi(it.description!!) }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralStatusControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralStatusControllerIntegrationTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.TestDataCleaner
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
+import java.util.UUID
+
+class ReferralStatusControllerIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var testDataCleaner: TestDataCleaner
+
+  @Autowired
+  private lateinit var referralStatusDescriptionRepository: ReferralStatusDescriptionRepository
+
+  @BeforeEach
+  fun setup() {
+    testDataCleaner.cleanAllTables()
+    stubAuthTokenEndpoint()
+  }
+
+  @Nested
+  @DisplayName("Get possible transitions endpoint")
+  inner class GetPossibleTransitions {
+    @Test
+    fun `should return list of possible referral status transitions for a given status id`() {
+      // Given
+      val allStatuses = referralStatusDescriptionRepository.findAll()
+      assertThat(allStatuses).isNotEmpty()
+      val suitableButNotReadyStatus = allStatuses.first { it.description == "Suitable but not ready" }
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-status/${suitableButNotReadyStatus.id}/transitions",
+        returnType = object : ParameterizedTypeReference<List<ReferralStatus>>() {},
+      )
+
+      // Then
+      assertThat(response).hasSize(4)
+      assertThat(response.map { it.status }).containsExactlyInAnyOrder("Awaiting assessment", "Deprioritised", "Recall", "Return to court")
+      assertThat(response.map { it.transitionDescription }).containsExactlyInAnyOrder(
+        "The person’s suitability or readiness has changed. The programme team will reassess them.",
+        "The person is suitable but does not meet the prioritisation criteria. The referral will be paused in case they are reprioritised.",
+        "The person has been recalled. Depending on the recall type, the referral may be withdrawn or returned to awaiting assessment.",
+        "The person is not suitable for the programme or cannot continue with it. The referral will be returned to court.",
+      )
+    }
+
+    @Test
+    fun `should return empty list when referral status description does not exist`() {
+      // Given
+      val nonExistentId = UUID.randomUUID()
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-status/$nonExistentId/transitions",
+        returnType = object : ParameterizedTypeReference<List<ReferralStatus>>() {},
+      )
+
+      // Then
+      assertThat(response).isEmpty()
+    }
+  }
+}


### PR DESCRIPTION
* Implemented `ReferralStatus` model and mapping from entity to API representation.
* Added `ReferralStatusController` with GET endpoint for possible status transitions.
* Introduced `ReferralStatusService` to handle business logic for status transitions.
* Updated `ReferralStatusTransitionRepository` with query for transitions by status ID.
* Created integration tests for new endpoint to validate functionality.