### PR TITLE
APG-1968 Add `ldcScore` to LearningNeeds model and update related logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/risksAndNeeds/LearningNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/risksAndNeeds/LearningNeeds.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.PniAssessment
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysAccommodation
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysLearning
 import java.time.LocalDate
@@ -39,9 +40,17 @@ data class LearningNeeds(
 
   @Schema(example = "Ms Puckett spoke of wanting to secure suitable employment although she knows that she will first need to fully address her drug issues.")
   @get:JsonProperty("basicSkillsScoreDescription") val basicSkillsScoreDescription: String? = null,
+
+  @Schema(example = "2")
+  @get:JsonProperty("ldcScore") val ldcScore: Int? = null,
 )
 
-fun buildLearningNeeds(assessmentCompleted: LocalDate?, oasysLearning: OasysLearning?, oasysAccommodation: OasysAccommodation): LearningNeeds = LearningNeeds(
+fun buildLearningNeeds(
+  assessmentCompleted: LocalDate?,
+  oasysLearning: OasysLearning?,
+  oasysAccommodation: OasysAccommodation,
+  pniAssessment: PniAssessment?,
+): LearningNeeds = LearningNeeds(
   noFixedAbodeOrTransient = oasysAccommodation.noFixedAbodeOrTransient == "Yes",
   assessmentCompleted = assessmentCompleted,
   workRelatedSkills = oasysLearning?.workRelatedSkills,
@@ -51,4 +60,5 @@ fun buildLearningNeeds(assessmentCompleted: LocalDate?, oasysLearning: OasysLear
   qualifications = oasysLearning?.qualifications,
   basicSkillsScore = oasysLearning?.basicSkillsScore,
   basicSkillsScoreDescription = oasysLearning?.eTEIssuesDetails,
+  ldcScore = pniAssessment?.ldc?.score,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/RisksAndNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/RisksAndNeedsService.kt
@@ -37,6 +37,8 @@ class RisksAndNeedsService(
   private val oasysApiClient: OasysApiClient,
   private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
   private val assessRiskAndNeedsApiClient: AssessRiskAndNeedsApiClient,
+  private val pniService: PniService,
+
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -57,6 +59,7 @@ class RisksAndNeedsService(
       assessmentCompletedDate?.toLocalDate(),
       getDetails(assessmentId, oasysApiClient::getLearning, "LearningNeeds"),
       getDetails(assessmentId, oasysApiClient::getAccommodation, "OasysAccommodation"),
+      pniService.getPniCalculation(crn).assessment,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/RisksAndNeedsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/RisksAndNeedsControllerIntegrationTest.kt
@@ -22,11 +22,14 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.risksAndNeeds.RoshAnalysis
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.risksAndNeeds.ThinkingAndBehaviour
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.arnsApi.model.type.ScoreLevel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Ldc
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.OasysOffenceAnalysis.WhatOccurred
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.Timeline
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.risksAndNeeds.getLatestCompletedLayerThreeAssessment
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomAlphanumericString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomCrn
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.PniAssessmentFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.PniResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.arns.AllPredictorVersionedLegacyDtoFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.arns.RiskScoresDtoFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.oasys.OasysAlcoholMisuseDetailsFactory
@@ -347,6 +350,12 @@ class RisksAndNeedsControllerIntegrationTest : IntegrationTestBase() {
       val oasysLearning = OasysLearningFactory().withCrn(crn).produce()
       oasysApiStubs.stubSuccessfulOasysLearningResponse(assessmentId, oasysLearning)
       oasysApiStubs.stubSuccessfulOasysAccommodationResponse(assessmentId)
+      oasysApiStubs.stubSuccessfulPniResponse(
+        crn,
+        PniResponseFactory().withAssessment(
+          PniAssessmentFactory().withLdc(Ldc(4, 4)).produce(),
+        ).produce(),
+      )
 
       // When
       val response = performRequestAndExpectOk(
@@ -366,6 +375,7 @@ class RisksAndNeedsControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response).hasFieldOrProperty("qualifications")
       assertThat(response).hasFieldOrProperty("basicSkillsScore")
       assertThat(response).hasFieldOrProperty("basicSkillsScoreDescription")
+      assertThat(response).hasFieldOrProperty("ldcScore")
 
       assertThat(response.assessmentCompleted).isEqualTo(assessment.getLatestCompletedLayerThreeAssessment()?.completedAt?.toLocalDate())
       assertThat(response.noFixedAbodeOrTransient).isTrue
@@ -376,6 +386,7 @@ class RisksAndNeedsControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response.qualifications).isEqualTo("NVQ Level 2")
       assertThat(response.basicSkillsScore).isEqualTo("3")
       assertThat(response.basicSkillsScoreDescription).isEqualTo("ete issues")
+      assertThat(response.ldcScore).isEqualTo(4)
     }
 
     @Test


### PR DESCRIPTION

### Changes
- Added `ldcScore` field to the LearningNeeds model.
- Updated service logic to handle the new `ldcScore` attribute.
- Extended integration tests to include scenarios for `ldcScore`.

