### PR TITLE
Update Dockerfile with configurable build number and entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 FROM ${BASE_IMAGE}
 
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER=${BUILD_NUMBER:-1_0_0}
+
 WORKDIR /app
 COPY --chown=appuser:appgroup applicationinsights.json ./
 COPY --chown=appuser:appgroup applicationinsights.dev.json ./
@@ -19,4 +22,4 @@ COPY --from=builder --chown=appuser:appgroup /builder/extracted/spring-boot-load
 COPY --from=builder --chown=appuser:appgroup /builder/extracted/snapshot-dependencies/ ./
 COPY --from=builder --chown=appuser:appgroup /builder/extracted/application/ ./
 
-ENTRYPOINT ["java", "-XX:+ExitOnOutOfMemoryError", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:agent.jar", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:+AlwaysActAsServerClassMachine", "-javaagent:agent.jar", "-jar", "app.jar"]


### PR DESCRIPTION
```
### Changes
- Added a new `BUILD_NUMBER` argument in the Dockerfile to allow for configurable builds.
- Simplified the Java entry point command in the Dockerfile for easier runtime configuration.

### Notes
- This update does not introduce breaking changes.
- Ensure that the `BUILD_NUMBER` is passed during the build process, if required.

