### PR TITLE
Apg 2271/Fix NoSuchElementException when there are no attendees for a ONE_TO_ONE session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
@@ -195,8 +195,7 @@ class SessionNameFormatter {
       SessionType.GROUP -> "${session.moduleSessionTemplate.module.name} ${session.sessionNumber}: ${session.moduleSessionTemplate.name}$catchupSuffix"
 
       SessionType.ONE_TO_ONE -> {
-        requireNotNull(session.attendees.first()) { "Person name is required for individual sessions" }
-        "${session.attendees.first().personName}: ${session.moduleSessionTemplate.name}$catchupSuffix"
+        if (session.attendees.isEmpty()) "${session.moduleSessionTemplate.name}$catchupSuffix" else "${session.attendees.first().personName}: ${session.moduleSessionTemplate.name}$catchupSuffix"
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
@@ -682,6 +682,36 @@ class SessionNameFormatterTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `should return templateName for one-to-one session without an attendee`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 3,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Getting started one-to-one",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.SessionDetails))
+        .isEqualTo("Getting started one-to-one")
+    }
+
+    @Test
     fun `returns personName templateName catch-up for one-to-one catchup session`() {
       val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
       val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)


### PR DESCRIPTION
Fix NoSuchElementException when there are no attendees for a ONE_TO_ONE session. Currently when a referral is removed from a group all the future one-to-one sessions exist with no attendees