### PR TITLE
Remove redundant `deletedAt` filter from query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -185,7 +185,6 @@ fun incompleteMembershipCountSubquery(
     isLatestReferralStatusProgrammeComplete(query, cb, referralJoin),
     hasAttendedPostProgrammeReview(incompleteMembershipCountSubquery, cb, groupMembershipRoot),
     allSessionsHaveAttendanceData(incompleteMembershipCountSubquery, cb, groupMembershipRoot),
-    cb.isNull(groupMembershipRoot.get<LocalDateTime>("deletedAt")),
   )
 
   incompleteMembershipCountSubquery.select(cb.count(groupMembershipRoot))


### PR DESCRIPTION
This pull request removes the unnecessary `deletedAt` filter from the `GetProgrammeGroupsSpecification` query, improving the query's clarity and efficiency. No other changes have been made.