### PR TITLE
Update edit group endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -258,14 +258,21 @@ class ProgrammeGroupService(
       scheduleService.rescheduleSessionsForGroup(savedGroup.id!!)
     }
 
-    val successMessage = getUpdateSuccessMessage(updatedField)
+    val successMessage = getUpdateSuccessMessage(updatedField, updateGroupRequest.automaticallyRescheduleOtherSessions ?: false)
     return UpdateGroupResponse(successMessage = successMessage)
   }
-
-  private fun getUpdateSuccessMessage(updatedField: String?): String = when (updatedField) {
+  private fun getUpdateSuccessMessage(updatedField: String?, isScheduleUpdated: Boolean = false): String = when (updatedField) {
     "groupCode" -> "The group code has been updated."
-    "earliestStartDate" -> "The start date has been updated."
-    "daysAndTimes" -> "The days and times have been updated."
+    "earliestStartDate" -> if (isScheduleUpdated) {
+      "The start date and schedule have been updated."
+    } else {
+      "The start date has been updated."
+    }
+    "daysAndTimes" -> if (isScheduleUpdated) {
+      "The days and times and schedule have been updated."
+    } else {
+      "The days and times have been updated."
+    }
     "cohort" -> "The cohort has been updated."
     "sex" -> "The gender has been updated."
     "deliveryLocation" -> "The delivery location has been updated."

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -22,16 +22,17 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.GroupsByRegion
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupAllocations
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupCohort
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupCohort.Companion.toRadioOptions
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupModuleSessionsResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupModuleSessionsResponseGroup
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupModuleSessionsResponseGroupModule
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupModuleSessionsResponseGroupSession
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RescheduleSessionRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.StartDateText
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.UpdateGroupRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.UpdateGroupResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.editGroup.EditGroupCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.editGroup.EditGroupDaysAndTimes
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.fromDateTime
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.toApi
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.toEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.CreateGroupTeamMemberType
@@ -39,6 +40,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.GroupPageTab
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.ConflictException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ModuleRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupFacilitatorEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
@@ -55,6 +57,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.toFacilitatorType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.AccreditedProgrammeTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.GroupWaitlistItemViewRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralReportingLocationRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
@@ -81,8 +84,11 @@ class ProgrammeGroupService(
   private val sessionRepository: SessionRepository,
   private val facilitatorService: FacilitatorService,
   private val sessionNameFormatter: SessionNameFormatter,
+  private val sessionService: SessionService,
+  private val moduleRepository: ModuleRepository,
+  private val moduleSessionTemplateRepository: ModuleSessionTemplateRepository,
 ) {
-  private val log = LoggerFactory.getLogger(this::class.java)
+  val log = LoggerFactory.getLogger(this::class.java)
 
   fun createGroup(createGroupRequest: CreateGroupRequest, username: String): ProgrammeGroupEntity {
     val (userRegion) = userService.getUserRegions(username)
@@ -150,6 +156,32 @@ class ProgrammeGroupService(
     updateGroupRequest.earliestStartDate?.let {
       programmeGroup.earliestPossibleStartDate = it
       updatedField = "earliestStartDate"
+
+      // Always reschedule the date of the pre group one to one placeholder session if the date has changed.
+      val preGroupOneToOneModule = moduleSessionTemplateRepository.findByName("Pre-group one-to-one")
+      val preGroupOneToOnePlaceholderSession = preGroupOneToOneModule?.id?.let { moduleId ->
+        sessionRepository.findByModuleSessionTemplateIdAndProgrammeGroupId(
+          moduleId,
+          groupId,
+        ).firstOrNull { session -> session.isPlaceholder }
+      }
+      // Calculate the new pre group one to one placeholder date from the new earliest possible start date.
+      val dateForPreGroupSession = scheduleService.getNextSessionDateFromSuppliedDate(programmeGroup, programmeGroup.earliestPossibleStartDate)
+
+      // Only reschedule if we have both the session
+      if (preGroupOneToOnePlaceholderSession != null) {
+        val rescheduleRequest = RescheduleSessionRequest(
+          sessionStartDate = dateForPreGroupSession,
+          sessionStartTime = fromDateTime(preGroupOneToOnePlaceholderSession.startsAt),
+          sessionEndTime = null,
+          rescheduleOtherSessions = false,
+        )
+
+        sessionService.rescheduleSessions(
+          preGroupOneToOnePlaceholderSession.id!!,
+          rescheduleRequest,
+        )
+      }
     }
     updateGroupRequest.pduName?.let {
       programmeGroup.probationDeliveryUnitName = it

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -159,28 +159,37 @@ class ProgrammeGroupService(
 
       // Always reschedule the date of the pre group one to one placeholder session if the date has changed.
       val preGroupOneToOneModule = moduleSessionTemplateRepository.findByName("Pre-group one-to-one")
-      val preGroupOneToOnePlaceholderSession = preGroupOneToOneModule?.id?.let { moduleId ->
-        sessionRepository.findByModuleSessionTemplateIdAndProgrammeGroupId(
-          moduleId,
+
+      if (preGroupOneToOneModule == null) {
+        log.warn("Pre-group one-to-one module template not found when updating earliest start date for group $groupId. Cannot reschedule pre-group session.")
+      } else {
+        val preGroupOneToOnePlaceholderSession = sessionRepository.findByModuleSessionTemplateIdAndProgrammeGroupId(
+          preGroupOneToOneModule.id!!,
           groupId,
         ).firstOrNull { session -> session.isPlaceholder }
-      }
-      // Calculate the new pre group one to one placeholder date from the new earliest possible start date.
-      val dateForPreGroupSession = scheduleService.getNextSessionDateFromSuppliedDate(programmeGroup, programmeGroup.earliestPossibleStartDate)
 
-      // Only reschedule if we have both the session
-      if (preGroupOneToOnePlaceholderSession != null) {
-        val rescheduleRequest = RescheduleSessionRequest(
-          sessionStartDate = dateForPreGroupSession,
-          sessionStartTime = fromDateTime(preGroupOneToOnePlaceholderSession.startsAt),
-          sessionEndTime = null,
-          rescheduleOtherSessions = false,
-        )
+        if (preGroupOneToOnePlaceholderSession == null) {
+          log.warn("Pre-group one-to-one placeholder session not found for group $groupId when updating earliest start date. Cannot reschedule pre-group session.")
+        } else {
+          // Calculate the new pre group one to one placeholder date from the new earliest possible start date.
+          val dateForPreGroupSession = scheduleService.getNextSessionDateFromSuppliedDate(programmeGroup, programmeGroup.earliestPossibleStartDate)
 
-        sessionService.rescheduleSessions(
-          preGroupOneToOnePlaceholderSession.id!!,
-          rescheduleRequest,
-        )
+          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: $dateForPreGroupSession")
+
+          val rescheduleRequest = RescheduleSessionRequest(
+            sessionStartDate = dateForPreGroupSession,
+            sessionStartTime = fromDateTime(preGroupOneToOnePlaceholderSession.startsAt),
+            sessionEndTime = null,
+            rescheduleOtherSessions = false,
+          )
+
+          sessionService.rescheduleSessions(
+            preGroupOneToOnePlaceholderSession.id!!,
+            rescheduleRequest,
+          )
+
+          log.info("Successfully rescheduled pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId")
+        }
       }
     }
     updateGroupRequest.pduName?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -388,6 +388,22 @@ class ScheduleService(
     }
   }
 
+  fun getNextSessionDateFromSuppliedDate(group: ProgrammeGroupEntity, dateToScheduleFrom: LocalDate): LocalDate {
+    val groupSlots = group.programmeGroupSessionSlots
+    require(groupSlots.isNotEmpty()) { "Programme group slots must not be empty" }
+
+    val bankHolidays = englandAndWalesHolidayDates()
+
+    val slotQueue = buildSlotQueue(
+      bankHolidays = bankHolidays,
+      groupSlots = groupSlots,
+      startFrom = dateToScheduleFrom,
+    )
+
+    val nextSlot = slotQueue.poll()
+    return findNextValidDate(bankHolidays, dateToScheduleFrom, nextSlot.slot)
+  }
+
   /**
    * Finds the next valid date (not a bank holiday) starting from the given date,
    * on or after the slot's day of week.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -2974,6 +2974,65 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `should return 200 with alternative message when updating earliest start date with automaticallyRescheduleOtherSessions`() {
+      // Given
+      val group = testGroupHelper.createGroup()
+      val newStartDate = LocalDate.now().plusDays(10)
+      val updateRequest = UpdateGroupRequest(
+        earliestStartDate = newStartDate,
+        automaticallyRescheduleOtherSessions = true,
+      )
+
+      // When
+      val response = performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${group.id}",
+        body = updateRequest,
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then
+      assertThat(response.successMessage).isEqualTo("The start date and schedule have been updated.")
+      val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+      assertThat(updatedGroup.earliestPossibleStartDate).isEqualTo(newStartDate)
+    }
+
+    @Test
+    fun `should return 200 with alternative message when updating session slots with automaticallyRescheduleOtherSessions`() {
+      // Given
+      val group = testGroupHelper.createGroup()
+      val newSlots = setOf(
+        CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 30, AmOrPm.PM),
+        CreateGroupSessionSlot(DayOfWeek.FRIDAY, 10, 0, AmOrPm.AM),
+      )
+      val updateRequest = UpdateGroupRequest(
+        createGroupSessionSlot = newSlots,
+        automaticallyRescheduleOtherSessions = true,
+      )
+
+      // When
+      val response = performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${group.id}",
+        body = updateRequest,
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then
+      assertThat(response.successMessage).isEqualTo("The days and times and schedule have been updated.")
+      val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+      assertThat(updatedGroup.programmeGroupSessionSlots).hasSize(2)
+      assertThat(updatedGroup.programmeGroupSessionSlots).anyMatch {
+        it.dayOfWeek == DayOfWeek.WEDNESDAY && it.startTime == LocalTime.of(14, 30)
+      }
+      assertThat(updatedGroup.programmeGroupSessionSlots).anyMatch {
+        it.dayOfWeek == DayOfWeek.FRIDAY && it.startTime == LocalTime.of(10, 0)
+      }
+    }
+
+    @Test
     fun `should return 200 when updating team members`() {
       // Given
       val group = testGroupHelper.createGroup()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -2875,7 +2875,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       val group = testGroupHelper.createGroup()
       val newStartDate = LocalDate.now().plusDays(10)
-      val updateRequest = UpdateGroupRequest(earliestStartDate = newStartDate)
+      val updateRequest = UpdateGroupRequest(earliestStartDate = newStartDate, automaticallyRescheduleOtherSessions = false)
 
       // When
       val response = performRequestAndExpectStatusWithBody(
@@ -2950,7 +2950,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 30, AmOrPm.PM),
         CreateGroupSessionSlot(DayOfWeek.FRIDAY, 10, 0, AmOrPm.AM),
       )
-      val updateRequest = UpdateGroupRequest(createGroupSessionSlot = newSlots)
+      val updateRequest = UpdateGroupRequest(createGroupSessionSlot = newSlots, automaticallyRescheduleOtherSessions = false)
 
       // When
       val response = performRequestAndExpectStatusWithBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
@@ -447,4 +447,163 @@ class ScheduleServiceIntegrationTest : IntegrationTestBase() {
     // Should be the correct date
     assertThat(nextSlotDate).isEqualTo(LocalDate.of(2126, 7, 10))
   }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should return next available slot date when starting from a Monday`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+    val slot2 = CreateGroupSessionSlotFactory().produce(DayOfWeek.THURSDAY, 12, 0, AmOrPm.PM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1, slot2),
+    )
+
+    // Starting from Monday April 13, 2026
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 13)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should return the same Monday (next or same Monday)
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should skip bank holidays`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 3, 30),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Starting from Monday March 30, 2026 (not a bank holiday)
+    // Next Monday would be April 6, 2026 which IS a bank holiday (Easter Monday)
+    val dateToScheduleFrom = LocalDate.of(2026, 3, 30)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should return March 30 as it's a valid Monday, not a bank holiday
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 3, 30))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should skip to next week if current date slot is a bank holiday`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Starting from Easter Monday April 6, 2026 (bank holiday)
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 6)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should skip Easter Monday and return Monday April 13
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should handle multiple slots and return earliest available`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+    val slot2 = CreateGroupSessionSlotFactory().produce(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)
+    val slot3 = CreateGroupSessionSlotFactory().produce(DayOfWeek.FRIDAY, 10, 15, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1, slot2, slot3),
+    )
+
+    // Starting from Tuesday April 14, 2026
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 14)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Wednesday April 15 is the next available slot after Tuesday April 14
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 15))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should handle consecutive bank holidays`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Starting from April 6, 2026 (Easter Monday - bank holiday)
+    // The real bank holidays API will include this date
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 6)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should skip Easter Monday April 6 and return Monday April 13
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should work with single slot configuration`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.WEDNESDAY, 10, 0, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Starting from Monday April 13, 2026
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 13)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should return Wednesday April 15 (next Wednesday)
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 15))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+  }
+
+  @Test
+  fun `getNextSessionDateFromSuppliedDate should return same day if it matches a slot and is not a bank holiday`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.THURSDAY, 12, 0, AmOrPm.PM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.of(2026, 4, 1),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Starting from Thursday April 16, 2026 (not a bank holiday)
+    val dateToScheduleFrom = LocalDate.of(2026, 4, 16)
+
+    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
+      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
+      dateToScheduleFrom,
+    )
+
+    // Should return the same Thursday
+    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 16))
+    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+  }
 }


### PR DESCRIPTION
Update endpoint to reschedule the pre-group one to one placeholder start date even if reschedule flag is false when editing the start date.
Update the returned success message when the schedule has been updated