### PR TITLE
APG-1314: Add fields to the ReferralStatusHistory get and create endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.toApi
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.create.CreateReferralStatusHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.update.UpdateCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.DeliveryLocationPreferencesService
@@ -358,7 +357,7 @@ class ReferralController(
   ): ResponseEntity<List<ReferralStatusHistory>> {
     val result = referralService.getStatusHistory(id)
 
-    return ResponseEntity.ok(result.map { it.toApi() })
+    return ResponseEntity.ok(result)
   }
 
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusFormData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusFormData.kt
@@ -42,7 +42,7 @@ data class CurrentStatus(
   val createdAt: LocalDate,
 )
 
-fun ReferralStatusHistoryEntity.toApi() = CurrentStatus(
+fun ReferralStatusHistoryEntity.toCurrentStatus() = CurrentStatus(
   statusDescriptionId = referralStatusDescription.id,
   title = referralStatusDescription.description,
   tagColour = referralStatusDescription.labelColour,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusHistory.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import java.time.LocalDateTime
 import java.util.UUID
 
 data class ReferralStatusHistory(
@@ -28,4 +30,42 @@ data class ReferralStatusHistory(
   )
   @get:JsonProperty("referralStatusDescriptionName", required = true)
   val referralStatusDescriptionName: String,
+
+  @Schema(
+    example = "I have met with xxx, and the assessment has been completed",
+    required = true,
+    description = "Notes from the user, or possibly the system, to explain the change in status",
+  )
+  @get:JsonProperty("additionalDetails", required = false)
+  val additionalDetails: String?,
+
+  @Schema(
+    example = "John Doe",
+    required = true,
+    description = "The name of the User who updated the status.  SYSTEM and UNKNOWN_USER are known non-human values.",
+  )
+  @get:JsonProperty("updatedBy", required = false)
+  val updatedBy: String,
+
+  @Schema(
+    example = "2025-09-25T06:50:20.149Z",
+    required = true,
+    description = "The time when the Status was changed",
+  )
+  @get:JsonProperty("updatedAt", required = false)
+  val updatedAt: LocalDateTime,
+
+  @field:Schema(description = "The display colour of the status tag")
+  @get:JsonProperty("tagColour", required = true)
+  val tagColour: String,
+)
+
+fun ReferralStatusHistoryEntity.toApi(): ReferralStatusHistory = ReferralStatusHistory(
+  id = id!!,
+  referralStatusDescriptionId = referralStatusDescription.id,
+  referralStatusDescriptionName = referralStatusDescription.description,
+  additionalDetails = additionalDetails,
+  updatedBy = createdBy,
+  updatedAt = createdAt,
+  tagColour = referralStatusDescription.labelColour,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralStatusHistoryEntity.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusHistory
 import java.time.LocalDateTime
 import java.util.*
 
@@ -43,10 +42,4 @@ class ReferralStatusHistoryEntity(
 
   @Column(name = "start_date")
   var startDate: LocalDateTime? = null,
-)
-
-fun ReferralStatusHistoryEntity.toApi(): ReferralStatusHistory = ReferralStatusHistory(
-  id = id!!,
-  referralStatusDescriptionId = referralStatusDescription.id,
-  referralStatusDescriptionName = referralStatusDescription.description,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -254,12 +254,8 @@ class ReferralService(
       ),
     )
 
-    return ReferralStatusHistory(
-      id = historyEntry.id!!,
-      referralStatusDescriptionId = referralStatusDescription.id,
-      referralStatusDescriptionName = referralStatusDescription.description,
-    )
+    return historyEntry.toApi()
   }
 
-  fun getStatusHistory(referralId: UUID): List<ReferralStatusHistoryEntity> = referralStatusHistoryRepository.findAllByReferralId(referralId).sortedBy { it.createdAt }
+  fun getStatusHistory(referralId: UUID): List<ReferralStatusHistory> = referralStatusHistoryRepository.findAllByReferralId(referralId).sortedBy { it.createdAt }.map { it.toApi() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusFormData
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toApi
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toCurrentStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
 import java.util.UUID
@@ -23,6 +24,6 @@ class ReferralStatusService(
     val currentStatus = referralStatusHistoryRepository.findFirstByReferralIdOrderByCreatedAtDesc(referralId) ?: return null
     val availableStatuses = referralStatusTransitionRepository.findByFromStatusId(currentStatus.referralStatusDescription.id).map { it.toStatus.toApi(it.description) }
 
-    return ReferralStatusFormData(currentStatus.toApi(), availableStatuses)
+    return ReferralStatusFormData(currentStatus.toCurrentStatus(), availableStatuses)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -249,17 +249,22 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
             FindAndReferReferralDetailsFactory().withPersonReference(theCrnNumber).produce(),
           )
 
-        referralService.updateStatus(referral, awaitingAllocation.id, "Additional Details", "USER_ID")
-
         // When
-        val result = referralService.getStatusHistory(referral.id!!)
+        referralService.updateStatus(referral, awaitingAllocation.id, "Additional Details", "The User's name")
+        val getResult = referralService.getStatusHistory(referral.id!!)
 
         // Then
-        assertThat(result).hasSize(2)
+        assertThat(getResult).hasSize(2)
 
-        assertThat(result[0].referralStatusDescription.description).isEqualTo("Awaiting assessment")
+        assertThat(getResult[0].referralStatusDescriptionName).isEqualTo("Awaiting assessment")
+        assertThat(getResult[0].updatedBy).isEqualTo("SYSTEM")
+        assertThat(getResult[0].additionalDetails).isEqualTo(null)
+        assertThat(getResult[0].tagColour).isEqualTo("purple")
 
-        assertThat(result[1].referralStatusDescription.description).isEqualTo("Awaiting allocation")
+        assertThat(getResult[1].referralStatusDescriptionName).isEqualTo("Awaiting allocation")
+        assertThat(getResult[1].updatedBy).isEqualTo("The User's name")
+        assertThat(getResult[1].additionalDetails).isEqualTo("Additional Details")
+        assertThat(getResult[1].tagColour).isEqualTo("light-blue")
       }
     }
 


### PR DESCRIPTION
**WHAT**

This commit adds several fields (tag colour, user name, additional
comments) to the API endpoints that create and retrieve a list of
Referral Status Histories

**WHY**

In order to build the timeline UI, we need additional information about
the changes, so that we can provide our users with more information
