### PR TITLE
APG-1378: Filter by open or closed cases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListController.kt
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.caseList.CaseListFilters
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.caseList.ReferralCaseListItem
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.caseList.StatusFilters
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralCaseListItemService
 import java.net.URLDecoder
 
@@ -77,7 +76,7 @@ class CaseListController(private val referralCaseListItemService: ReferralCaseLi
       ApiResponse(
         responseCode = "200",
         description = "The filter reference data to display in the UI",
-        content = [Content(schema = Schema(implementation = StatusFilters::class))],
+        content = [Content(schema = Schema(implementation = CaseListFilters::class))],
       ),
     ],
     security = [SecurityRequirement(name = "bearerAuth")],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralStatusDescriptionRepository.kt
@@ -51,4 +51,5 @@ interface ReferralStatusDescriptionRepository : JpaRepository<ReferralStatusDesc
    */
   @Override()
   fun save(entity: ReferralStatusDescriptionEntity): Unit = throw NotImplementedError("Not implemented yet")
+  fun findAllByIsClosed(isClosed: Boolean): MutableList<ReferralStatusDescriptionEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetReferralCaseListItemSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetReferralCaseListItemSpecification.kt
@@ -5,16 +5,21 @@ import jakarta.persistence.criteria.CriteriaQuery
 import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import org.springframework.data.jpa.domain.Specification
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller.OpenOrClosed
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralCaseListItemViewEntity
 
 fun getReferralCaseListItemSpecification(
-  openOrClosed: OpenOrClosed,
+  possibleStatuses: List<String>,
   crnOrPersonName: String? = null,
   cohort: String? = null,
   status: String? = null,
 ): Specification<ReferralCaseListItemViewEntity> = Specification<ReferralCaseListItemViewEntity> { root: Root<ReferralCaseListItemViewEntity?>, query: CriteriaQuery<*>?, criteriaBuilder: CriteriaBuilder ->
   val predicates: MutableList<Predicate> = mutableListOf()
+
+  possibleStatuses.let {
+    predicates.add(
+      root.get<String>("status").`in`(possibleStatuses),
+    )
+  }
 
   crnOrPersonName?.let {
     predicates.add(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -2,10 +2,13 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ser
 
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller.OpenOrClosed
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusFormData
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toApi
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toCurrentStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
 import java.util.UUID
@@ -15,6 +18,7 @@ import java.util.UUID
 class ReferralStatusService(
   private val referralStatusTransitionRepository: ReferralStatusTransitionRepository,
   private val referralStatusHistoryRepository: ReferralStatusHistoryRepository,
+  private val referralStatusDescriptionRepository: ReferralStatusDescriptionRepository,
 ) {
 
   fun getReferralStatusTransitionsForReferralStatusDescriptionId(fromStatusId: UUID): List<ReferralStatus> = referralStatusTransitionRepository.findByFromStatusId(fromStatusId)
@@ -29,4 +33,13 @@ class ReferralStatusService(
 
     return ReferralStatusFormData(currentStatus.toCurrentStatus(), availableStatuses)
   }
+
+  fun getAllStatuses(): List<ReferralStatusDescriptionEntity> = referralStatusDescriptionRepository.findAll().sortedBy { it.description }
+
+  fun getOpenOrClosedStatuses(openOrClosed: OpenOrClosed): List<ReferralStatusDescriptionEntity> {
+    val isClosed = openOrClosed === OpenOrClosed.CLOSED
+    return referralStatusDescriptionRepository.findAllByIsClosed(isClosed)
+  }
+
+  fun getOpenOrClosedStatusesDescriptions(openOrClosed: OpenOrClosed) = getOpenOrClosedStatuses(openOrClosed).map { it.description }
 }


### PR DESCRIPTION
## WHAT

On the UI we are able to select `Open` or `Closed` tabs. This PR adds the filtering for each of these tabs.

## HOW

Depending on whether `OPEN` or `CLOSED` is passed through the controller. We retrieve a group of statuses depending on if they are `is_closed` in the ReferralStatusDescription table