### PR TITLE
Refactor `getFirstUserRegionDescription` into `UserService`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -666,7 +666,7 @@ class ProgrammeGroupService(
   ): GroupsByRegion {
     val groupCohort = if (cohort.isNullOrEmpty()) null else ProgrammeGroupCohort.fromString(cohort)
 
-    val firstUserRegionDescription = getFirstUserRegionDescription(username)
+    val firstUserRegionDescription = userService.getFirstUserRegionDescription(username)
 
     // Base spec without startedAt filter (used for total count)
     val baseSpec = getProgrammeGroupsSpecification(
@@ -699,18 +699,6 @@ class ProgrammeGroupService(
       probationDeliveryUnitNames = allPduNames,
       deliveryLocationNames = deliveryLocationNames,
     )
-  }
-
-  private fun getFirstUserRegionDescription(username: String): String {
-    val distinctRegionDescriptions = userService.getUserRegions(username).map { it.description }.distinct()
-
-    if (distinctRegionDescriptions.isEmpty()) {
-      throw NotFoundException("Cannot find any regions (or teams) for user $username")
-    } else if (distinctRegionDescriptions.size > 1) {
-      log.warn("User $username has more than one region on their account, going to use '${distinctRegionDescriptions.first()}'")
-    }
-
-    return distinctRegionDescriptions.first()
   }
 
   fun getGroupSessionPage(groupId: UUID, sessionId: UUID): GroupSessionResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
@@ -42,8 +42,7 @@ class ReferralCaseListItemService(
     val (offenceType, hasLdc) = cohort?.let { ProgrammeGroupCohort.toOffenceTypeAndLdc(it) }
       ?: (null to null)
 
-    val (userRegion) = userService.getUserRegions(username)
-    val userRegionName = userRegion.description
+    val userRegionName = userService.getFirstUserRegionDescription(username)
 
     val referralsToReturn = getReferralCaseList(
       pageable = pageable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusPersonalDetails
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 
 @Service
@@ -16,6 +17,19 @@ class UserService(
 ) {
 
   val log = LoggerFactory.getLogger(this::class.java)
+
+  fun getFirstUserRegionDescription(username: String): String {
+    val distinctRegionDescriptions = this.getUserRegions(username).map { it.description }.distinct()
+
+    if (distinctRegionDescriptions.isEmpty()) {
+      log.warn("No regions found for user: $username")
+      throw NotFoundException("Cannot find any regions (or teams) for user $username")
+    } else if (distinctRegionDescriptions.size > 1) {
+      log.warn("User $username has more than one region on their account, going to use '${distinctRegionDescriptions.first()}'")
+    }
+
+    return distinctRegionDescriptions.first()
+  }
 
   fun getPersonalDetailsByIdentifier(identifier: String): NDeliusPersonalDetails {
     val userName = authenticationHolder.username ?: "UNKNOWN_USER"


### PR DESCRIPTION
Refactors the `getFirstUserRegionDescription` method, moving it into the `UserService` class to improve code organization and maintainability. All references to the method have been updated accordingly.
This will give some logging also to see which region is being used for the case list endpoint.