### PR TITLE
APG-2169 Refactor `ProgrammeGroupService` and query filters for clarity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetGroupWaitlistItemSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetGroupWaitlistItemSpecification.kt
@@ -15,7 +15,7 @@ fun getGroupWaitlistItemSpecification(
   nameOrCRN: String?,
   pdu: String?,
   reportingTeams: List<String>?,
-): Specification<GroupWaitlistItemViewEntity> = Specification<GroupWaitlistItemViewEntity> { root, _, criteriaBuilder ->
+): Specification<GroupWaitlistItemViewEntity> = Specification { root, _, criteriaBuilder ->
   val predicates = mutableListOf<Predicate>()
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -136,12 +136,12 @@ fun incompleteMembershipCountSubquery(
   val isMembershipComplete = cb.and(
     isLatestReferralStatusProgrammeComplete(query, cb, referralJoin),
     hasAttendedPostProgrammeReview(incompleteMembershipCountSubquery, cb, groupMembershipRoot),
+    cb.isNotNull(groupMembershipRoot.get<LocalDateTime>("deletedAt")),
   )
 
   incompleteMembershipCountSubquery.select(cb.count(groupMembershipRoot))
   incompleteMembershipCountSubquery.where(
     cb.equal(groupMembershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
-    cb.isNull(groupMembershipRoot.get<LocalDateTime>("deletedAt")),
     cb.not(isMembershipComplete),
   )
   return incompleteMembershipCountSubquery

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -1,12 +1,29 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.specification
 
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Join
 import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import jakarta.persistence.criteria.Subquery
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ProgrammeGroupCohort
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.GroupPageByRegionTab
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.ProgrammeGroupSexEnum
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ModuleEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ModuleSessionTemplateEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceNDeliusOutcomeEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionEntity
+import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.jvm.java
 
 fun getProgrammeGroupsSpecification(
   groupCode: String?,
@@ -15,7 +32,7 @@ fun getProgrammeGroupsSpecification(
   cohort: ProgrammeGroupCohort?,
   sex: String?,
   regionName: String?,
-): Specification<ProgrammeGroupEntity> = Specification<ProgrammeGroupEntity> { root, _, cb ->
+): Specification<ProgrammeGroupEntity> = Specification { root, _, cb ->
   val predicates = mutableListOf<Predicate>()
 
   // Exclude soft-deleted
@@ -53,4 +70,107 @@ fun getProgrammeGroupsSpecification(
   }
 
   cb.and(*predicates.toTypedArray())
+}
+
+fun hasAttendedPostProgrammeReview(
+  parentSubquery: Subquery<Long>,
+  cb: CriteriaBuilder,
+  groupMembershipRoot: Root<ProgrammeGroupMembershipEntity>,
+): Predicate {
+  val postProgrammeReviewAttendanceSubquery = parentSubquery.subquery(Long::class.java)
+  val attendanceRoot = postProgrammeReviewAttendanceSubquery.from(SessionAttendanceEntity::class.java)
+  val sessionJoin = attendanceRoot.join<SessionAttendanceEntity, SessionEntity>("session")
+  val moduleSessionTemplateJoin = sessionJoin.join<SessionEntity, ModuleSessionTemplateEntity>("moduleSessionTemplate")
+  val moduleJoin = moduleSessionTemplateJoin.join<ModuleSessionTemplateEntity, ModuleEntity>("module")
+  val outcomeJoin = attendanceRoot.join<SessionAttendanceEntity, SessionAttendanceNDeliusOutcomeEntity>("outcomeType")
+
+  postProgrammeReviewAttendanceSubquery.select(cb.count(attendanceRoot))
+  postProgrammeReviewAttendanceSubquery.where(
+    cb.equal(attendanceRoot.get<ProgrammeGroupMembershipEntity>("groupMembership"), groupMembershipRoot),
+    cb.like(cb.lower(moduleJoin.get("name")), "post-programme%"),
+    cb.isFalse(sessionJoin.get("isPlaceholder")),
+    cb.isTrue(outcomeJoin.get("attendance")),
+    cb.isTrue(outcomeJoin.get("compliant")),
+  )
+
+  return cb.greaterThan(postProgrammeReviewAttendanceSubquery, 0L)
+}
+
+fun isLatestReferralStatusProgrammeComplete(
+  query: CriteriaQuery<*>,
+  cb: CriteriaBuilder,
+  referralJoin: Join<ProgrammeGroupMembershipEntity, ReferralEntity>,
+): Predicate {
+  val latestStatusCreatedAtSubquery = query.subquery(LocalDateTime::class.java)
+  val latestStatusHistoryRoot = latestStatusCreatedAtSubquery.from(ReferralStatusHistoryEntity::class.java)
+
+  latestStatusCreatedAtSubquery.select(cb.greatest(latestStatusHistoryRoot.get("createdAt")))
+  latestStatusCreatedAtSubquery.where(
+    cb.equal(latestStatusHistoryRoot.get<ReferralEntity>("referral"), referralJoin),
+  )
+
+  val programmeCompleteStatusExistsSubquery = query.subquery(Long::class.java)
+  val statusHistoryRoot = programmeCompleteStatusExistsSubquery.from(ReferralStatusHistoryEntity::class.java)
+  val referralStatusDescriptionJoin =
+    statusHistoryRoot.join<ReferralStatusHistoryEntity, ReferralStatusDescriptionEntity>("referralStatusDescription")
+
+  programmeCompleteStatusExistsSubquery.select(cb.literal(1L))
+  programmeCompleteStatusExistsSubquery.where(
+    cb.equal(statusHistoryRoot.get<ReferralEntity>("referral"), referralJoin),
+    cb.equal(statusHistoryRoot.get<LocalDateTime>("createdAt"), latestStatusCreatedAtSubquery),
+    cb.equal(referralStatusDescriptionJoin.get<String>("description"), "Programme complete"),
+  )
+
+  return cb.exists(programmeCompleteStatusExistsSubquery)
+}
+
+fun incompleteMembershipCountSubquery(
+  query: CriteriaQuery<*>,
+  cb: CriteriaBuilder,
+  root: Root<ProgrammeGroupEntity>,
+): Subquery<Long> {
+  val incompleteMembershipCountSubquery = query.subquery(Long::class.java)
+  val groupMembershipRoot = incompleteMembershipCountSubquery.from(ProgrammeGroupMembershipEntity::class.java)
+  val referralJoin = groupMembershipRoot.join<ProgrammeGroupMembershipEntity, ReferralEntity>("referral")
+
+  val isMembershipComplete = cb.and(
+    isLatestReferralStatusProgrammeComplete(query, cb, referralJoin),
+    hasAttendedPostProgrammeReview(incompleteMembershipCountSubquery, cb, groupMembershipRoot),
+  )
+
+  incompleteMembershipCountSubquery.select(cb.count(groupMembershipRoot))
+  incompleteMembershipCountSubquery.where(
+    cb.equal(groupMembershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
+    cb.isNull(groupMembershipRoot.get<LocalDateTime>("deletedAt")),
+    cb.not(isMembershipComplete),
+  )
+  return incompleteMembershipCountSubquery
+}
+
+fun getProgrammeGroupsByRegionTabSpecification(
+  selectedTab: GroupPageByRegionTab,
+): Specification<ProgrammeGroupEntity> = Specification { root, query, cb ->
+  val datePath = root.get<LocalDate>("earliestPossibleStartDate")
+  val incompleteMembershipCountSubquery = incompleteMembershipCountSubquery(query, cb, root)
+
+  when (selectedTab) {
+    GroupPageByRegionTab.NOT_STARTED_OR_IN_PROGRESS -> {
+      val notStartedOrInProgressDateSpec = cb.or(
+        cb.isNull(datePath),
+        cb.greaterThan(datePath, LocalDate.now()),
+      )
+
+      cb.or(
+        notStartedOrInProgressDateSpec,
+        cb.greaterThan(incompleteMembershipCountSubquery, 0L),
+      )
+    }
+
+    GroupPageByRegionTab.COMPLETE -> {
+      cb.and(
+        cb.lessThanOrEqualTo(datePath, LocalDate.now()),
+        cb.equal(incompleteMembershipCountSubquery, 0L),
+      )
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
@@ -150,6 +150,7 @@ class ProgrammeGroupMembershipService(
         ?: throw NotFoundException("No active Membership found for Referral (${referral.id}) and Group (${group.id})")
 
     val now = LocalDateTime.now()
+    //  Group membership is soft deleted
     groupMembership.deletedAt = now
     groupMembership.deletedByUsername = deletedByUsername
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
-import jakarta.persistence.criteria.Subquery
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -45,11 +43,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupFacilitatorEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupSessionSlotEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceNDeliusOutcomeEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionEntity
@@ -65,6 +59,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralReportingLocationRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.specification.getGroupWaitlistItemSpecification
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.specification.getProgrammeGroupsByRegionTabSpecification
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.specification.getProgrammeGroupsSpecification
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameContext
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameFormatter
@@ -667,15 +662,7 @@ class ProgrammeGroupService(
   ): GroupsByRegion {
     val groupCohort = if (cohort.isNullOrEmpty()) null else ProgrammeGroupCohort.fromString(cohort)
 
-    val distinctRegionDescriptions = userService.getUserRegions(username).map { it.description }.distinct()
-
-    if (distinctRegionDescriptions.isEmpty()) {
-      throw NotFoundException("Cannot find any regions (or teams) for user $username")
-    } else if (distinctRegionDescriptions.size > 1) {
-      log.warn("User $username has more than one region on their account, going to use '${distinctRegionDescriptions.first()}'")
-    }
-
-    val firstUserRegionDescription = distinctRegionDescriptions.first()
+    val firstUserRegionDescription = getFirstUserRegionDescription(username)
 
     // Base spec without startedAt filter (used for total count)
     val baseSpec = getProgrammeGroupsSpecification(
@@ -687,54 +674,7 @@ class ProgrammeGroupService(
       regionName = firstUserRegionDescription,
     )
 
-    // Apply tab-specific date filter
-    val startedAtSpec = Specification<ProgrammeGroupEntity> { root, query, cb ->
-      val datePath = root.get<LocalDate>("earliestPossibleStartDate")
-
-      // Subquery to find referrals that DO NOT have "Programme complete" status in their history
-      val subquery: Subquery<Long> = query.subquery(Long::class.java)
-      val membershipRoot = subquery.from(ProgrammeGroupMembershipEntity::class.java)
-      val referralJoin = membershipRoot.join<ProgrammeGroupMembershipEntity, ReferralEntity>("referral")
-
-      // We want to count memberships in this group where the referral DOES NOT have a "Programme complete" status
-      // To do this, we can check if there's no "Programme complete" status history for that referral.
-      val historySubquery: Subquery<Long> = subquery.subquery(Long::class.java)
-      val historyRoot = historySubquery.from(ReferralStatusHistoryEntity::class.java)
-      val statusDescJoin =
-        historyRoot.join<ReferralStatusHistoryEntity, ReferralStatusDescriptionEntity>("referralStatusDescription")
-
-      historySubquery.select(cb.count(historyRoot))
-      historySubquery.where(
-        cb.equal(historyRoot.get<ReferralEntity>("referral"), referralJoin),
-        cb.equal(statusDescJoin.get<String>("description"), "Programme complete"),
-      )
-
-      subquery.select(cb.count(membershipRoot))
-      subquery.where(
-        cb.equal(membershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
-        cb.equal(historySubquery, 0L),
-      )
-
-      when (selectedTab) {
-        GroupPageByRegionTab.NOT_STARTED_OR_IN_PROGRESS -> {
-          val notStartedOrInProgressDateSpec = cb.or(
-            cb.isNull(datePath),
-            cb.greaterThan(datePath, LocalDate.now()),
-          )
-
-          cb.or(notStartedOrInProgressDateSpec, cb.greaterThan(subquery, 0L))
-        }
-
-        GroupPageByRegionTab.COMPLETE -> {
-          val completeDateSpec = cb.lessThanOrEqualTo(datePath, LocalDate.now())
-
-          cb.and(completeDateSpec, cb.equal(subquery, 0L))
-        }
-      }
-    }
-
-    val activeSpec = baseSpec.and(startedAtSpec)
-
+    val activeSpec = baseSpec.and(getProgrammeGroupsByRegionTabSpecification(selectedTab))
     val pagedData: Page<Group> = programmeGroupRepository.findAll(activeSpec, pageable).map { it.toApi() }
 
     val totalForAllTabs: Long = programmeGroupRepository.count(baseSpec)
@@ -755,6 +695,18 @@ class ProgrammeGroupService(
       probationDeliveryUnitNames = allPduNames,
       deliveryLocationNames = deliveryLocationNames,
     )
+  }
+
+  private fun getFirstUserRegionDescription(username: String): String {
+    val distinctRegionDescriptions = userService.getUserRegions(username).map { it.description }.distinct()
+
+    if (distinctRegionDescriptions.isEmpty()) {
+      throw NotFoundException("Cannot find any regions (or teams) for user $username")
+    } else if (distinctRegionDescriptions.size > 1) {
+      log.warn("User $username has more than one region on their account, going to use '${distinctRegionDescriptions.first()}'")
+    }
+
+    return distinctRegionDescriptions.first()
   }
 
   fun getGroupSessionPage(groupId: UUID, sessionId: UUID): GroupSessionResponse {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -661,16 +661,17 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       )
 
       // Then
-      assertThat(response.pagedGroupData.totalElements).isEqualTo(4)
+      assertThat(response.pagedGroupData.totalElements).isEqualTo(5)
       val codes = response.pagedGroupData.content.map { it.code }
       assertThat(codes).containsExactlyInAnyOrder(
         "GROUP-A-NS-1",
         "GROUP-A-NS-2",
         "GROUP-A-NS-3",
         "GROUP-A-S-1",
+        "GROUP-A-C-1",
       )
-      // otherTabTotal should be count of started groups in the region (2)
-      assertThat(response.otherTabTotal).isEqualTo(2)
+      // otherTabTotal should be count of completed groups in the region
+      assertThat(response.otherTabTotal).isEqualTo(1)
       assertThat(response.regionName).isEqualTo("WIREMOCKED REGION")
     }
 
@@ -747,11 +748,13 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
       // Then: should contain only groups where all members are complete AND attended a post programme review
       // group5 is complete. group4 has no members. group3 is NOT complete because referral2 is "On Programme"
-      assertThat(response.pagedGroupData.totalElements).isEqualTo(2)
+      assertThat(response.pagedGroupData.totalElements).isEqualTo(1)
+
       val groupCodes = response.pagedGroupData.content.map { it.code }
-      assertThat(groupCodes).containsExactlyInAnyOrder("GROUP-A-C-1", "GROUP-A-S-2")
-      // otherTabTotal should be count of not-started or in progress groups (3: group1, group2, group3)
-      assertThat(response.otherTabTotal).isEqualTo(3)
+      assertThat(groupCodes).containsExactlyInAnyOrder("GROUP-A-S-2")
+
+      // otherTabTotal should be count of not-started or in progress groups (4: group1, group2, group3, group4)
+      assertThat(response.otherTabTotal).isEqualTo(4)
       assertThat(response.regionName).isEqualTo("WIREMOCKED REGION")
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -59,11 +59,17 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.PagedProgrammeDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomWord
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ModuleSessionTemplateEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupSessionSlotEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceNDeliusOutcomeEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionNotesHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.Pathway
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode.ATTC
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode.UAAB
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.HmppsDomainEventTypes
@@ -89,6 +95,8 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionAttendanceOutcomeTypeRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionAttendanceRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ProgrammeGroupMembershipService
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralService
@@ -127,6 +135,12 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var nDeliusAppointmentRepository: NDeliusAppointmentRepository
+
+  @Autowired
+  private lateinit var sessionAttendanceOutcomeTypeRepository: SessionAttendanceOutcomeTypeRepository
+
+  @Autowired
+  private lateinit var sessionAttendanceRepository: SessionAttendanceRepository
 
   @Autowired
   private lateinit var scheduleService: ScheduleService
@@ -526,6 +540,62 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
   @Nested
   @DisplayName("Get programme groups by region")
   inner class GetProgrammeGroupsByRegionTests {
+    private lateinit var attendedCompliedOutcome: SessionAttendanceNDeliusOutcomeEntity
+    private lateinit var unacceptableAbsenceOutcome: SessionAttendanceNDeliusOutcomeEntity
+
+    @BeforeEach
+    fun setupOutcomes() {
+      attendedCompliedOutcome = sessionAttendanceOutcomeTypeRepository.save(
+        SessionAttendanceNDeliusOutcomeEntity(
+          code = ATTC,
+          description = "Attended - Complied",
+          attendance = true,
+          compliant = true,
+        ),
+      )
+      unacceptableAbsenceOutcome = sessionAttendanceOutcomeTypeRepository.save(
+        SessionAttendanceNDeliusOutcomeEntity(
+          code = UAAB,
+          description = "Unacceptable Absence",
+          attendance = false,
+          compliant = false,
+        ),
+      )
+    }
+
+    private fun setupPostProgrammeReviewForGroup(group: ProgrammeGroupEntity, memberships: List<ProgrammeGroupMembershipEntity>, attended: Boolean = true) {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Post-programme reviews", 1)
+
+      val moduleSessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 1,
+          sessionType = SessionType.GROUP,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Post-programme review",
+          durationMinutes = 120,
+        ),
+      )
+
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(moduleSessionTemplate)
+          .produce(),
+      )
+
+      memberships.forEach { membership ->
+        sessionAttendanceRepository.save(
+          SessionAttendanceEntity(
+            session = session,
+            groupMembership = membership,
+            outcomeType = if (attended) attendedCompliedOutcome else unacceptableAbsenceOutcome,
+          ),
+        )
+      }
+    }
+
     @Test
     fun `should return NOT_STARTED OR IN PROGRESS groups only with correct otherTabTotal`() {
       // Given
@@ -565,40 +635,45 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val referral2 = testDataGenerator.createReferral(personName = "GROUP-A-S-1-On-Programme", crn = "X123457")
       val referral3 = testDataGenerator.createReferral(personName = "GROUP-A-C-1-Completed", crn = "X123458")
 
-      testDataGenerator.allocateReferralsToGroup(listOf(referral1, referral2), group4)
-      testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6)
+      val groupMembership1 = testDataGenerator.allocateReferralsToGroup(listOf(referral1), group4).first()
+      val groupMembership2 = testDataGenerator.allocateReferralsToGroup(listOf(referral2), group4).first()
+      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6).first()
 
-      val referralStatusDescriptionCompleted =
-        referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
-      val referralStatusDescriptionOnProgramme = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
+      // Set up PPR for group6 (Completed group)
+      setupPostProgrammeReviewForGroup(group6, listOf(groupMembership3), attended = true)
+      // Set up PPR for group4 (Started group) but one member has not attended
+      setupPostProgrammeReviewForGroup(group4, listOf(groupMembership1, groupMembership2), attended = false)
+
+      val programmeCompleteReferralStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
+      val onProgrammeReferralStatus = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral1,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral1,
-          referralStatusDescriptionCompleted,
+          programmeCompleteReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral2,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral3,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral3,
-          referralStatusDescriptionCompleted,
+          programmeCompleteReferralStatus,
         ),
       )
 
@@ -633,12 +708,10 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         .withEarliestStartDate(LocalDate.now().plusDays(5)).produce()
       val group2 = ProgrammeGroupFactory().withCode("GROUP-A-NS-2").withRegionName(region)
         .withEarliestStartDate(LocalDate.now().plusDays(5)).produce()
-
       val group3 = ProgrammeGroupFactory().withCode("GROUP-A-S-1").withRegionName(region)
         .withEarliestStartDate(LocalDate.now().minusDays(5)).produce()
       val group4 = ProgrammeGroupFactory().withCode("GROUP-A-S-2").withRegionName(region)
         .withEarliestStartDate(LocalDate.now().minusDays(1)).produce()
-
       val group5 = ProgrammeGroupFactory().withCode("GROUP-A-C-1").withRegionName(region)
         .withEarliestStartDate(LocalDate.now().minusDays(5)).produce()
 
@@ -648,40 +721,44 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val referral2 = testDataGenerator.createReferral(personName = "GROUP-A-S-1-On-Programme", crn = "X123457")
       val referral3 = testDataGenerator.createReferral(personName = "GROUP-A-C-1-Completed", crn = "X123458")
 
-      testDataGenerator.allocateReferralsToGroup(listOf(referral1, referral2), group3)
-      testDataGenerator.allocateReferralsToGroup(listOf(referral3), group5)
+      val groupMembership1 = testDataGenerator.allocateReferralsToGroup(listOf(referral1), group3).first()
+      val groupMembership2 = testDataGenerator.allocateReferralsToGroup(listOf(referral2), group3).first()
+      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group5).first()
 
-      val referralStatusDescriptionCompleted =
-        referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
-      val referralStatusDescriptionOnProgramme = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
+      // Set up PPR attendance
+      setupPostProgrammeReviewForGroup(group5, listOf(groupMembership3), attended = true)
+      setupPostProgrammeReviewForGroup(group3, listOf(groupMembership1, groupMembership2), attended = true)
+
+      val programmeCompleteReferralStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
+      val onProgrammeReferralStatus = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral1,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral1,
-          referralStatusDescriptionCompleted,
+          programmeCompleteReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral2,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral3,
-          referralStatusDescriptionOnProgramme,
+          onProgrammeReferralStatus,
         ),
       )
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral3,
-          referralStatusDescriptionCompleted,
+          programmeCompleteReferralStatus,
         ),
       )
 
@@ -692,11 +769,12 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         object : ParameterizedTypeReference<GroupsByRegionResponse<Group>>() {},
       )
 
-      // Then: should contain only started groups
+      // Then: should contain only groups where all members are complete AND attended a post programme review
+      // group5 is complete. group4 has no members. group3 is NOT complete because referral2 is "On Programme"
       assertThat(response.pagedGroupData.totalElements).isEqualTo(2)
-      val codes = response.pagedGroupData.content.map { it.code }
-      assertThat(codes).containsExactlyInAnyOrder("GROUP-A-C-1", "GROUP-A-S-2")
-      // otherTabTotal should be count of not-started or in progress groups (3)
+      val groupCodes = response.pagedGroupData.content.map { it.code }
+      assertThat(groupCodes).containsExactlyInAnyOrder("GROUP-A-C-1", "GROUP-A-S-2")
+      // otherTabTotal should be count of not-started or in progress groups (3: group1, group2, group3)
       assertThat(response.otherTabTotal).isEqualTo(3)
       assertThat(response.regionName).isEqualTo("WIREMOCKED REGION")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -547,22 +547,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setupOutcomes() {
-      attendedCompliedOutcome = sessionAttendanceOutcomeTypeRepository.save(
-        SessionAttendanceNDeliusOutcomeEntity(
-          code = ATTC,
-          description = "Attended - Complied",
-          attendance = true,
-          compliant = true,
-        ),
-      )
-      unacceptableAbsenceOutcome = sessionAttendanceOutcomeTypeRepository.save(
-        SessionAttendanceNDeliusOutcomeEntity(
-          code = UAAB,
-          description = "Unacceptable Absence",
-          attendance = false,
-          compliant = false,
-        ),
-      )
+      attendedCompliedOutcome = sessionAttendanceOutcomeTypeRepository.findByCode(ATTC)!!
+      unacceptableAbsenceOutcome = sessionAttendanceOutcomeTypeRepository.findByCode(UAAB)!!
     }
 
     private fun setupPostProgrammeReviewForGroup(group: ProgrammeGroupEntity, memberships: List<ProgrammeGroupMembershipEntity>, attended: Boolean = true) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -59,7 +59,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.PagedProgrammeDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomWord
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ModuleSessionTemplateEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupSessionSlotEntity
@@ -68,7 +67,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceNDeliusOutcomeEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionNotesHistoryEntity
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.Pathway
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode.ATTC
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode.UAAB
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
@@ -91,6 +89,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fact
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.ProgrammeGroupFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.SessionFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.NDeliusAppointmentRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
@@ -141,6 +140,9 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var sessionAttendanceRepository: SessionAttendanceRepository
+
+  @Autowired
+  private lateinit var moduleSessionTemplateRepository: ModuleSessionTemplateRepository
 
   @Autowired
   private lateinit var scheduleService: ScheduleService
@@ -564,24 +566,12 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     private fun setupPostProgrammeReviewForGroup(group: ProgrammeGroupEntity, memberships: List<ProgrammeGroupMembershipEntity>, attended: Boolean = true) {
-      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
-      val module = testDataGenerator.createModule(programmeTemplate, "Post-programme reviews", 1)
-
-      val moduleSessionTemplate = testDataGenerator.createModuleSessionTemplate(
-        ModuleSessionTemplateEntity(
-          module = module,
-          sessionNumber = 1,
-          sessionType = SessionType.GROUP,
-          pathway = Pathway.MODERATE_INTENSITY,
-          name = "Post-programme review",
-          durationMinutes = 120,
-        ),
-      )
+      val postProgrammeReviewSessionTemplate = moduleSessionTemplateRepository.findByName("Post-programme review")
 
       val session = testDataGenerator.createSession(
         SessionFactory()
           .withProgrammeGroup(group)
-          .withModuleSessionTemplate(moduleSessionTemplate)
+          .withModuleSessionTemplate(postProgrammeReviewSessionTemplate!!)
           .produce(),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
@@ -23,6 +23,8 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralReportingLocationEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceNDeliusOutcomeEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.Pathway
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
@@ -155,6 +157,16 @@ class TestDataGenerator {
       val statusHistory = ReferralStatusHistoryEntityFactory().produce(referral, it)
       entityManager.persist(statusHistory)
     }
+  }
+
+  fun createSessionAttendance(sessionAttendance: SessionAttendanceEntity): SessionAttendanceEntity {
+    entityManager.persist(sessionAttendance)
+    return sessionAttendance
+  }
+
+  fun createSessionAttendanceOutcome(outcome: SessionAttendanceNDeliusOutcomeEntity): SessionAttendanceNDeliusOutcomeEntity {
+    entityManager.persist(outcome)
+    return outcome
   }
 
   fun createGroupMembership(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
@@ -264,6 +264,7 @@ class ProgrammeGroupServiceIntegrationTest : IntegrationTestBase() {
           .withCode("COMPLETED_GROUP")
           .withRegionName("Region Description")
           .withEarliestStartDate(LocalDate.now().minusDays(10))
+          .withDeletedAt(LocalDateTime.now())
           .produce(),
       )
       val referral1 = testDataGenerator.createReferral("Person 1", "CRN1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
@@ -25,10 +25,13 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupFacilitatorEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupSessionSlotEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.FacilitatorType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FacilitatorEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusHistoryEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.SessionAttendanceNDeliusOutcomeEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupRequestFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupSessionSlotFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupTeamMemberFactory
@@ -38,6 +41,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.inte
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionAttendanceOutcomeTypeRepository
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -60,6 +64,9 @@ class ProgrammeGroupServiceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var referralStatusDescriptionRepository: ReferralStatusDescriptionRepository
+
+  @Autowired
+  private lateinit var sessionAttendanceOutcomeTypeRepository: SessionAttendanceOutcomeTypeRepository
 
   @Nested
   @DisplayName("getProgrammeGroupsForRegion")
@@ -268,7 +275,30 @@ class ProgrammeGroupServiceIntegrationTest : IntegrationTestBase() {
             referralStatusDescription = statusComplete,
           ),
       )
-      testDataGenerator.allocateReferralsToGroup(listOf(referral1), completedGroup)
+      val memberships = testDataGenerator.allocateReferralsToGroup(listOf(referral1), completedGroup)
+
+      // Setup post-programme review attendance to make it "complete"
+      val template = testDataGenerator.createAccreditedProgrammeTemplate("Template")
+      val module = testDataGenerator.createModule(template, "post-programme review", 1)
+      val moduleSessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        module = module,
+        name = "Post Programme Session",
+        sessionNumber = 1,
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory(programmeGroup = completedGroup, moduleSessionTemplate = moduleSessionTemplate).produce(),
+      )
+      val outcome = sessionAttendanceOutcomeTypeRepository.findByCode(SessionAttendanceNDeliusCode.ATTC)
+        ?: testDataGenerator.createSessionAttendanceOutcome(
+          SessionAttendanceNDeliusOutcomeEntityFactory().withCode(SessionAttendanceNDeliusCode.ATTC).produce(),
+        )
+      testDataGenerator.createSessionAttendance(
+        SessionAttendanceEntity(
+          session = session,
+          groupMembership = memberships.first(),
+          outcomeType = outcome,
+        ),
+      )
 
       // Given a group that has one completed and one not completed referral (should be in NOT_STARTED_OR_IN_PROGRESS tab)
       val partiallyCompletedGroup = testDataGenerator.createGroup(


### PR DESCRIPTION
This pull request includes the following changes:
- Simplified the logic within `ProgrammeGroupService` by criteria based code to Specification specific classes
- Added criteria filtering for the COMPLETE group tab to include referrals that have a status of Programme Complete, and also ensuring that each referral has an attendance of the final Post programme review session
- Modularized the query filters for region tabs, making them more maintainable and reusable.
- Increased test coverage to verify the refactored components.