### PR TITLE
Correct Session Names

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/TemplateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/TemplateService.kt
@@ -55,18 +55,30 @@ class TemplateService(
 
   private fun addCatchUpModuleSessions(entity: ModuleSessionTemplateEntity): List<ModuleSessionTemplate> {
     val sessionTemplate = entity.toApi()
+    val module = entity.module
     return if (entity.sessionType == SessionType.ONE_TO_ONE) {
+      // If it's a one-to-one catchup:
+      // If the module name is "Post-programme reviews" or "Pre-group one-to-ones", drop the s (e.g. "Pre-group one-to-ones" -> "Pre-group one-to-one")
+      // and append "catch-up" directly -> (e.g. "Pre-group one-to-one catch-up", "Post-programme review catch-up").
+      // Otherwise, just add "one-to-one catch-up"-> (e.g. "Getting started one-to-one catch-up").
+      // If it's not a one-to-one catchup:
+      // Return the module name and session number and append catch-up -> (e.g. "Getting started 1 catch-up")
+      val catchUpName = if (module.name in listOf("Post-programme reviews", "Pre-group one-to-ones")) {
+        "${module.name.dropLast(1)} catch-up"
+      } else {
+        "${module.name} one-to-one catch-up"
+      }
       listOf(
         sessionTemplate,
         sessionTemplate.copy(
-          name = "${sessionTemplate.name} catch-up",
+          name = catchUpName,
           sessionScheduleType = SessionScheduleType.CATCH_UP,
         ),
       )
     } else {
       listOf(
         sessionTemplate.apply {
-          name = "${sessionTemplate.name} catch-up"
+          name = "${module.name} ${sessionTemplate.number} catch-up"
           sessionScheduleType = SessionScheduleType.CATCH_UP
         },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -2101,8 +2101,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response.sessionTemplates).hasSize(4)
       assertThat(response.sessionTemplates.map { it.name })
         .containsExactly(
-          "Introduction to Building Choices catch-up",
-          "Understanding myself catch-up",
+          "Getting started 1 catch-up",
+          "Getting started 2 catch-up",
           "Getting started one-to-one",
           "Getting started one-to-one catch-up",
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/TemplateServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/TemplateServiceIntegrationTest.kt
@@ -106,14 +106,32 @@ class TemplateServiceIntegrationTest : IntegrationTestBase() {
       assertThat(sessionTemplates).hasSize(8)
         .extracting("name", "number", "sessionScheduleType")
         .containsExactly(
-          tuple("Understanding my feelings catch-up", 1, SessionScheduleType.CATCH_UP),
-          tuple("Helpful and unhelpful feelings catch-up", 2, SessionScheduleType.CATCH_UP),
-          tuple("Managing my feelings, part 1 catch-up", 3, SessionScheduleType.CATCH_UP),
-          tuple("Managing my feelings, part 2 catch-up", 4, SessionScheduleType.CATCH_UP),
-          tuple("Understanding my thinking catch-up", 5, SessionScheduleType.CATCH_UP),
-          tuple("Developing my flexible thinking catch-up", 6, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 1 catch-up", 1, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 2 catch-up", 2, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 3 catch-up", 3, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 4 catch-up", 4, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 5 catch-up", 5, SessionScheduleType.CATCH_UP),
+          tuple("Managing myself 6 catch-up", 6, SessionScheduleType.CATCH_UP),
           tuple("Managing myself one-to-one", 7, SessionScheduleType.SCHEDULED),
           tuple("Managing myself one-to-one catch-up", 7, SessionScheduleType.CATCH_UP),
+        )
+    }
+
+    @Test
+    fun `Successfully retrieves all session templates for Bringing it all together module`() {
+      // Given
+      val bringingItAllTogetherModule = modules.find { it.name == "Bringing it all together" }
+
+      // When
+      val sessionTemplates = service.getSessionTemplatesForGroupAndModule(groupId, bringingItAllTogetherModule?.id!!).second
+
+      // Then
+      assertThat(sessionTemplates).hasSize(3)
+        .extracting("name", "number", "sessionScheduleType")
+        .containsExactly(
+          tuple("Bringing it all together 1 catch-up", 1, SessionScheduleType.CATCH_UP),
+          tuple("Bringing it all together 2 catch-up", 2, SessionScheduleType.CATCH_UP),
+          tuple("Bringing it all together 3 catch-up", 3, SessionScheduleType.CATCH_UP),
         )
     }
 


### PR DESCRIPTION
Correct Session names that are returned for create a session, they should be as follows:

**Pre-group one-to-one**
Pre-group one-to-one
Pre-group one-to-one catch-up

**Getting started**
Getting started 1 catch-up
Getting started 2 catch-up
Getting started one-to-one
Getting started one-to-one catch-up

**Managing myself**
Managing myself 1 catch-up
Managing myself 2 catch-up
Managing myself 3 catch-up
Managing myself 4 catch-up
Managing myself 5 catch-up
Managing myself 6 catch-up
Managing myself one-to-one
Managing myself one-to-one catch-up

**Managing life’s problems**
Managing life’s problems 1 catch-up
Managing life’s problems 2 catch-up
Managing life’s problems 3 catch-up
Managing life’s problems 4 catch-up
Managing life’s problems one-to-one
Managing life’s problems one-to-one catch-up

**Managing people around me**
Managing people around me 1 catch-up
Managing people around me 2 catch-up
Managing people around me 3 catch-up
Managing people around me 4 catch-up
Managing people around me 5 catch-up
Managing people around me 6 catch-up
Managing people around me one-to-one
Managing people around me one-to-one catch-up

**Bringing it all together**
Bringing it all together 1 catch-up
Bringing it all together 2 catch-up
Bringing it all together 3 catch-up

**Post-programme review**
Post-programme review
Post-programme review catch-up

