### PR TITLE
feat: Automatically increment eventNumber from 0..20 for imported Referrals

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.mode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.update.UpdateCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.DeliveryLocationPreferencesService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.OffenceService
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralEventNumberResolverService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralStatusService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.SentenceService
@@ -48,6 +49,7 @@ import java.util.UUID
 @PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
 class ReferralController(
   private val referralService: ReferralService,
+  private val referralEventNumberResolverService: ReferralEventNumberResolverService,
   private val userService: UserService,
   private val offenceService: OffenceService,
   private val sentenceService: SentenceService,
@@ -127,6 +129,7 @@ class ReferralController(
     @PathVariable @Parameter(description = "The id (UUID) of a referral", required = true) id: UUID,
   ): ResponseEntity<PersonalDetails> {
     val referral = referralService.getReferralById(id)
+    referralEventNumberResolverService.resolveIfEventNumberIsZero(referral)
     return userService.getPersonalDetailsByIdentifier(referral.crn).let {
       ResponseEntity.ok(it.toModel(referral.setting))
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/TelemetryClientConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/TelemetryClientConfig.kt
@@ -11,4 +11,4 @@ class TelemetryClientConfig {
   fun telemetryClient(): TelemetryClient = TelemetryClient()
 }
 
-fun TelemetryClient.logToAppInsights(page: String, messages: Map<String, String>) = this.trackEvent(page, messages, null)
+fun TelemetryClient.logToAppInsights(eventName: String, properties: Map<String, String>) = this.trackEvent(eventName, properties, null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralEntity.kt
@@ -85,7 +85,7 @@ class ReferralEntity(
   //  The Delius event number representing a specific court case event
   @Nullable
   @Column("event_number")
-  val eventNumber: Int? = null,
+  var eventNumber: Int? = null,
 
   @Nullable
   @Column("sentence_end_date")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+
+private const val FIRST_VALID_EVENT_NUMBER = 1
+private const val LAST_VALID_EVENT_NUMBER = 20
+
+@Service
+class ReferralEventNumberResolverService(
+  private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
+  private val referralRepository: ReferralRepository,
+  private val telemetryClient: TelemetryClient,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  /**
+   * When Referrals are populated by the data-importer-service, they have the eventNumber of 0, we know that this
+   * is an invalid number, and so when we attempt to fetch offence details associated with it, we will always get
+   * a 4xx error.  It does not appear that the eventNumber is stored in Interventions Manager data, and therefore
+   * we need a naieve solution which simply:
+   * 1. Recognises that an event number is 0
+   * 2. Iterates up, one at a time (until 20), to see if we can get a 2xx response from nDelius
+   * 3. If no success is found, we leave the event number as 0
+   */
+  @Transactional
+  fun resolveIfEventNumberIsZero(referral: ReferralEntity): Int? {
+    if (referral.eventNumber != 0) {
+      return referral.eventNumber
+    }
+
+    log.info(
+      "Referral {} has event number 0. Attempting to resolve by checking nDelius sentence endpoint for CRN {} ({}..{}).",
+      referral.id,
+      referral.crn,
+      FIRST_VALID_EVENT_NUMBER,
+      LAST_VALID_EVENT_NUMBER,
+    )
+
+    for (candidateEventNumber in FIRST_VALID_EVENT_NUMBER..LAST_VALID_EVENT_NUMBER) {
+      when (val response = nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, candidateEventNumber)) {
+        is ClientResult.Success -> {
+          referral.eventNumber = candidateEventNumber
+          referralRepository.save(referral)
+          logSuccess(referral, candidateEventNumber)
+          return candidateEventNumber
+        }
+
+        is ClientResult.Failure.StatusCode -> {
+          log.info(
+            "Event number {} was not valid for referral {} (status {}). Trying next.",
+            candidateEventNumber,
+            referral.id,
+            response.status.value(),
+          )
+        }
+
+        is ClientResult.Failure.Other -> {
+          log.warn(
+            "Could not validate event number {} for referral {} due to: {}. Trying next.",
+            candidateEventNumber,
+            referral.id,
+            response.getErrorMessage(),
+          )
+        }
+      }
+    }
+
+    logFailureEvent(referral)
+    return referral.eventNumber
+  }
+
+  private fun logFailureEvent(referral: ReferralEntity) {
+    log.warn(
+      "Could not resolve a valid event number for referral {} after checking {} to {}. Keeping event number as 0.",
+      referral.id,
+      FIRST_VALID_EVENT_NUMBER,
+      LAST_VALID_EVENT_NUMBER,
+    )
+
+    telemetryClient.logToAppInsights(
+      "Referral.event-number-resolution.failure",
+      mapOf(
+        "referralId" to referral.id.toString(),
+      ),
+    )
+  }
+
+  private fun logSuccess(referral: ReferralEntity, newEventNumber: Int) {
+    log.info(
+      "Resolved event number for referral {}. Using {} after {} attempt(s).",
+      referral.id,
+      newEventNumber,
+      newEventNumber,
+    )
+
+    telemetryClient.logToAppInsights(
+      "Referral.event-number-resolution.success",
+      mapOf(
+        "referralId" to referral.id.toString(),
+        "newEventNumber" to newEventNumber.toString(),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -463,6 +463,38 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
   @DisplayName("Get personal details endpoint")
   inner class GetPersonalDetails {
     @Test
+    fun `should resolve and persist event number when referral event number is zero`() {
+      val nDeliusPersonalDetails =
+        NDeliusPersonalDetailsFactory().withDateOfBirth(LocalDate.of(1990, 1, 1)).produce()
+      val referralEntity = ReferralEntityFactory()
+        .withCrn(nDeliusPersonalDetails.crn)
+        .withEventNumber(0)
+        .withCohort(OffenceCohort.SEXUAL_OFFENCE)
+        .produce()
+      val statusHistory = ReferralStatusHistoryEntityFactory().produce(
+        referralEntity,
+        referralStatusDescriptionRepository.getAwaitingAssessmentStatusDescription(),
+      )
+      testDataGenerator.createReferralWithStatusHistory(referralEntity, statusHistory)
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+
+      nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(nDeliusPersonalDetails)
+      nDeliusApiStubs.stubNotFoundSentenceInformationResponse(referralEntity.crn, "1")
+      nDeliusApiStubs.stubNotFoundSentenceInformationResponse(referralEntity.crn, "2")
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(referralEntity.crn, 3)
+
+      performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}/personal-details",
+        returnType = object : ParameterizedTypeReference<PersonalDetails>() {},
+      )
+
+      val updatedReferral = referralRepository.findById(savedReferral.id!!).orElseThrow()
+      assertThat(updatedReferral.eventNumber).isEqualTo(3)
+    }
+
+    @Test
     fun `should return personal details when access granted is true`() {
       val nDeliusPersonalDetails =
         NDeliusPersonalDetailsFactory().withDateOfBirth(LocalDate.of(1990, 1, 1)).produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -13,6 +14,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 
@@ -25,22 +27,26 @@ class ReferralEventNumberResolverServiceTest {
   @Mock
   private lateinit var referralRepository: ReferralRepository
 
+  @Mock
+  private lateinit var telemetryClient: TelemetryClient
+
   @Test
   fun `does not attempt resolution when event number is already non-zero`() {
     val referral = ReferralEntityFactory().withEventNumber(4).produce()
-    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
 
     val result = service.resolveIfEventNumberIsZero(referral)
 
     assertThat(result).isEqualTo(4)
     verifyNoInteractions(nDeliusIntegrationApiClient)
     verifyNoInteractions(referralRepository)
+    verifyNoInteractions(telemetryClient)
   }
 
   @Test
   fun `updates referral event number when a valid number is found`() {
     val referral = ReferralEntityFactory().withEventNumber(0).produce()
-    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
 
     `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, 1)).thenReturn(
       ClientResult.Failure.StatusCode(HttpMethod.GET, "/case/${referral.crn}/sentence/1", HttpStatusCode.valueOf(404), null),
@@ -65,7 +71,7 @@ class ReferralEventNumberResolverServiceTest {
   @Test
   fun `keeps event number as zero when no valid number is found`() {
     val referral = ReferralEntityFactory().withEventNumber(0).produce()
-    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
 
     (1..20).forEach { candidate ->
       `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, candidate)).thenReturn(
@@ -83,5 +89,5 @@ class ReferralEventNumberResolverServiceTest {
     }
   }
 
-  private fun mockSentenceResponse() = uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory().produce()
+  private fun mockSentenceResponse() = NDeliusSentenceResponseFactory().produce()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatusCode
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+
+@ExtendWith(MockitoExtension::class)
+class ReferralEventNumberResolverServiceTest {
+
+  @Mock
+  private lateinit var nDeliusIntegrationApiClient: NDeliusIntegrationApiClient
+
+  @Mock
+  private lateinit var referralRepository: ReferralRepository
+
+  @Test
+  fun `does not attempt resolution when event number is already non-zero`() {
+    val referral = ReferralEntityFactory().withEventNumber(4).produce()
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+
+    val result = service.resolveIfEventNumberIsZero(referral)
+
+    assertThat(result).isEqualTo(4)
+    verifyNoInteractions(nDeliusIntegrationApiClient)
+    verifyNoInteractions(referralRepository)
+  }
+
+  @Test
+  fun `updates referral event number when a valid number is found`() {
+    val referral = ReferralEntityFactory().withEventNumber(0).produce()
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+
+    `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, 1)).thenReturn(
+      ClientResult.Failure.StatusCode(HttpMethod.GET, "/case/${referral.crn}/sentence/1", HttpStatusCode.valueOf(404), null),
+    )
+    `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, 2)).thenReturn(
+      ClientResult.Failure.StatusCode(HttpMethod.GET, "/case/${referral.crn}/sentence/2", HttpStatusCode.valueOf(404), null),
+    )
+    `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, 3)).thenReturn(
+      ClientResult.Success(HttpStatusCode.valueOf(200), mockSentenceResponse()),
+    )
+
+    val result = service.resolveIfEventNumberIsZero(referral)
+
+    assertThat(result).isEqualTo(3)
+    assertThat(referral.eventNumber).isEqualTo(3)
+    verify(referralRepository).save(referral)
+    verify(nDeliusIntegrationApiClient).getSentenceInformation(referral.crn, 1)
+    verify(nDeliusIntegrationApiClient).getSentenceInformation(referral.crn, 2)
+    verify(nDeliusIntegrationApiClient).getSentenceInformation(referral.crn, 3)
+  }
+
+  @Test
+  fun `keeps event number as zero when no valid number is found`() {
+    val referral = ReferralEntityFactory().withEventNumber(0).produce()
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository)
+
+    (1..20).forEach { candidate ->
+      `when`(nDeliusIntegrationApiClient.getSentenceInformation(referral.crn, candidate)).thenReturn(
+        ClientResult.Failure.StatusCode(HttpMethod.GET, "/case/${referral.crn}/sentence/$candidate", HttpStatusCode.valueOf(404), null),
+      )
+    }
+
+    val result = service.resolveIfEventNumberIsZero(referral)
+
+    assertThat(result).isEqualTo(0)
+    assertThat(referral.eventNumber).isEqualTo(0)
+    verify(referralRepository, never()).save(referral)
+    (1..20).forEach { candidate ->
+      verify(nDeliusIntegrationApiClient).getSentenceInformation(referral.crn, candidate)
+    }
+  }
+
+  private fun mockSentenceResponse() = uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory().produce()
+}


### PR DESCRIPTION
**WHAT**

Created the `ReferralEventNumberResolverService`, and connected it to the `/referral-details/{id}/personal-details` route.

The `resolveIfEventNumberIsZero` method attempts to resolve the `eventNumber` all the way to `20` if it starts at 0 (i.e. if it was imported from the Data Importer Service)

Added custom event logging to AppInsights (as well as regular .info and .warn logging)

**WHY**

When data is imported from the Interventions Manager (IM) backup, we set the eventNumber to 0, because (so far) it appears that the IM data does not contain the eventNumber.

However, when we reach out to get any information about an offence, we require both the licence/requirement ID (which we *do* have) and the eventNumber.  Without it, nDelius/OASys return 4xx errors.

As a naieve solution to this problem, we can attempt to simply iterate up, one at a time, with Referrals.  We have been doing this manually as part of the data import checking process, and it appears to work (though is time consuming)

**HOW**

Introduced a new, single-purpose, service (`ReferralEventNumberResolutionService`) and plugged this into a single endpoint.

This implementation method allows for relatively easy extraction/removal, should a more sophisticated solution become available (e.g. an import from nDelius), and also allows configuration on a per-endpoint basis.
