### PR TITLE
APG-2238 : Ensure LAO check on caselist is limited to 500 crns max

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClient.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.BaseHMPPSClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CreateAppointmentRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.DeleteAppointmentsRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
@@ -34,11 +35,18 @@ class NDeliusIntegrationApiClient(
     path = "/case/$crn/sentence/$eventNumber"
   }
 
-  fun verifyLimitedAccessOffenderCheck(username: String, identifiers: List<String>) = postRequest<LimitedAccessOffenderCheckResponse>(
-    N_DELIUS_INTEGRATION_API,
-  ) {
-    path = "/user/$username/access"
-    body = identifiers
+  fun verifyLimitedAccessOffenderCheck(
+    username: String,
+    identifiers: List<String>,
+  ): ClientResult<LimitedAccessOffenderCheckResponse> {
+    require(identifiers.size <= 500) { "Identifier limit exceeded: ${identifiers.size} identifiers provided, maximum is 500" }
+
+    return postRequest<LimitedAccessOffenderCheckResponse>(
+      N_DELIUS_INTEGRATION_API,
+    ) {
+      path = "/user/$username/access"
+      body = identifiers
+    }
   }
 
   fun getOffences(crn: String, eventNumber: Int) = getRequest<Offences>(N_DELIUS_INTEGRATION_API) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepository.kt
@@ -11,6 +11,5 @@ interface ReferralCaseListItemRepository :
   JpaRepository<ReferralCaseListItemViewEntity, UUID>,
   JpaSpecificationExecutor<ReferralCaseListItemViewEntity>,
   ReferralCaseListItemRepositoryCustom {
-  fun countAllByStatusIn(statuses: List<String>): Int
   fun findByCrn(crn: String): List<ReferralCaseListItemViewEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepositoryCustom.kt
@@ -4,5 +4,9 @@ import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralCaseListItemViewEntity
 
 interface ReferralCaseListItemRepositoryCustom {
-  fun findAllCrns(spec: Specification<ReferralCaseListItemViewEntity>): List<String>
+  fun findAllCrns(
+    spec: Specification<ReferralCaseListItemViewEntity>,
+    offset: Int = 0,
+    limit: Int = Integer.MAX_VALUE,
+  ): List<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralCaseListItemRepositoryImpl.kt
@@ -10,7 +10,11 @@ class ReferralCaseListItemRepositoryImpl(
   private val entityManager: EntityManager,
 ) : ReferralCaseListItemRepositoryCustom {
 
-  override fun findAllCrns(spec: Specification<ReferralCaseListItemViewEntity>): List<String> {
+  override fun findAllCrns(
+    spec: Specification<ReferralCaseListItemViewEntity>,
+    offset: Int,
+    limit: Int,
+  ): List<String> {
     val builder = entityManager.criteriaBuilder
     val query = builder.createQuery(String::class.java)
     val root = query.from(ReferralCaseListItemViewEntity::class.java)
@@ -19,6 +23,9 @@ class ReferralCaseListItemRepositoryImpl(
 
     spec.toPredicate(root, query, builder)?.let { query.where(it) }
 
-    return entityManager.createQuery(query).resultList
+    return entityManager.createQuery(query)
+      .setFirstResult(offset)
+      .setMaxResults(limit)
+      .resultList
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
@@ -100,7 +100,6 @@ class ReferralCaseListItemService(
     } else {
       withRegionNames(baseSpec, userRegions)
     }
-
     val crns = referralCaseListItemRepository.findAllCrns(specWithRegions)
 
     if (crns.isEmpty()) {
@@ -108,9 +107,12 @@ class ReferralCaseListItemService(
       return PageImpl(emptyList(), pageable, 0)
     }
 
-    // This endpoint is currently failing in preprod. While PI team are investigating we are temporarily disabling it.
-    val allowedCrns = crns.toSet()
-//    val allowedCrns = userService.getAccessibleOffenders(username, crns)
+    // Only fetch up to 500 referrals at a time as this is the limit for our LAO check request
+    // We are overfetching so that when we filter out LAO referrals we should still enough referrals for a page of 50
+    val batchSize = if (pageable.pageSize * 2 > 500) 500 else pageable.pageSize * 2
+    val crnBatch =
+      referralCaseListItemRepository.findAllCrns(specWithRegions, pageable.offset.toInt(), batchSize)
+    val allowedCrns = userService.getAccessibleOffenders(username, crnBatch)
 
     if (allowedCrns.isEmpty()) {
       log.warn("No CRNs are allowed for user: $username. Returning empty list for ReferralCaseList.")
@@ -118,6 +120,9 @@ class ReferralCaseListItemService(
     }
 
     val restrictedSpec = withAllowedCrns(specWithRegions, allowedCrns)
+    val caseListReferrals = referralCaseListItemRepository.findAll(restrictedSpec, pageable)
+
+    if (caseListReferrals.totalElements < 50) log.warn("Only ${caseListReferrals.totalElements} out of ${pageable.pageSize} referrals returned due to Limited Access Offender check ")
     return referralCaseListItemRepository.findAll(restrictedSpec, pageable)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -269,6 +270,60 @@ class CaseListControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response.filters.statusFilterValues.open).contains("Breach", "On programme")
       assertThat(response.filters.locationFilterValues.map { it.pduName }).contains("PDU1", "PDU2")
       assertThat(response.filters.cohort).containsAll(ProgrammeGroupCohort.entries.map { it.label })
+    }
+
+    @Test
+    fun `getCaseListItems for OPEN referrals return 200 and paged list of referral case list items where some referrals are LAO`() {
+      // Given
+      testReferralHelper.createReferrals(10)
+      // & When
+      val response = performRequestAndExpectOk(
+        HttpMethod.GET,
+        "/pages/caselist/open",
+        object : ParameterizedTypeReference<PagedCaseListReferrals<ReferralCaseListItem>>() {},
+      )
+      val referralCaseListItems = response.pagedReferrals.content
+
+      // Then
+      assertThat(response).isNotNull
+      assertThat(response.pagedReferrals.totalElements).isEqualTo(6)
+      assertThat(referralCaseListItems.map { it.crn })
+        .containsExactlyInAnyOrder("X7182552", "CRN-999999", "CRN-888888", "CRN-777777", "CRN-66666", "CRN-555555")
+
+      referralCaseListItems.forEach { item ->
+        assertThat(item).hasFieldOrProperty("crn")
+        assertThat(item).hasFieldOrProperty("personName")
+        assertThat(item).hasFieldOrProperty("referralStatus")
+        assertThat(item).hasFieldOrProperty("cohort")
+        assertThat(item).hasFieldOrProperty("hasLdc")
+        assertThat(item).hasFieldOrProperty("sentenceEndDate")
+        assertThat(item).hasFieldOrProperty("sentenceEndDateSource")
+      }
+      assertThat(response.otherTabTotal).isEqualTo(1)
+      assertThat(response.filters).isNotNull
+      assertThat(response.filters.statusFilterValues.open).contains("Breach", "On programme")
+      assertThat(response.filters.locationFilterValues.map { it.pduName }).contains("PDU1", "PDU2")
+      assertThat(response.filters.cohort).containsAll(ProgrammeGroupCohort.entries.map { it.label })
+    }
+
+    @Test
+    @Disabled("Disabled due to running time of test creating 501 referrals")
+    fun `getCaseListItems for OPEN referrals returns smaller page when 500 referrals are LAO`() {
+      // Given
+      testReferralHelper.createReferrals(510)
+      // & When
+      val response = performRequestAndExpectOk(
+        HttpMethod.GET,
+        "/pages/caselist/open",
+        object : ParameterizedTypeReference<PagedCaseListReferrals<ReferralCaseListItem>>() {},
+      )
+      val referralCaseListItems = response.pagedReferrals.content
+
+      // Then
+      assertThat(response).isNotNull
+      assertThat(response.pagedReferrals.totalElements).isEqualTo(6)
+      assertThat(referralCaseListItems.map { it.crn })
+        .containsExactlyInAnyOrder("X7182552", "CRN-999999", "CRN-888888", "CRN-777777", "CRN-66666", "CRN-555555")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/NDeliusIntegrationApiClientIntegrationTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.ProbationPractitioner
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementStaff
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomCrn
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffenceFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.OffencesFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.UpdateAppointmentsRequestFactory
@@ -161,6 +162,19 @@ class NDeliusIntegrationApiClientIntegrationTest : IntegrationTestBase() {
     when (val response = nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(crn))) {
       is ClientResult.Failure.StatusCode<*> -> assertThat(response.status).isEqualTo(HttpStatus.FORBIDDEN)
       else -> fail("Unexpected result: ${response::class.simpleName}")
+    }
+  }
+
+  @Test
+  fun `should return error when making request for more than 500 crns`() {
+    stubAuthTokenEndpoint()
+    val username = "john.doe"
+    val crnList = List(501) { randomCrn() }
+
+    try {
+      nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, crnList)
+    } catch (exception: IllegalArgumentException) {
+      assertThat(exception.message).isEqualTo("Identifier limit exceeded: ${crnList.size} identifiers provided, maximum is 500")
     }
   }
 


### PR DESCRIPTION
## WHAT

On the caselist we make a call to check if the logged in user is permitted to access the crns that are being displayed. The current implementation looks at ALL the crns in the db which in higher environments is 1000's. The endpoint which accepts a list of CRNs to check only accepts max 500 crns.

This PR limits the amount of crns sent to the access check endpoint to be 500.