### PR TITLE
Re-enable OpenAPI version test in `OpenApiDocsTest`

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/OpenApiDocsTest.kt
@@ -53,7 +53,10 @@ class OpenApiDocsTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+      .expectBody()
+      .jsonPath("info.version").value<String> { version ->
+        assertThat(version).startsWith(LocalDate.now().format(DateTimeFormatter.ISO_DATE))
+      }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/OpenApiDocsTest.kt
@@ -47,7 +47,6 @@ class OpenApiDocsTest : IntegrationTestBase() {
   }
 
   @Test
-  @Disabled
   fun `the open api json contains the version number`() {
     webTestClient.get()
       .uri("/v3/api-docs")


### PR DESCRIPTION
This pull request re-enables the test for the OpenAPI version in `OpenApiDocsTest`, which was failing in GHA with the following error:

```
`uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.OpenApiDocsTest

  Test the open api json contains the version number() FAILED (3.7s)

  java.lang.AssertionError: JSON path "info.version" expected:<2026-04-23> but was:<2026-04-23.2538.e5c0392>
      at uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.OpenApiDocsTest.the open api json contains the version number(OpenApiDocsTest.kt:56)`
```


<img width="1281" height="236" alt="image" src="https://github.com/user-attachments/assets/f3b0d6e6-a2d5-4f3c-953f-777941ed9a42" />


Updated test to reflect that the version number in the swagger docs page now seems to have a date as a prefix, in addition to some other stuff.