### PR TITLE
APG-2158 Fix all cohort values being assigned to SEXUAL_OFFENCE 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
@@ -67,7 +67,7 @@ class CohortService(
     return listOfNotNull(ospDc, ospIic).any { isSignificantRisk(it) }
   }
 
-  private fun isSignificantRisk(riskLevel: String): Boolean = riskLevel != RiskScoreLevel.NOT_APPLICABLE.toString()
+  private fun isSignificantRisk(riskLevel: String): Boolean = riskLevel != RiskScoreLevel.NOT_APPLICABLE.type
 
   private fun hasSignificantSexDomainScore(pniScore: PniScore): Boolean = with(pniScore.domainScores.sexDomainScore.individualSexScores) {
     listOfNotNull(sexualPreOccupation, offenceRelatedSexualInterests, emotionalCongruence)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortServiceTest.kt
@@ -37,8 +37,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when OSP DC score is significant`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("HIGH", "NOT_APPLICABLE", 0, 0, 0)
+    val pniScore = createBasePniScore("High", "Not Applicable", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -46,8 +45,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when OSP IIC score is significant`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "MEDIUM", 0, 0, 0)
+    val pniScore = createBasePniScore("Not Applicable", "MEDIUM", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -55,8 +53,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when both OSP scores are significant`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("MEDIUM", "HIGH", 0, 0, 0)
+    val pniScore = createBasePniScore("MEDIUM", "High", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -64,8 +61,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when sexual preoccupation is above zero`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", 1, 0, 0)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", 1, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -73,8 +69,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when offence related sexual interests is above zero`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", 0, 2, 0)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", 0, 2, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -82,8 +77,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when emotional congruence is above zero`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", 0, 0, 1)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", 0, 0, 1)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -91,8 +85,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when multiple sex domain scores are above zero`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", 1, 2, 1)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", 1, 2, 1)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -100,8 +93,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when both OSP and sex domain criteria are met`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("MEDIUM", "HIGH", 1, 2, 1)
+    val pniScore = createBasePniScore("MEDIUM", "High", 1, 2, 1)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -109,8 +101,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return GENERAL_OFFENCE when all scores are not significant`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", 0, 0, 0)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.GENERAL_OFFENCE)
@@ -118,7 +109,6 @@ class CohortServiceTest {
 
   @Test
   fun `should return GENERAL_OFFENCE when OSP scores are null`() {
-    val crn = "TEST123"
     val pniScore = createBasePniScore(null, null, 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
@@ -127,8 +117,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return GENERAL_OFFENCE when sex domain scores are null`() {
-    val crn = "TEST123"
-    val pniScore = createBasePniScore("NOT_APPLICABLE", "NOT_APPLICABLE", null, null, null)
+    val pniScore = createBasePniScore("Not Applicable", "Not Applicable", null, null, null)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.GENERAL_OFFENCE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortServiceTest.kt
@@ -45,7 +45,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when OSP IIC score is significant`() {
-    val pniScore = createBasePniScore("Not Applicable", "MEDIUM", 0, 0, 0)
+    val pniScore = createBasePniScore("Not Applicable", "Medium", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -53,7 +53,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when both OSP scores are significant`() {
-    val pniScore = createBasePniScore("MEDIUM", "High", 0, 0, 0)
+    val pniScore = createBasePniScore("Medium", "High", 0, 0, 0)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
@@ -93,7 +93,7 @@ class CohortServiceTest {
 
   @Test
   fun `should return SEXUAL_OFFENCE when both OSP and sex domain criteria are met`() {
-    val pniScore = createBasePniScore("MEDIUM", "High", 1, 2, 1)
+    val pniScore = createBasePniScore("Medium", "High", 1, 2, 1)
 
     val result = cohortService.determineOffenceCohort(pniScore)
     assertThat(result).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)


### PR DESCRIPTION
Currently all referrals which have a completed OASYs assessment are being assigned to the `SEXUAL_OFFENCE` cohort. This is due to when calculating the cohort the ENUM object is being used as the value itself
```kotlin
RiskScoreLevel.NOT_APPLICABLE.toString()
```
This gives a value = `NOT_APPLICABLE` whereas the value being returned from the Oasys endpoint looks like `Not Applicable` which is what we have called the `type` on the ENUM class. 

The fix is to use the `type` rather than the `.toString()` value when calculating the cohort.

## NOTE

When checking any referrals currently in prod there are some that are `GENERAL_OFFENCE` this is because these referrals are missing the OASYs assessment and therefore the values are null in which we always default to `GENERAL_OFFENCE`