### PR TITLE
Apg 2249/add new field to endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -12,6 +12,11 @@ data class RecordSessionAttendance(
   val sessionTitle: String,
 
   @Schema(
+    description = "A module name of a session",
+    example = "Getting started",
+  )
+
+  @Schema(
     description = "Region name of a programme group",
     example = "North East",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -13,8 +13,9 @@ data class RecordSessionAttendance(
 
   @Schema(
     description = "A module name of a session",
-    example = "Getting started",
+    example = "Getting started 1",
   )
+  val sessionModule: String,
 
   @Schema(
     description = "Region name of a programme group",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -6,13 +6,13 @@ import java.util.UUID
 @Schema(description = "Details of a Record Attendance")
 data class RecordSessionAttendance(
   @Schema(
-    description = "A title of a session",
-    example = "Getting started 1",
+    description = "The name of the session template",
+    example = "Introduction to Building Choices",
   )
   val sessionTitle: String,
 
   @Schema(
-    description = "A module name of a session",
+    description = "A module name and session number or type of a session",
     example = "Getting started 1",
   )
   val sessionModule: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -6,13 +6,13 @@ import java.util.UUID
 @Schema(description = "Details of a Record Attendance")
 data class RecordSessionAttendance(
   @Schema(
-    description = "The name of the session template",
+    description = "The name of the session",
     example = "Introduction to Building Choices",
   )
   val sessionTitle: String,
 
   @Schema(
-    description = "A module name and session number or type of a session",
+    description = "The name of the module",
     example = "Getting started 1",
   )
   val sessionModule: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -433,6 +433,7 @@ class SessionService(
 
     return RecordSessionAttendance(
       sessionTitle = session.sessionName,
+      sessionModule = session.moduleSessionTemplate.module.name,
       groupRegionName = programmeGroup.regionName,
       people = filteredAttendees.map { attendee ->
         val latestAttendance = latestAttendanceByReferralId[attendee.referralId]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -433,7 +433,7 @@ class SessionService(
 
     return RecordSessionAttendance(
       sessionTitle = session.sessionName,
-      sessionModule = session.moduleSessionTemplate.module.name,
+      sessionModule = sessionNameFormatter.format(session, SessionNameContext.ScheduleOverview),
       groupRegionName = programmeGroup.regionName,
       people = filteredAttendees.map { attendee ->
         val latestAttendance = latestAttendanceByReferralId[attendee.referralId]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -1647,6 +1647,7 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
 
       // Then
       assertThat(response.sessionTitle).isEqualTo(session.sessionName)
+      assertThat(response.sessionModule).isEqualTo("${session.moduleSessionTemplate.module.name} ${session.sessionNumber}")
       assertThat(response.groupRegionName).isEqualTo(group.regionName)
       assertThat(response.people).isNotEmpty()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionServiceTest.kt
@@ -746,9 +746,9 @@ class SessionServiceTest {
     // Given
     val facilitator = FacilitatorEntityFactory().produce()
     val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
-    val module = ModuleEntityFactory().withName("Post-programme reviews").produce()
+    val module = ModuleEntityFactory().withName("Getting started").produce()
     val moduleSessionTemplateEntity = ModuleSessionTemplateEntityFactory()
-      .withSessionType(ONE_TO_ONE)
+      .withSessionType(GROUP)
       .withName("Template 1")
       .withModule(module)
       .produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionServiceTest.kt
@@ -789,6 +789,7 @@ class SessionServiceTest {
     assertThat(result).isNotNull()
     assertThat(result.sessionTitle).isEqualTo("Template 1")
     assertThat(result.groupRegionName).isEqualTo("TEST REGION")
+    assertThat(result.sessionModule).isEqualTo("Getting started 1")
     assertThat(result.people).hasSize(1)
     assertThat(result.people[0].referralId).isEqualTo(referralId)
     assertThat(result.people[0].crn).isEqualTo(referralEntity.crn)


### PR DESCRIPTION
https://accredited-programmes-manage-and-deliver-dev.hmpps.service.justice.gov.uk/group/919d9bd6-49f9-4456-886b-3192c6000f1f/session/1821a4e8-6341-4887-b0eb-3920972eec4a/record-attendance

The title on this page is incorrect. Instead of 'Did Jessie Schamberger attend Introduction to Building Choices?', it should say 'Did Jessie Schamberger attend Getting started 1?'. 

We want the module name and not the session name.

<img width="920" height="524" alt="Screenshot 2026-05-01 at 08 32 27" src="https://github.com/user-attachments/assets/9e9e11b6-d868-4cd6-8b64-18f97c6b4ad6" />
