### PR TITLE
chore(ReferralStatusDescriptionRepository): Add utility methods (and tests)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
@@ -9,6 +9,39 @@ interface ReferralStatusDescriptionRepository : JpaRepository<ReferralStatusDesc
   @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Awaiting assessment'")
   fun getAwaitingAssessmentStatusDescription(): ReferralStatusDescriptionEntity
 
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Awaiting allocation'")
+  fun getAwaitingAllocationStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Suitable but not ready'")
+  fun getSuitableButNotReadyStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Deprioritised'")
+  fun getDeprioritisedStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Recall'")
+  fun getRecallStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Return to court'")
+  fun getReturnToCourtStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Scheduled'")
+  fun getScheduledStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'On programme'")
+  fun getOnProgrammeStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Programme complete'")
+  fun getProgrammeCompleteStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Breach (non-attendance)'")
+  fun getBreachNonAttendanceStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Deferred'")
+  fun getDeferredStatusDescription(): ReferralStatusDescriptionEntity
+
+  @Query("SELECT rs FROM ReferralStatusDescriptionEntity rs WHERE rs.description = 'Withdrawn'")
+  fun getWithdrawnStatusDescription(): ReferralStatusDescriptionEntity
+
   /**
    * Right now, all ReferralStatusDescriptions are Reference data which should be created or modified only
    * by developers / system maintainers via SQL migration scripts.  Attempting to use this method (even in tests)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepositoryIntegrationTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import jakarta.transaction.Transactional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+
+class ReferralStatusDescriptionRepositoryIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var repository: ReferralStatusDescriptionRepository
+
+  @BeforeEach
+  override fun beforeEach() {
+    testDataCleaner.cleanAllTables()
+  }
+
+  @Test
+  @Transactional
+  fun `getAwaitingAssessmentStatusDescription returns a Referral Status Description`() {
+    val result = repository.getAwaitingAssessmentStatusDescription()
+    assertThat(result.description).isEqualTo("Awaiting assessment")
+  }
+
+  @Test
+  @Transactional
+  fun `getAwaitingAllocationStatusDescription returns a Referral Status Description`() {
+    val result = repository.getAwaitingAllocationStatusDescription()
+    assertThat(result.description).isEqualTo("Awaiting allocation")
+  }
+
+  @Test
+  @Transactional
+  fun `getSuitableButNotReadyStatusDescription returns a Referral Status Description`() {
+    val result = repository.getSuitableButNotReadyStatusDescription()
+    assertThat(result.description).isEqualTo("Suitable but not ready")
+  }
+
+  @Test
+  @Transactional
+  fun `getDeprioritisedStatusDescription returns a Referral Status Description`() {
+    val result = repository.getDeprioritisedStatusDescription()
+    assertThat(result.description).isEqualTo("Deprioritised")
+  }
+
+  @Test
+  @Transactional
+  fun `getRecallStatusDescription returns a Referral Status Description`() {
+    val result = repository.getRecallStatusDescription()
+    assertThat(result.description).isEqualTo("Recall")
+  }
+
+  @Test
+  @Transactional
+  fun `getReturnToCourtStatusDescription returns a Referral Status Description`() {
+    val result = repository.getReturnToCourtStatusDescription()
+    assertThat(result.description).isEqualTo("Return to court")
+  }
+
+  @Test
+  @Transactional
+  fun `getScheduledStatusDescription returns a Referral Status Description`() {
+    val result = repository.getScheduledStatusDescription()
+    assertThat(result.description).isEqualTo("Scheduled")
+  }
+
+  @Test
+  @Transactional
+  fun `getOnProgrammeStatusDescription returns a Referral Status Description`() {
+    val result = repository.getOnProgrammeStatusDescription()
+    assertThat(result.description).isEqualTo("On programme")
+  }
+
+  @Test
+  @Transactional
+  fun `getProgrammeCompleteStatusDescription returns a Referral Status Description`() {
+    val result = repository.getProgrammeCompleteStatusDescription()
+    assertThat(result.description).isEqualTo("Programme complete")
+  }
+
+  @Test
+  @Transactional
+  fun `getBreachNonAttendanceStatusDescription returns a Referral Status Description`() {
+    val result = repository.getBreachNonAttendanceStatusDescription()
+    assertThat(result.description).isEqualTo("Breach (non-attendance)")
+  }
+
+  @Test
+  @Transactional
+  fun `getDeferredStatusDescription returns a Referral Status Description`() {
+    val result = repository.getDeferredStatusDescription()
+    assertThat(result.description).isEqualTo("Deferred")
+  }
+
+  @Test
+  @Transactional
+  fun `getWithdrawnStatusDescription returns a Referral Status Description`() {
+    val result = repository.getWithdrawnStatusDescription()
+    assertThat(result.description).isEqualTo("Withdrawn")
+  }
+}


### PR DESCRIPTION
**WHAT**

This PR introduces a handful of utility methods to the ReferralStatusDescriptionRepository that gets the known Referral Status Descriptions (as described in the migration files) 

It also includes tests for each of them to make sure they work as expected
