### PR TITLE
APG-2270 Remove JSON format annotation from licence expiry data in de…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusSentenceResponse.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
@@ -17,7 +16,6 @@ data class NDeliusSentenceResponse(
   val expectedEndDate: LocalDate? = null,
 
   @get:JsonProperty("licenceExpiryDate", required = false)
-  @JsonFormat(pattern = "d MMMM yyyy")
   val licenceExpiryDate: LocalDate? = null,
 
   @get:JsonProperty("postSentenceSupervisionEndDate", required = false)


### PR DESCRIPTION
This PR is to fix the following error that was identified when looking at pre prod data in the UI

```bash
Failed to deserialize java.time.LocalDate: (java.time.format.DateTimeParseException) Text '2028-02-11' could not be parsed at index 4
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 134] (through reference chain: uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse["licenceExpiryDate"]). | trace_id=f298d8a3f1c1e30bf522c46d88c7f819, trace_flags=03, span_id=b54163cc730fad92
```