### PR TITLE
APG-1381: Add referral_reporting_location table and entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/caseList/ReferralCaseListItem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/caseList/ReferralCaseListItem.kt
@@ -11,6 +11,8 @@ data class ReferralCaseListItem(
   val referralStatus: String,
   val cohort: OffenceCohort,
   val hasLdc: Boolean,
+  val pdu: String,
+  val reportingTeam: String,
 )
 
 fun ReferralCaseListItemViewEntity.toApi() = ReferralCaseListItem(
@@ -20,4 +22,6 @@ fun ReferralCaseListItemViewEntity.toApi() = ReferralCaseListItem(
   referralStatus = status,
   cohort = OffenceCohort.valueOf(cohort),
   hasLdc = hasLdc,
+  pdu = pduName,
+  reportingTeam = reportingTeam,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralCaseListItemViewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralCaseListItemViewEntity.kt
@@ -36,4 +36,12 @@ class ReferralCaseListItemViewEntity(
   @NotNull
   @Column(name = "has_ldc")
   var hasLdc: Boolean,
+
+  @NotNull
+  @Column(name = "pdu_name")
+  var pduName: String,
+
+  @NotNull
+  @Column(name = "reporting_team")
+  var reportingTeam: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -102,8 +102,8 @@ class ReferralEntity(
     mappedBy = "referral",
   )
   val referralReportingLocationEntity: ReferralReportingLocationEntity? = null,
-)
 
+)
 fun ReferralEntity.mostRecentStatus(): ReferralStatusDescriptionEntity {
   val mostRecentStatus = this.statusHistories.maxBy { it.createdAt }.referralStatusDescription
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
@@ -358,6 +358,27 @@ class CaseListControllerIntegrationTest : IntegrationTestBase() {
         }
     }
 
+    @Test
+    fun `getCaseListItems for OPEN referrals with reporting location should default to 'UNKNOWN' values and return 200 and paged list of referral case list items`() {
+      val response = performRequestAndExpectOk(
+        HttpMethod.GET,
+        "/pages/caselist/open",
+        object : ParameterizedTypeReference<RestResponsePage<ReferralCaseListItem>>() {},
+      )
+      val referralCaseListItems = response.content
+
+      assertThat(response).isNotNull
+      assertThat(response.totalElements).isEqualTo(6)
+      assertThat(referralCaseListItems.map { it.crn })
+        .containsExactlyInAnyOrder("X7182552", "CRN-999999", "CRN-888888", "CRN-777777", "CRN-66666", "CRN-555555")
+
+      assertThat(referralCaseListItems)
+        .allSatisfy { item ->
+          assertThat(item.reportingTeam).isEqualTo("UNKNOWN_REPORTING_TEAM")
+          assertThat(item.pdu).isEqualTo("UNKNOWN_PDU_NAME")
+        }
+    }
+
     @Nested
     @DisplayName("Get Case List Filter Data")
     inner class GetCaseListFilterData {


### PR DESCRIPTION
## WHAT

Adds the `reporting_team` and `pdu` to the response from the endpoint `/pdu/{openOrClosed}/-referrals`

An example of the JSON response is added below with the default example containing NULL values and the other value where there is a row present in the `referral_reporting_location` table.

```json
{
    "content": [
        {
            "referralId": "39fde7e8-d2e3-472b-8364-5848bf673aa6",
            "crn": "X718250",
            "personName": "Edgar Schiller",
            "referralStatus": "Awaiting assessment",
            "cohort": "SEXUAL_OFFENCE",
            "hasLdc": false,
            "pdu": "PDU_1",
            "reportingTeam": "TEAM_1"
        },
        {
            "referralId": "6885d1f6-5958-40e0-9448-1ff8cc37e643",
            "crn": "D002399",
            "personName": "Karen Puckett",
            "referralStatus": "Awaiting assessment",
            "cohort": "GENERAL_OFFENCE",
            "hasLdc": false,
            "pdu": "UNKNOWN_PDU_NAME",
            "reportingTeam": "UNKNOWN_REPORTING_TEAM"
        },
    ],
    "pageable": {
        "pageNumber": 0,
        "pageSize": 10,
        "sort": {
            "empty": false,
            "sorted": true,
            "unsorted": false
        },
        "offset": 0,
        "paged": true,
        "unpaged": false
    },
    "last": true,
    "totalElements": 6,
    "totalPages": 1,
    "first": true,
    "size": 10,
    "number": 0,
    "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
    },
    "numberOfElements": 6,
    "empty": false
}
```