### PR TITLE
Update the remove from group success message

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
@@ -331,15 +331,11 @@ class ProgrammeGroupController(
     @Valid
     @RequestBody removeFromGroupRequest: RemoveFromGroupRequest,
   ): ResponseEntity<RemoveFromGroupResponse> {
-    programmeGroupMembershipService.removeReferralFromGroup(
+    val response = programmeGroupMembershipService.removeReferralFromGroup(
       referralId,
       groupId,
       authenticationHolder.username ?: "SYSTEM",
       removeFromGroupRequest,
-    )
-
-    val response = RemoveFromGroupResponse(
-      message = "Future scheduled sessions for this PoP have been deleted in nDelius and the Digital Service.",
     )
 
     return ResponseEntity.status(HttpStatus.OK).body(response)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RemoveFromGroupRequest
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RemoveFromGroupResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.ConflictException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
@@ -104,7 +105,7 @@ class ProgrammeGroupMembershipService(
     groupId: UUID,
     removedFromGroupBy: String,
     removeFromGroupRequest: RemoveFromGroupRequest,
-  ): ReferralEntity {
+  ): RemoveFromGroupResponse {
     log.info("Attempting to remove Referral with id: $referralId from group with id: $groupId...")
 
     val group = (
@@ -130,7 +131,11 @@ class ProgrammeGroupMembershipService(
       )
 
     referral.statusHistories.add(statusHistory)
-    return referralRepository.save(referral)
+    referralRepository.save(referral)
+
+    return RemoveFromGroupResponse(
+      message = "${referral.personName} was removed from this group. Their referral status is now ${desiredStatus.description}",
+    )
   }
 
   fun deleteGroupMembershipForReferralAndGroup(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -943,6 +943,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
       val referral = testReferralHelper.createReferralAndUpdateStatus(
         referralStatusDescriptionRepository.getAwaitingAllocationStatusDescription(),
+        personName = "Alex River",
       )
       nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
       nDeliusApiStubs.stubSuccessfulDeleteAppointmentsResponse()
@@ -989,7 +990,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val foundReferral = referralRepository.findByIdOrNull(referral.id!!)!!
 
       // Then
-      assertThat(response.message).contains("Future scheduled sessions for this PoP have been deleted in nDelius and the Digital Service.")
+      assertThat(response.message).contains("Alex River was removed from this group. Their referral status is now Awaiting allocation")
       assertThat(foundReferral).isNotNull
       assertThat(foundReferral.id).isEqualTo(referral.id)
 
@@ -1021,6 +1022,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
       val referral = testReferralHelper.createReferralAndUpdateStatus(
         referralStatusDescriptionRepository.getOnProgrammeStatusDescription(),
+        personName = "Alex River",
       )
 
       nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
@@ -1084,7 +1086,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val foundReferral = referralRepository.findByIdOrNull(referral.id!!)!!
 
       // Then
-      assertThat(response.message).contains("Future scheduled sessions for this PoP have been deleted in nDelius and the Digital Service.")
+      assertThat(response.message).contains("Alex River was removed from this group. Their referral status is now Return to court")
       assertThat(foundReferral).isNotNull
       assertThat(foundReferral.id).isEqualTo(referral.id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -238,9 +238,9 @@ class TestReferralHelper {
    * @param statusEntity The status to set. If null, defaults to AWAITING_ALLOCATION status.
    * @return The created and updated [ReferralEntity]
    */
-  fun createReferralAndUpdateStatus(statusEntity: ReferralStatusDescriptionEntity? = null): ReferralEntity {
+  fun createReferralAndUpdateStatus(statusEntity: ReferralStatusDescriptionEntity? = null, personName: String? = null): ReferralEntity {
     val status = statusEntity ?: referralStatusDescriptionRepository.getAwaitingAllocationStatusDescription()
-    val referral = createReferral()
+    val referral = if (personName != null) createReferral(personName = personName) else createReferral()
     referralService.updateStatus(referral, status.id, null, "AUTH_USER")
 
     return referralRepository.findByIdOrNull(referral.id!!)!!


### PR DESCRIPTION
Update the success message when removing someone from a group to be in the format:
'[Alex River] was removed from this group. Their referral status is now [status, eg Return to court]'.