### PR TITLE
add popname and isCatchup to attendancehistory

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
@@ -48,6 +48,12 @@ data class AttendanceHistorySession(
   val groupCode: String,
 
   @Schema(
+    description = "The name of the person",
+    example = "Alex River",
+  )
+  val popName: String,
+
+  @Schema(
     description = "The group id for the session",
     example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   )
@@ -76,4 +82,10 @@ data class AttendanceHistorySession(
     example = "true",
   )
   val hasNotes: Boolean,
+
+  @Schema(
+    description = "Whether the session is a catch-up session",
+    example = "true",
+  )
+  val isCatchup: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -420,10 +420,12 @@ class ReferralService(
             sessionName = session.sessionName,
             groupId = membership.programmeGroup.id,
             groupCode = membership.programmeGroup.code,
+            popName = referral.personName,
             date = session.startsAt.format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
             time = "${formatTimeForUiDisplay(session.startsAt.toLocalTime())} to ${formatTimeForUiDisplay(session.endsAt.toLocalTime())}",
             attendanceStatus = programmeGroupService.getAttendanceTextFromOutcome(latestAttendance?.outcomeType),
             hasNotes = latestAttendance?.notesHistory?.isNotEmpty() == true,
+            isCatchup = session.isCatchup,
           )
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -1339,6 +1339,8 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.attendanceHistory).allMatch { it.attendanceStatus == "Attended - Complied" }
       assertThat(response.attendanceHistory).allMatch { it.hasNotes }
       assertThat(response.attendanceHistory).allMatch { it.groupId == group.id }
+      assertThat(response.attendanceHistory).allMatch { it.popName == "Alex River" }
+      assertThat(response.attendanceHistory).allMatch { it.isCatchup == false }
     }
 
     @Test


### PR DESCRIPTION
https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/referral/2052df49-855c-4b8c-981d-f01147895600/attendance-history

On this page, under the Attendance and Notes' column, the link should include the popName, groupCode and 'catch-up' at the end of the session name if it is a catch-up.

<img width="1432" height="975" alt="Screenshot 2026-04-14 at 14 21 58" src="https://github.com/user-attachments/assets/29f9c1da-67e0-44a2-b66d-f57ef8cf45fa" />


So the format should be the same as:

Salvatore Rohan (X984597): Getting started one-to-one catch-up

the same as the text on this page under 'Getting started' 

https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/group/466ba4c3-2dbd-4cac-bba1-63127af52a5c/sessions-and-attendance

<img width="1432" height="109" alt="Screenshot 2026-04-14 at 14 26 41" src="https://github.com/user-attachments/assets/34c1bb24-16d8-40c0-b5d1-37dd65fbe2b7" />




