### PR TITLE
APG-2158 Automatically refresh cohort on referral details page

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/JpaAuditConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/JpaAuditConfig.kt
@@ -13,6 +13,9 @@ import java.util.Optional
 class JpaAuditConfig {
   @Bean
   fun auditorAware() = AuditorAware {
+    val override = AuditorContext.get()
+    if (override != null) return@AuditorAware Optional.of(override)
+
     Optional.ofNullable(
       when (val principal = SecurityContextHolder.getContext().authentication?.principal) {
         is String -> principal
@@ -22,4 +25,12 @@ class JpaAuditConfig {
       },
     )
   }
+}
+
+object AuditorContext {
+  private val auditor = ThreadLocal<String?>()
+
+  fun set(value: String?) = auditor.set(value)
+  fun get(): String? = auditor.get()
+  fun clear() = auditor.remove()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralCohortHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralCohortHistoryEntity.kt
@@ -13,10 +13,8 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.ColumnDefault
-import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import java.time.LocalDateTime
 import java.util.UUID
@@ -43,8 +41,7 @@ class ReferralCohortHistoryEntity(
 
   @NotNull
   @Column(name = "created_by")
-  @CreatedBy
-  var createdBy: String? = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
+  var createdBy: String,
 
   @NotNull
   @Column(name = "created_at")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralLdcHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralLdcHistoryEntity.kt
@@ -41,14 +41,15 @@ open class ReferralLdcHistoryEntity(
   @NotNull
   @Column(name = "created_by")
   @CreatedBy
-  open var createdBy: String? = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
+  var createdBy: String? = SecurityContextHolder.getContext().authentication?.name,
 
   @NotNull
   @CreatedDate
   open var createdAt: LocalDateTime? = LocalDateTime.now(),
 )
 
-fun UpdateLdc.toEntity(referralEntity: ReferralEntity): ReferralLdcHistoryEntity = ReferralLdcHistoryEntity(
+fun UpdateLdc.toEntity(referralEntity: ReferralEntity, createdBy: String? = null): ReferralLdcHistoryEntity = ReferralLdcHistoryEntity(
   referral = referralEntity,
   hasLdc = hasLdc,
+  createdBy = createdBy,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.RiskScoreLevel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.AuditorContext
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralCohortHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralCohortHistoryRepository
@@ -19,14 +21,29 @@ class CohortService(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun updateCohortForReferral(referralEntity: ReferralEntity, cohort: OffenceCohort): ReferralEntity {
-    log.info("Updating cohort to '$cohort' for referral with Id: '${referralEntity.id}'")
-    referralCohortHistoryRepository.save(
-      ReferralCohortHistoryEntity(
-        referral = referralEntity,
-        cohort = cohort,
-      ),
-    )
+  fun updateCohortForReferral(
+    referralEntity: ReferralEntity,
+    cohort: OffenceCohort,
+    createdBy: String = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
+  ): ReferralEntity {
+    // Overwrite the username to be written when system is automatically updating this value
+    AuditorContext.set(createdBy)
+    try {
+      val latestCohortHistory =
+        referralCohortHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralEntity.id!!)
+      if (latestCohortHistory?.cohort != cohort) {
+        log.info("Updating cohort to '$cohort' for referral with Id: '${referralEntity.id}'")
+        referralCohortHistoryRepository.save(
+          ReferralCohortHistoryEntity(
+            referral = referralEntity,
+            cohort = cohort,
+            createdBy = createdBy,
+          ),
+        )
+      }
+    } finally {
+      AuditorContext.clear()
+    }
     return referralEntity
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LdcService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LdcService.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ldc.UpdateLdc
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.AuditorContext
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.toEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralLdcHistoryRepository
@@ -15,9 +17,23 @@ class LdcService(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun updateLdcStatusForReferral(referralEntity: ReferralEntity, updateLdc: UpdateLdc) {
-    log.info("Updating LDC status to '${updateLdc.hasLdc}' for referral with Id: '${referralEntity.id}'")
-    ldcHistoryRepository.save(updateLdc.toEntity(referralEntity))
+  fun updateLdcStatusForReferral(
+    referralEntity: ReferralEntity,
+    updateLdc: UpdateLdc,
+    createdBy: String = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
+  ) {
+    // Overwrite the username to be written when system is automatically updating this value
+    AuditorContext.set(createdBy)
+    try {
+      val latestLdcHistory = ldcHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralEntity.id!!)
+      if (latestLdcHistory?.hasLdc != updateLdc.hasLdc) {
+        log.info("Updating LDC status to '${updateLdc.hasLdc}' for referral with Id: '${referralEntity.id}'")
+        val entity = updateLdc.toEntity(referralEntity)
+        ldcHistoryRepository.save(entity)
+      }
+    } finally {
+      AuditorContext.clear()
+    }
   }
 
   fun hasOverriddenLdcStatus(referralId: UUID): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -83,8 +83,8 @@ class ReferralService(
   suspend fun refreshPersonalDetailsForReferral(referralId: UUID): ReferralDetails? = coroutineScope {
     val referral = referralRepository.findByIdWithMemberships(referralId) ?: return@coroutineScope null
 
-    val hasLdcDeferred = async(Dispatchers.IO) {
-      pniService.getPniResponse(referral.crn)?.hasLdc() ?: false
+    val pniDeferred = async(Dispatchers.IO) {
+      pniService.getPniResponse(referral.crn)
     }
 
     val personalDetailsDeferred = async(Dispatchers.IO) {
@@ -99,10 +99,18 @@ class ReferralService(
       )
     }
 
-    val hasLdc = hasLdcDeferred.await()
+    val pniResponse = pniDeferred.await()
+
+    val hasLdc = pniResponse?.hasLdc() ?: false
+    val cohort =
+      pniResponse?.let { cohortService.determineOffenceCohort(it.toPniScore()) } ?: OffenceCohort.GENERAL_OFFENCE
 
     if (!ldcService.hasOverriddenLdcStatus(referralId)) {
-      ldcService.updateLdcStatusForReferral(referral, UpdateLdc(hasLdc))
+      ldcService.updateLdcStatusForReferral(referral, UpdateLdc(hasLdc), "SYSTEM")
+    }
+
+    if (!cohortService.hasOverriddenCohort(referralId)) {
+      cohortService.updateCohortForReferral(referral, cohort, "SYSTEM")
     }
 
     val personalDetails = personalDetailsDeferred.await()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralControllerIntegrationTest.kt
@@ -145,7 +145,7 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.personName).isEqualTo(nDeliusPersonalDetails.name.getNameAsString())
       assertThat(response.dateOfBirth).isEqualTo(nDeliusPersonalDetails.dateOfBirth)
       assertThat(response.createdAt).isEqualTo(savedReferral.createdAt.toLocalDate())
-      assertThat(response.cohort).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
+      assertThat(response.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
       assertThat(response.probationPractitionerName)
         .isEqualTo(nDeliusPersonalDetails.probationPractitioner!!.name.getNameAsString())
       assertThat(response.probationPractitionerEmail)
@@ -166,7 +166,8 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
         referralEntity,
         referralStatusDescriptionRepository.getAwaitingAssessmentStatusDescription(),
       )
-      val cohortHistory = ReferralCohortHistoryFactory().withReferral(referralEntity).produce()
+      val cohortHistory =
+        ReferralCohortHistoryFactory().withCohort(OffenceCohort.SEXUAL_OFFENCE).withReferral(referralEntity).produce()
 
       testDataGenerator.createReferralWithFields(
         referralEntity,
@@ -196,7 +197,7 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.personName).isEqualTo(nDeliusPersonalDetails.name.getNameAsString())
       assertThat(response.dateOfBirth).isEqualTo(nDeliusPersonalDetails.dateOfBirth)
       assertThat(response.createdAt).isEqualTo(savedReferral.createdAt.toLocalDate())
-      assertThat(response.cohort).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
+      assertThat(response.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
       assertThat(response.probationPractitionerName)
         .isEqualTo(nDeliusPersonalDetails.probationPractitioner!!.name.getNameAsString())
       assertThat(response.probationPractitionerEmail)
@@ -253,7 +254,7 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.personName).isEqualTo(nDeliusPersonalDetails.name.getNameAsString())
       assertThat(response.dateOfBirth).isEqualTo(nDeliusPersonalDetails.dateOfBirth)
       assertThat(response.createdAt).isEqualTo(savedReferral.createdAt.toLocalDate())
-      assertThat(response.cohort).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
+      assertThat(response.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
       assertThat(response.probationPractitionerName)
         .isEqualTo(nDeliusPersonalDetails.probationPractitioner!!.name.getNameAsString())
       assertThat(response.probationPractitionerEmail)
@@ -307,7 +308,7 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(response.personName).isEqualTo(nDeliusPersonalDetails.name.getNameAsString())
       assertThat(response.dateOfBirth).isEqualTo(nDeliusPersonalDetails.dateOfBirth)
       assertThat(response.createdAt).isEqualTo(savedReferral.createdAt.toLocalDate())
-      assertThat(response.cohort).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
+      assertThat(response.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
       assertThat(response.probationPractitionerName)
         .isEqualTo(nDeliusPersonalDetails.probationPractitioner!!.name.getNameAsString())
       assertThat(response.probationPractitionerEmail)
@@ -489,6 +490,94 @@ class ReferralControllerIntegrationTest(@Autowired private val programmeGroupMem
       assertThat(updatedReferral.referralLdcHistories).isNotEmpty()
       val latestLdcEntry = updatedReferral.referralLdcHistories.maxByOrNull { it.createdAt!! }
       assertThat(latestLdcEntry?.hasLdc).isFalse()
+    }
+
+    @Test
+    fun `should update cohort when user has not overwritten cohort entry and cohort has changed`() {
+      // Given
+      val referralEntity = ReferralEntityFactory()
+        .produce()
+      val statusHistory = ReferralStatusHistoryEntityFactory().produce(
+        referralEntity,
+        referralStatusDescriptionRepository.getAwaitingAssessmentStatusDescription(),
+      )
+      val cohortHistory = ReferralCohortHistoryFactory().withReferral(referralEntity).produce()
+
+      testDataGenerator.createReferralWithFields(
+        referralEntity,
+        listOf(statusHistory, cohortHistory),
+      )
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+
+      val nDeliusPersonalDetails = NDeliusPersonalDetailsFactory().produce()
+
+      nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(nDeliusPersonalDetails)
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(referralEntity.crn, referralEntity.eventNumber)
+
+      oasysApiStubs.stubSuccessfulPniResponse(referralEntity.crn)
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}",
+        returnType = object : ParameterizedTypeReference<ReferralDetails>() {},
+      )
+
+      // Then
+      assertThat(response.id).isEqualTo(savedReferral.id)
+      assertThat(response.crn).isEqualTo(savedReferral.crn)
+
+      val updatedReferral = referralRepository.findByCrn(referralEntity.crn).first()
+      assertThat(updatedReferral.referralCohortHistories).isNotEmpty()
+      val latestCohortEntry = updatedReferral.referralCohortHistories.maxByOrNull { it.createdAt }
+      assertThat(latestCohortEntry?.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
+    }
+
+    @Test
+    fun `should not update cohort when user has overwritten cohort entry and cohort has changed`() {
+      // Given
+      val referralEntity = ReferralEntityFactory()
+        .produce()
+      val statusHistory = ReferralStatusHistoryEntityFactory().produce(
+        referralEntity,
+        referralStatusDescriptionRepository.getAwaitingAssessmentStatusDescription(),
+      )
+      val cohortHistory =
+        ReferralCohortHistoryFactory()
+          .withReferral(referralEntity)
+          .withCohort(OffenceCohort.GENERAL_OFFENCE)
+          .withCreatedBy("TEST_USER").produce()
+
+      testDataGenerator.createReferralWithFields(
+        referralEntity,
+        listOf(statusHistory, cohortHistory),
+      )
+      val savedReferral = referralRepository.findByCrn(referralEntity.crn)[0]
+
+      val nDeliusPersonalDetails = NDeliusPersonalDetailsFactory().produce()
+
+      nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(nDeliusPersonalDetails)
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(referralEntity.crn, referralEntity.eventNumber)
+
+      oasysApiStubs.stubSuccessfulPniResponse(referralEntity.crn)
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/referral-details/${savedReferral.id}",
+        returnType = object : ParameterizedTypeReference<ReferralDetails>() {},
+      )
+
+      // Then
+      assertThat(response.id).isEqualTo(savedReferral.id)
+      assertThat(response.crn).isEqualTo(savedReferral.crn)
+
+      val updatedReferral = referralRepository.findByCrn(referralEntity.crn).first()
+      assertThat(updatedReferral.referralCohortHistories).isNotEmpty()
+      val latestCohortEntry = updatedReferral.referralCohortHistories.maxByOrNull { it.createdAt }
+      assertThat(latestCohortEntry?.cohort).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataCleaner.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataCleaner.kt
@@ -20,6 +20,7 @@ class TestDataCleaner(
       createNativeQuery("TRUNCATE TABLE message_history CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE referral_status_history CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE referral_ldc_history CASCADE").executeUpdate()
+      createNativeQuery("TRUNCATE TABLE referral_cohort_history CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE referral CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE preferred_delivery_location_probation_delivery_unit CASCADE").executeUpdate()
       createNativeQuery("TRUNCATE TABLE preferred_delivery_location CASCADE").executeUpdate()


### PR DESCRIPTION
## WHAT

This PR adds the functionality to update the cohort when the `referral-details` endpoint is called. The value will be overwritten if;
* It is different that the current value
* AND it has not been previously set by the user

## NOTES

As part of the implementation of this feature I realised the LDC value was never being updated due to the user always being set as the logged in user rather than our `SYSTEM` value. This has been fixed and also applied to the cohort update