### PR TITLE
Apg 1993/dont reschedule pre group one to one

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -175,10 +175,10 @@ class ProgrammeGroupService(
         if (preGroupOneToOnePlaceholderSession == null) {
           log.warn("Pre-group one-to-one placeholder session not found for group $groupId when updating earliest start date. Cannot reschedule pre-group session.")
         } else {
-          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: ${updateGroupRequest.earliestStartDate}")
+          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: ${it}")
 
           val rescheduleRequest = RescheduleSessionRequest(
-            sessionStartDate = updateGroupRequest.earliestStartDate!!,
+            sessionStartDate = it,
             sessionStartTime = fromDateTime(preGroupOneToOnePlaceholderSession.startsAt),
             sessionEndTime = null,
             rescheduleOtherSessions = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -175,7 +175,7 @@ class ProgrammeGroupService(
         if (preGroupOneToOnePlaceholderSession == null) {
           log.warn("Pre-group one-to-one placeholder session not found for group $groupId when updating earliest start date. Cannot reschedule pre-group session.")
         } else {
-          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: ${it}")
+          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: $it")
 
           val rescheduleRequest = RescheduleSessionRequest(
             sessionStartDate = it,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -158,8 +158,6 @@ class ProgrammeGroupService(
       updatedField = "sex"
     }
     updateGroupRequest.earliestStartDate?.let {
-      log.warn("PupdateGroupRequest $updateGroupRequest")
-
       programmeGroup.earliestPossibleStartDate = it
       updatedField = "earliestStartDate"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -158,6 +158,8 @@ class ProgrammeGroupService(
       updatedField = "sex"
     }
     updateGroupRequest.earliestStartDate?.let {
+      log.warn("PupdateGroupRequest $updateGroupRequest")
+
       programmeGroup.earliestPossibleStartDate = it
       updatedField = "earliestStartDate"
 
@@ -175,13 +177,11 @@ class ProgrammeGroupService(
         if (preGroupOneToOnePlaceholderSession == null) {
           log.warn("Pre-group one-to-one placeholder session not found for group $groupId when updating earliest start date. Cannot reschedule pre-group session.")
         } else {
-          // Calculate the new pre group one to one placeholder date from the new earliest possible start date.
-          val dateForPreGroupSession = scheduleService.getNextSessionDateFromSuppliedDate(programmeGroup, programmeGroup.earliestPossibleStartDate)
-
-          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: $dateForPreGroupSession")
+          
+          log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: ${updateGroupRequest.earliestStartDate}")
 
           val rescheduleRequest = RescheduleSessionRequest(
-            sessionStartDate = dateForPreGroupSession,
+            sessionStartDate = updateGroupRequest.earliestStartDate!!,
             sessionStartTime = fromDateTime(preGroupOneToOnePlaceholderSession.startsAt),
             sessionEndTime = null,
             rescheduleOtherSessions = false,
@@ -270,7 +270,7 @@ class ProgrammeGroupService(
 
     // Reschedule future sessions if requested
     if (updateGroupRequest.automaticallyRescheduleOtherSessions == true) {
-      scheduleService.rescheduleSessionsForGroup(savedGroup.id!!)
+      scheduleService.rescheduleSessionsForGroup(savedGroup.id!!, skipPreGroupOneToOnePlaceholder = true)
     }
 
     val successMessage = getUpdateSuccessMessage(updatedField, updateGroupRequest.automaticallyRescheduleOtherSessions ?: false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -177,7 +177,6 @@ class ProgrammeGroupService(
         if (preGroupOneToOnePlaceholderSession == null) {
           log.warn("Pre-group one-to-one placeholder session not found for group $groupId when updating earliest start date. Cannot reschedule pre-group session.")
         } else {
-          
           log.info("Rescheduling pre-group one-to-one placeholder session ${preGroupOneToOnePlaceholderSession.id} for group $groupId to new date: ${updateGroupRequest.earliestStartDate}")
 
           val rescheduleRequest = RescheduleSessionRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -206,7 +206,7 @@ class ScheduleService(
     // If skipping pre-group one-to-one placeholder, exclude that template
     if (skipPreGroupOneToOnePlaceholder) {
       allSessionTemplates = allSessionTemplates.filter { template ->
-        !(template.sessionType == ONE_TO_ONE && template.module.name.startsWith("Pre-group", ignoreCase = true))
+        !(template.sessionType == ONE_TO_ONE && template.module.name == "Pre-group one-to-ones")
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -174,6 +174,7 @@ class ScheduleService(
   fun scheduleSessionsForGroup(
     programmeGroupId: UUID,
     mostRecentSession: SessionEntity? = null,
+    skipPreGroupOneToOnePlaceholder: Boolean = false,
   ): MutableSet<SessionEntity> {
     val group = programmeGroupRepository.findByIdOrNull(programmeGroupId)
       ?: throw NotFoundException("Group with id: $programmeGroupId could not be found")
@@ -199,6 +200,13 @@ class ScheduleService(
             template.module.moduleNumber == mostRecentSession.moduleNumber &&
               template.sessionNumber > mostRecentSession.sessionNumber
             )
+      }
+    }
+
+    // If skipping pre-group one-to-one placeholder, exclude that template
+    if (skipPreGroupOneToOnePlaceholder) {
+      allSessionTemplates = allSessionTemplates.filter { template ->
+        !(template.sessionType == ONE_TO_ONE && template.module.name.startsWith("Pre-group", ignoreCase = true))
       }
     }
 
@@ -321,7 +329,7 @@ class ScheduleService(
     return slotQueue
   }
 
-  fun rescheduleSessionsForGroup(programmeGroupId: UUID): MutableSet<SessionEntity> {
+  fun rescheduleSessionsForGroup(programmeGroupId: UUID, skipPreGroupOneToOnePlaceholder: Boolean = false): MutableSet<SessionEntity> {
     val group = requireNotNull(programmeGroupRepository.findByIdOrNull(programmeGroupId)) {
       "Group must not be null"
     }
@@ -330,7 +338,10 @@ class ScheduleService(
     }
 
     val now = LocalDateTime.now(clock)
-    val futureSessions = group.sessions.filter { it.startsAt > now }.toSet()
+    var futureSessions = group.sessions.filter { it.startsAt > now }.toSet()
+    if (skipPreGroupOneToOnePlaceholder){
+      futureSessions = futureSessions.filterNot { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }.toSet()
+    }
     val futureNDeliusAppointmentsToRemove = futureSessions.flatMap { session -> session.ndeliusAppointments }
     val mostRecentSession = group.sessions.filter { it.startsAt <= now }.maxByOrNull { it.startsAt }
 
@@ -341,7 +352,7 @@ class ScheduleService(
     }
 
     // If there is no prior session, just schedule from start
-    return scheduleSessionsForGroup(programmeGroupId, mostRecentSession)
+    return scheduleSessionsForGroup(programmeGroupId, mostRecentSession, skipPreGroupOneToOnePlaceholder)
   }
 
   fun removeFutureSessionsForIndividual(group: ProgrammeGroupEntity, referralId: UUID) {
@@ -386,22 +397,6 @@ class ScheduleService(
         nDeliusAppointmentRepository.saveAll(nDeliusAppointmentEntities)
       }
     }
-  }
-
-  fun getNextSessionDateFromSuppliedDate(group: ProgrammeGroupEntity, dateToScheduleFrom: LocalDate): LocalDate {
-    val groupSlots = group.programmeGroupSessionSlots
-    require(groupSlots.isNotEmpty()) { "Programme group slots must not be empty" }
-
-    val bankHolidays = englandAndWalesHolidayDates()
-
-    val slotQueue = buildSlotQueue(
-      bankHolidays = bankHolidays,
-      groupSlots = groupSlots,
-      startFrom = dateToScheduleFrom,
-    )
-
-    val nextSlot = slotQueue.poll()
-    return findNextValidDate(bankHolidays, dateToScheduleFrom, nextSlot.slot)
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -339,7 +339,7 @@ class ScheduleService(
 
     val now = LocalDateTime.now(clock)
     var futureSessions = group.sessions.filter { it.startsAt > now }.toSet()
-    if (skipPreGroupOneToOnePlaceholder){
+    if (skipPreGroupOneToOnePlaceholder) {
       futureSessions = futureSessions.filterNot { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }.toSet()
     }
     val futureNDeliusAppointmentsToRemove = futureSessions.flatMap { session -> session.ndeliusAppointments }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -3267,6 +3267,79 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         HttpStatus.NOT_FOUND.value(),
       )
     }
+
+    @Test
+    fun `updating earliestStartDate updates the pre-group one-to-one placeholder date`() {
+      // Given
+      val slot = CreateGroupSessionSlotFactory().produce(DayOfWeek.WEDNESDAY, 10, 0, AmOrPm.AM)
+      val group = testGroupHelper.createGroup(
+        earliestStartDate = LocalDate.of(2027, 1, 4),
+        createGroupSessionSlots = setOf(slot),
+      )
+
+      val savedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+      val originalPlaceholder = savedGroup.sessions.first { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+
+      assertThat(originalPlaceholder.startsAt.toLocalDate()).isEqualTo(LocalDate.of(2027, 1, 6))
+
+      val newStartDate = LocalDate.of(2027, 6, 30) // A Tuesday
+      val updateRequest = UpdateGroupRequest(earliestStartDate = newStartDate, automaticallyRescheduleOtherSessions = false)
+
+      // When
+      val response = performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = updateRequest,
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then
+      assertThat(response.successMessage).isEqualTo("The start date has been updated.")
+      val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+      assertThat(updatedGroup.earliestPossibleStartDate).isEqualTo(newStartDate)
+
+      val updatedPlaceholder = updatedGroup.sessions.first { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+      assertThat(updatedPlaceholder.startsAt.toLocalDate()).isEqualTo(newStartDate)
+    }
+
+    @Test
+    fun `updating earliestStartDate with automaticallyRescheduleOtherSessions true reschedules other sessions but preserves placeholder date`() {
+      // Given — group starting in the future so all sessions are future sessions
+      val slot = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+      val group = testGroupHelper.createGroup(
+        earliestStartDate = LocalDate.of(2027, 1, 4),
+        createGroupSessionSlots = setOf(slot),
+      )
+
+      assertThat(programmeGroupRepository.findByIdOrNull(group.id!!)!!.sessions).hasSize(27)
+
+      val newStartDate = LocalDate.of(2028, 3, 6) // A Tuesday
+      val updateRequest = UpdateGroupRequest(earliestStartDate = newStartDate, automaticallyRescheduleOtherSessions = true)
+
+      // When
+      val response = performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = updateRequest,
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then
+      assertThat(response.successMessage).isEqualTo("The start date and schedule have been updated.")
+      val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+      assertThat(updatedGroup.sessions).hasSize(27)
+
+      // Placeholder should be set to the exact new start date (not recalculated to next Monday slot)
+      val placeholder = updatedGroup.sessions.first { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+      assertThat(placeholder.startsAt.toLocalDate()).isEqualTo(newStartDate)
+
+      // All non-placeholder sessions should be on or after the new start date and on Mondays
+      val nonPlaceholderSessions = updatedGroup.sessions.filter { !it.isPlaceholder }
+      assertThat(nonPlaceholderSessions).allMatch { it.startsAt.toLocalDate() >= newStartDate }
+      assertThat(nonPlaceholderSessions).allMatch { it.startsAt.dayOfWeek == DayOfWeek.MONDAY }
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fact
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupSessionSlotFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.TestReferralHelper
 import java.time.DayOfWeek
 import java.time.Instant
@@ -26,7 +27,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 
-class ScheduleServiceIntegrationTest : IntegrationTestBase() {
+class ScheduleServiceIntegrationTest(@Autowired private val sessionRepository: SessionRepository) : IntegrationTestBase() {
 
   @Autowired
   private lateinit var scheduleService: ScheduleService
@@ -62,6 +63,53 @@ class ScheduleServiceIntegrationTest : IntegrationTestBase() {
         ),
       ),
     )
+  }
+
+  @Test
+  fun `scheduleSessionsForGroup with skipPreGroupOneToOnePlaceholder true should not create a pre-group one-to-one placeholder`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.now(clock).plusDays(7),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Remove existing sessions to start fresh
+    val freshGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+    freshGroup.sessions.clear()
+    programmeGroupRepository.save(freshGroup)
+
+    scheduleService.scheduleSessionsForGroup(group.id!!, skipPreGroupOneToOnePlaceholder = true)
+
+    val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+
+    // Should have 26 sessions — no pre-group one-to-one placeholder
+    assertThat(updatedGroup.sessions).hasSize(26)
+    val preGroupPlaceholders = updatedGroup.sessions.filter { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+    assertThat(preGroupPlaceholders).isEmpty()
+  }
+
+  @Test
+  fun `scheduleSessionsForGroup with skipPreGroupOneToOnePlaceholder false should create a pre-group one-to-one placeholder`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.now(clock).plusDays(7),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    // Remove existing sessions to start fresh
+    val freshGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+    freshGroup.sessions.clear()
+    programmeGroupRepository.save(freshGroup)
+
+    scheduleService.scheduleSessionsForGroup(group.id!!, skipPreGroupOneToOnePlaceholder = false)
+
+    val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+
+    assertThat(updatedGroup.sessions).hasSize(27)
+    val preGroupPlaceholders = updatedGroup.sessions.filter { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+    assertThat(preGroupPlaceholders).hasSize(1)
   }
 
   @Test
@@ -111,6 +159,56 @@ class ScheduleServiceIntegrationTest : IntegrationTestBase() {
 
     assertThat(group.sessions).hasSize(27)
     assertThat(group.sessions.find { it.startsAt.toLocalDate() == LocalDate.of(2026, 3, 6) }).isNull()
+  }
+
+  @Test
+  fun `Reschedule sessions with skipPreGroupOneToOnePlaceholder should preserve the pre-group placeholder date and not create a new one`() {
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+
+    // Group starting in the future - clock is 2025-11-22
+    val group = testGroupHelper.createGroup(
+      earliestStartDate = LocalDate.now(clock).plusDays(7),
+      createGroupSessionSlots = setOf(slot1),
+    )
+
+    val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+
+    // Find the original pre-group one-to-one placeholder and record its date
+    val preGroupOneToOnePlaceholderSession = updatedGroup.sessions.first { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+
+    // Simulate setting a new earliest start date
+    updatedGroup.earliestPossibleStartDate = LocalDate.now(clock).plusYears(2).plusDays(2) //On a Wednesday, outside of group cadence
+    programmeGroupRepository.save(updatedGroup)
+
+    // Manually update the placeholder date to match the new earliest start date (as ProgrammeGroupService does)
+    val newEarliestStartDate = updatedGroup.earliestPossibleStartDate
+    val newPlaceholderDate = newEarliestStartDate.atTime(preGroupOneToOnePlaceholderSession.startsAt.toLocalTime())
+    val originalDuration = java.time.Duration.between(preGroupOneToOnePlaceholderSession.startsAt, preGroupOneToOnePlaceholderSession.endsAt)
+    preGroupOneToOnePlaceholderSession.startsAt = newPlaceholderDate
+    preGroupOneToOnePlaceholderSession.endsAt = newPlaceholderDate.plus(originalDuration)
+    sessionRepository.save(preGroupOneToOnePlaceholderSession)
+
+    // Reschedule with skipPreGroupOneToOnePlaceholder = true
+    scheduleService.rescheduleSessionsForGroup(updatedGroup.id!!, skipPreGroupOneToOnePlaceholder = true)
+
+    val rescheduledGroup = programmeGroupRepository.findByIdOrNull(updatedGroup.id!!)!!
+
+    // Should still have exactly 27 sessions - no duplicate placeholder created
+    assertThat(rescheduledGroup.sessions).hasSize(27)
+
+    // Should still have exactly one pre-group one-to-one placeholder
+    val placeholders = rescheduledGroup.sessions.filter { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
+    assertThat(placeholders).hasSize(1)
+
+    // The placeholder date should not have been reset to a slot-calculated date
+    assertThat(placeholders.first().startsAt.toLocalDate()).isEqualTo(newPlaceholderDate.toLocalDate())
+
+    // All non Pre-group one-to-one placeholder sessions should have been rescheduled to the new date range
+    val nonPreGroupOneToOnePlaceholderSessions = rescheduledGroup.sessions.filter { !(it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder) }
+    assertThat(nonPreGroupOneToOnePlaceholderSessions).allMatch { it.startsAt.year >= 2027 }
+
+    // All rescheduled sessions should be on Monday (the slot day)
+    assertThat(nonPreGroupOneToOnePlaceholderSessions).allMatch { it.startsAt.dayOfWeek == DayOfWeek.MONDAY }
   }
 
   @Test
@@ -446,164 +544,5 @@ class ScheduleServiceIntegrationTest : IntegrationTestBase() {
 
     // Should be the correct date
     assertThat(nextSlotDate).isEqualTo(LocalDate.of(2126, 7, 10))
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should return next available slot date when starting from a Monday`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
-    val slot2 = CreateGroupSessionSlotFactory().produce(DayOfWeek.THURSDAY, 12, 0, AmOrPm.PM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1, slot2),
-    )
-
-    // Starting from Monday April 13, 2026
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 13)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should return the same Monday (next or same Monday)
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should skip bank holidays`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 3, 30),
-      createGroupSessionSlots = setOf(slot1),
-    )
-
-    // Starting from Monday March 30, 2026 (not a bank holiday)
-    // Next Monday would be April 6, 2026 which IS a bank holiday (Easter Monday)
-    val dateToScheduleFrom = LocalDate.of(2026, 3, 30)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should return March 30 as it's a valid Monday, not a bank holiday
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 3, 30))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should skip to next week if current date slot is a bank holiday`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1),
-    )
-
-    // Starting from Easter Monday April 6, 2026 (bank holiday)
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 6)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should skip Easter Monday and return Monday April 13
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should handle multiple slots and return earliest available`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
-    val slot2 = CreateGroupSessionSlotFactory().produce(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)
-    val slot3 = CreateGroupSessionSlotFactory().produce(DayOfWeek.FRIDAY, 10, 15, AmOrPm.AM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1, slot2, slot3),
-    )
-
-    // Starting from Tuesday April 14, 2026
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 14)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Wednesday April 15 is the next available slot after Tuesday April 14
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 15))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should handle consecutive bank holidays`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1),
-    )
-
-    // Starting from April 6, 2026 (Easter Monday - bank holiday)
-    // The real bank holidays API will include this date
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 6)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should skip Easter Monday April 6 and return Monday April 13
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 13))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should work with single slot configuration`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.WEDNESDAY, 10, 0, AmOrPm.AM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1),
-    )
-
-    // Starting from Monday April 13, 2026
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 13)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should return Wednesday April 15 (next Wednesday)
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 15))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
-  }
-
-  @Test
-  fun `getNextSessionDateFromSuppliedDate should return same day if it matches a slot and is not a bank holiday`() {
-    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.THURSDAY, 12, 0, AmOrPm.PM)
-
-    val group = testGroupHelper.createGroup(
-      earliestStartDate = LocalDate.of(2026, 4, 1),
-      createGroupSessionSlots = setOf(slot1),
-    )
-
-    // Starting from Thursday April 16, 2026 (not a bank holiday)
-    val dateToScheduleFrom = LocalDate.of(2026, 4, 16)
-
-    val nextDate = scheduleService.getNextSessionDateFromSuppliedDate(
-      programmeGroupRepository.findByIdOrNull(group.id!!)!!,
-      dateToScheduleFrom,
-    )
-
-    // Should return the same Thursday
-    assertThat(nextDate).isEqualTo(LocalDate.of(2026, 4, 16))
-    assertThat(nextDate.dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
@@ -177,7 +177,7 @@ class ScheduleServiceIntegrationTest(@Autowired private val sessionRepository: S
     val preGroupOneToOnePlaceholderSession = updatedGroup.sessions.first { it.moduleName == "Pre-group one-to-ones" && it.isPlaceholder }
 
     // Simulate setting a new earliest start date
-    updatedGroup.earliestPossibleStartDate = LocalDate.now(clock).plusYears(2).plusDays(2) //On a Wednesday, outside of group cadence
+    updatedGroup.earliestPossibleStartDate = LocalDate.now(clock).plusYears(2).plusDays(2) // On a Wednesday, outside of group cadence
     programmeGroupRepository.save(updatedGroup)
 
     // Manually update the placeholder date to match the new earliest start date (as ProgrammeGroupService does)


### PR DESCRIPTION
Change to the logic around editing a group start date
If you edit the group start date
Even if the group start date does not match the cadence of the group (e.g slots are on Mondays at 1pm and you change the start date to be a Friday)
Regardless of if the user chooses to automatically reschedule sessions
The pre-group one-to-one session placeholder start date should be set to the start date selected when editing a group