### PR TITLE
Attendance History Tweaks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
@@ -67,7 +67,7 @@ data class AttendanceHistorySession(
   )
   val date: String,
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm:ss")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
   @Schema(
     description = "The unformatted date of the session for sorting",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/attendance/AttendanceHistoryResponse.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.attendance
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Schema(description = "Response containing attendance history for a referral")
@@ -64,6 +66,12 @@ data class AttendanceHistorySession(
     example = "11 July 2025",
   )
   val date: String,
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm:ss")
+  @Schema(
+    description = "The unformatted date of the session for sorting",
+  )
+  val unformattedDate: LocalDateTime,
 
   @Schema(
     description = "The time range of the session",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -48,6 +48,8 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameContext
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameFormatter
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.formatTimeForUiDisplay
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -76,6 +78,7 @@ class ReferralService(
   private val domainEventPublisher: DomainEventPublisher,
   @Value("\${services.manage-and-deliver-api.base-url}") private val madBaseUrl: String,
   private val programmeGroupService: ProgrammeGroupService,
+  private val sessionNameFormatter: SessionNameFormatter,
   private val referralStatusService: ReferralStatusService,
 ) {
   companion object {
@@ -421,13 +424,16 @@ class ReferralService(
             .filter { it.session.id == session.id }
             .maxByOrNull { it.createdAt }
 
+          log.warn("IN here ${sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory)}")
+
           AttendanceHistorySession(
             sessionId = session.id!!,
-            sessionName = session.sessionName,
+            sessionName = sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory),
             groupId = membership.programmeGroup.id,
             groupCode = membership.programmeGroup.code,
             popName = referral.personName,
             date = session.startsAt.format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
+            unformattedDate = session.startsAt,
             time = "${formatTimeForUiDisplay(session.startsAt.toLocalTime())} to ${formatTimeForUiDisplay(session.endsAt.toLocalTime())}",
             attendanceStatus = programmeGroupService.getAttendanceTextFromOutcome(latestAttendance?.outcomeType),
             hasNotes = latestAttendance?.notesHistory?.isNotEmpty() == true,
@@ -437,7 +443,7 @@ class ReferralService(
       }
       // Remove any duplicate sessions in the event that there are multiple attendance records for a session.
       .distinctBy { it.sessionId }
-      .sortedByDescending { it.date }
+      .sortedBy { it.unformattedDate }
 
     return AttendanceHistoryResponse(
       popName = referral.personName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -424,8 +424,6 @@ class ReferralService(
             .filter { it.session.id == session.id }
             .maxByOrNull { it.createdAt }
 
-          log.warn("IN here ${sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory)}")
-
           AttendanceHistorySession(
             sessionId = session.id!!,
             sessionName = sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
@@ -45,6 +45,11 @@ sealed class SessionNameContext {
    * Formatting for the Session notes page.
    */
   data class SessionNotes(val popName: String) : SessionNameContext()
+
+  /**
+   * Formatting for the Attendance History page.
+   */
+  object AttendanceHistory : SessionNameContext()
 }
 
 /**
@@ -78,6 +83,7 @@ class SessionNameFormatter {
     is SessionNameContext.SessionsAndAttendance -> sessionsAndAttendance(context.sessionTemplate, session)
     is SessionNameContext.SessionDetails -> sessionDetails(session)
     is SessionNameContext.SessionNotes -> sessionNotes(session, context.popName)
+    is SessionNameContext.AttendanceHistory -> attendanceHistory(session)
   }
 
   /**
@@ -192,6 +198,42 @@ class SessionNameFormatter {
         requireNotNull(session.attendees.first()) { "Person name is required for individual sessions" }
         "${session.attendees.first().personName}: ${session.moduleSessionTemplate.name}$catchupSuffix"
       }
+    }
+  }
+
+  /**
+   * Formats the session name for use on the attendance history page.
+   *
+   * - GROUP: `"<module.name> <sessionNumber>"`
+   * - GROUP CATCH_UP: `"<module.name> <sessionNumber> catch-up"`
+   * - ONE_TO_ONE: `"<module.name> <sessionNumber> one-to-one"`
+   * - ONE_TO_ONE CATCH_UP: `"<module.name> <sessionNumber> one-to-one catch-up"`
+   * - PRE-GROUP and POST-PROGRAMME SESSIONS: `"<module.name>"`
+   * - PRE-GROUP and POST-PROGRAMME CATCH UP SESSIONS: `"<module.name> catch-up"`
+   */
+  private fun attendanceHistory(session: SessionEntity): String {
+    val catchupSuffix = if (session.isCatchup) " catch-up" else ""
+    val moduleName = session.moduleSessionTemplate.module.name
+    var prefix = ""
+    var isPreOrPost = false
+    if (moduleName in listOf("Post-programme reviews", "Pre-group one-to-ones")) {
+      prefix = moduleName.dropLast(1)
+      isPreOrPost = true
+    } else {
+      prefix = "${session.moduleSessionTemplate.module.name} ${session.sessionNumber}"
+    }
+    return when {
+      session.sessionType == SessionType.GROUP -> "$prefix$catchupSuffix"
+
+      session.sessionType == SessionType.ONE_TO_ONE && !isPreOrPost -> {
+        "$prefix one-to-one$catchupSuffix"
+      }
+
+      session.sessionType == SessionType.ONE_TO_ONE && isPreOrPost -> {
+        "$prefix$catchupSuffix"
+      }
+
+      else -> "$prefix$catchupSuffix"
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
@@ -220,10 +220,10 @@ class SessionNameFormatter {
       prefix = moduleName.dropLast(1)
       isPreOrPost = true
     } else {
-      prefix = "${session.moduleSessionTemplate.module.name} ${session.sessionNumber}"
+      prefix = session.moduleSessionTemplate.module.name
     }
     return when {
-      session.sessionType == SessionType.GROUP -> "$prefix$catchupSuffix"
+      session.sessionType == SessionType.GROUP -> "$prefix ${session.sessionNumber}$catchupSuffix"
 
       session.sessionType == SessionType.ONE_TO_ONE && !isPreOrPost -> {
         "$prefix one-to-one$catchupSuffix"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -1341,6 +1341,7 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.attendanceHistory).allMatch { it.hasNotes }
       assertThat(response.attendanceHistory).allMatch { it.groupId == group.id }
       assertThat(response.attendanceHistory).allMatch { it.popName == "Alex River" }
+      assertThat(response.attendanceHistory).allMatch { it.sessionName == "Getting started 1" }
       assertThat(response.attendanceHistory).allMatch { it.isCatchup == false }
     }
 
@@ -1396,6 +1397,68 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
         returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
         expectedResponseStatus = HttpStatus.NOT_FOUND.value(),
       )
+    }
+
+    @Test
+    fun `should return attendance history in session date order`() {
+      // Given
+      val group = testGroupHelper.createGroup()
+      val referral = testReferralHelper.createReferral(personName = "Alex River")
+      testGroupHelper.allocateToGroup(group, referral)
+
+      val groupSessions = sessionRepository.findByProgrammeGroupId(group.id!!)
+        .filter { it.sessionType == SessionType.GROUP }
+        .sortedBy { it.startsAt }
+
+      val earlierSession = groupSessions[0]
+      val laterSession = groupSessions[1]
+
+      nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
+
+      // Record attendance on the later session first
+      performRequestAndExpectStatusWithBody(
+        expectedResponseStatus = HttpStatus.CREATED.value(),
+        httpMethod = HttpMethod.POST,
+        uri = "/session/${laterSession.id}/attendance",
+        body = SessionAttendance(
+          attendees = listOf(
+            SessionAttendee(
+              referralId = laterSession.attendees.first().referralId,
+              outcomeCode = SessionAttendanceNDeliusCode.ATTC,
+              sessionNotes = "Later session notes",
+            ),
+          ),
+        ),
+        returnType = object : ParameterizedTypeReference<SessionAttendance>() {},
+      )
+
+      // Record attendance on the earlier session second
+      performRequestAndExpectStatusWithBody(
+        expectedResponseStatus = HttpStatus.CREATED.value(),
+        httpMethod = HttpMethod.POST,
+        uri = "/session/${earlierSession.id}/attendance",
+        body = SessionAttendance(
+          attendees = listOf(
+            SessionAttendee(
+              referralId = earlierSession.attendees.first().referralId,
+              outcomeCode = SessionAttendanceNDeliusCode.ATTC,
+              sessionNotes = "Earlier session notes",
+            ),
+          ),
+        ),
+        returnType = object : ParameterizedTypeReference<SessionAttendance>() {},
+      )
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/bff/referral/${referral.id}/attendance-history",
+        returnType = object : ParameterizedTypeReference<AttendanceHistoryResponse>() {},
+      )
+
+      // Then
+      assertThat(response.attendanceHistory).hasSize(2)
+      assertThat(response.attendanceHistory[0].unformattedDate).isBeforeOrEqualTo(response.attendanceHistory[1].unformattedDate)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
@@ -86,6 +86,7 @@ class ReferralServiceTest {
 
   private lateinit var referralService: ReferralService
 
+  @Mock
   private lateinit var sessionNameFormatter: SessionNameFormatter
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameFormatter
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -85,6 +86,8 @@ class ReferralServiceTest {
 
   private lateinit var referralService: ReferralService
 
+  private lateinit var sessionNameFormatter: SessionNameFormatter
+
   @BeforeEach
   fun beforeEach() {
     referralService = ReferralService(
@@ -107,6 +110,7 @@ class ReferralServiceTest {
       madBaseUrl = "http://localhost:8080",
       programmeGroupService = programmeGroupService,
       referralStatusService = referralStatusService,
+      sessionNameFormatter = sessionNameFormatter,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
@@ -879,4 +879,190 @@ class SessionNameFormatterTest : IntegrationTestBase() {
         .isEqualTo("Alex River: Post-programme review session notes")
     }
   }
+
+  @Nested
+  inner class AttendanceHistory {
+    @Test
+    fun `returns correct attendance history name for regular group session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 1,
+          sessionType = SessionType.GROUP,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Introduction to Building Choices",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Getting started 1")
+    }
+
+    @Test
+    fun `returns correct attendance history name for catch up group session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 3,
+          sessionType = SessionType.GROUP,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Introduction to Building Choices",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .withIsCatchup(true)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Getting started 3 catch-up")
+    }
+
+    @Test
+    fun `returns correct attendance history name for one to one session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 2,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Introduction to Building Choices",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Getting started 2 one-to-one")
+    }
+
+    @Test
+    fun `returns correct attendance history name for one to one catch up session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 2,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Introduction to Building Choices",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .withIsCatchup(true)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Getting started 2 one-to-one catch-up")
+    }
+
+    @Test
+    fun `returns correct attendance history name for pre group one to one session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Pre-group one-to-ones", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 2,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Pre-group one-to-one",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Pre-group one-to-one")
+    }
+
+    @Test
+    fun `returns correct attendance history name for post programme review catch up session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Post-programme reviews", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 2,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Post-programme review",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .withIsCatchup(true)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
+        .isEqualTo("Post-programme review catch-up")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
@@ -970,7 +970,7 @@ class SessionNameFormatterTest : IntegrationTestBase() {
       )
 
       assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
-        .isEqualTo("Getting started 2 one-to-one")
+        .isEqualTo("Getting started one-to-one")
     }
 
     @Test
@@ -1001,7 +1001,7 @@ class SessionNameFormatterTest : IntegrationTestBase() {
       )
 
       assertThat(sessionNameFormatter.format(session, SessionNameContext.AttendanceHistory))
-        .isEqualTo("Getting started 2 one-to-one catch-up")
+        .isEqualTo("Getting started one-to-one catch-up")
     }
 
     @Test


### PR DESCRIPTION
Return sessions in date order earliest to latest
Correct Session names that are returned, they should be as follows:

Pre-group one-to-one
Pre-group one-to-one
Pre-group one-to-one catch-up

Getting started
Getting started 1 catch-up
Getting started 2 catch-up
Getting started one-to-one
Getting started one-to-one catch-up

Managing myself
Managing myself 1 catch-up
Managing myself 2 catch-up
Managing myself 3 catch-up
Managing myself 4 catch-up
Managing myself 5 catch-up
Managing myself 6 catch-up
Managing myself one-to-one
Managing myself one-to-one catch-up

Managing life’s problems
Managing life’s problems 1 catch-up
Managing life’s problems 2 catch-up
Managing life’s problems 3 catch-up
Managing life’s problems 4 catch-up
Managing life’s problems one-to-one
Managing life’s problems one-to-one catch-up

Managing people around me
Managing people around me 1 catch-up
Managing people around me 2 catch-up
Managing people around me 3 catch-up
Managing people around me 4 catch-up
Managing people around me 5 catch-up
Managing people around me 6 catch-up
Managing people around me one-to-one
Managing people around me one-to-one catch-up

Bringing it all together
Bringing it all together 1 catch-up
Bringing it all together 2 catch-up
Bringing it all together 3 catch-up

Post-programme review
Post-programme review
Post-programme review catch-up