### PR TITLE
APG-1378: Adds the count of the opposite referrals tab to the bff filters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListController.kt
@@ -81,8 +81,13 @@ class CaseListController(private val referralCaseListItemService: ReferralCaseLi
     ],
     security = [SecurityRequirement(name = "bearerAuth")],
   )
-  @GetMapping("/bff/caselist/filters", produces = [MediaType.APPLICATION_JSON_VALUE])
-  fun getCaseListFilterData(): ResponseEntity<CaseListFilterValues> = ResponseEntity.ok().body(referralCaseListItemService.getCaseListFilterData())
+  @GetMapping("/bff/caselist/filters/{openOrClosed}", produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun getCaseListFilterData(
+    @PathVariable(
+      name = "openOrClosed",
+      required = true,
+    ) openOrClosed: OpenOrClosed,
+  ): ResponseEntity<CaseListFilterValues> = ResponseEntity.ok().body(referralCaseListItemService.getCaseListFilterData(openOrClosed))
 }
 
 enum class OpenOrClosed {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/caseList/CaseListFilterValues.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/caseList/CaseListFilterValues.kt
@@ -10,6 +10,13 @@ data class CaseListFilterValues(
   )
   @get:JsonProperty("statusFilters", required = true)
   val statusFilterValues: StatusFilterValues,
+
+  @Schema(
+    required = true,
+    description = "A count of the referrals for the opposite caselist tab you are in",
+  )
+  @get:JsonProperty("otherReferralsCount", required = true)
+  val otherReferralsCount: Int,
 )
 
 data class StatusFilterValues(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepository.kt
@@ -10,4 +10,6 @@ import java.util.UUID
 interface ReferralCaseListItemRepository :
   JpaRepository<ReferralCaseListItemViewEntity, UUID>,
   JpaSpecificationExecutor<ReferralCaseListItemViewEntity>,
-  ReferralCaseListItemRepositoryCustom
+  ReferralCaseListItemRepositoryCustom {
+  fun countAllByStatusIn(statuses: List<String>): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
@@ -53,10 +53,13 @@ class ReferralCaseListItemService(
     return pagedEntities.map { it.toApi() }
   }
 
-  fun getCaseListFilterData(): CaseListFilterValues {
+  fun getCaseListFilterData(openOrClosed: OpenOrClosed): CaseListFilterValues {
     val allStatuses = referralStatusService.getAllStatuses()
 
     val (closed, open) = allStatuses.partition { it.isClosed }
+
+    val statusesToCount = if (openOrClosed == OpenOrClosed.OPEN) closed else open
+    val otherReferralsCount = referralCaseListItemRepository.countAllByStatusIn(statusesToCount.map { it.description })
 
     val statusFilterValues = StatusFilterValues(
       open = open.map { it.description },
@@ -65,6 +68,7 @@ class ReferralCaseListItemService(
 
     return CaseListFilterValues(
       statusFilterValues = statusFilterValues,
+      otherReferralsCount = otherReferralsCount,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
@@ -357,27 +357,49 @@ class CaseListControllerIntegrationTest : IntegrationTestBase() {
           assertThat(item.referralStatus).isEqualTo("Awaiting assessment")
         }
     }
-  }
 
-  @Nested
-  @DisplayName("Get Case List Filter Data")
-  inner class GetCaseListFilterData {
-    @Test
-    fun `getCaseListFilterData should return status filters`() {
-      // When
-      val response = performRequestAndExpectOk(
-        HttpMethod.GET,
-        "/bff/caselist/filters",
-        object : ParameterizedTypeReference<CaseListFilterValues>() {},
-      )
+    @Nested
+    @DisplayName("Get Case List Filter Data")
+    inner class GetCaseListFilterData {
+      @Test
+      fun `getCaseListFilterData should return status filters for OPEN cases`() {
+        // When
+        val response = performRequestAndExpectOk(
+          HttpMethod.GET,
+          "/bff/caselist/filters/OPEN",
+          object : ParameterizedTypeReference<CaseListFilterValues>() {},
+        )
 
-      // Then
-      assertThat(response).isNotNull
-      assertThat(response).hasFieldOrProperty("statusFilterValues")
-      val (statusFilters) = response
+        // Then
+        assertThat(response).isNotNull
+        assertThat(response).hasFieldOrProperty("statusFilterValues")
+        assertThat(response).hasFieldOrProperty("otherReferralsCount")
+        assertThat(response.otherReferralsCount).isEqualTo(1)
+        val (statusFilters) = response
 
-      assertThat(statusFilters.open).hasSize(10)
-      assertThat(statusFilters.closed).hasSize(2)
+        assertThat(statusFilters.open).hasSize(10)
+        assertThat(statusFilters.closed).hasSize(2)
+      }
+
+      @Test
+      fun `getCaseListFilterData should return status filters for CLOSED cases`() {
+        // When
+        val response = performRequestAndExpectOk(
+          HttpMethod.GET,
+          "/bff/caselist/filters/CLOSED",
+          object : ParameterizedTypeReference<CaseListFilterValues>() {},
+        )
+
+        // Then
+        assertThat(response).isNotNull
+        assertThat(response).hasFieldOrProperty("statusFilterValues")
+        assertThat(response).hasFieldOrProperty("otherReferralsCount")
+        assertThat(response.otherReferralsCount).isEqualTo(6)
+        val (statusFilters) = response
+
+        assertThat(statusFilters.open).hasSize(10)
+        assertThat(statusFilters.closed).hasSize(2)
+      }
     }
   }
 }


### PR DESCRIPTION
In order for the ui to display the number of referrals in the other tab than it is currently in we need to provide a count for the `otherReferrals`. This means if the UI sends a request where it is in the `Open` tab we should count the `Closed` referrals and send this number back.

```json
{
    "statusFilters": {
        "open": [
            "Awaiting allocation",
            "Awaiting assessment",
            "Breach (non-attendance)",
            "Deferred",
            "Deprioritised",
            "On programme",
            "Recall",
            "Return to court",
            "Scheduled",
            "Suitable but not ready"
        ],
        "closed": [
            "Programme complete",
            "Withdrawn"
        ]
    },
    "otherReferralsCount": 6
}
```