### PR TITLE
Refine `GetProgrammeGroupsSpecification` and add soft-delete support

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -25,7 +25,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.jvm.java
 
-fun hasAtLeastOneMembership(
+fun hasAtLeastOneActiveMembership(
   query: CriteriaQuery<*>,
   cb: CriteriaBuilder,
   root: Root<ProgrammeGroupEntity>,
@@ -211,7 +211,7 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.or(
         notStartedOrInProgressDateSpec,
         cb.greaterThan(incompleteMembershipCountSubquery, 0L),
-        cb.not(hasAtLeastOneMembership(query, cb, root)),
+        cb.not(hasAtLeastOneActiveMembership(query, cb, root)),
       )
     }
 
@@ -219,8 +219,24 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.and(
         cb.lessThanOrEqualTo(datePath, LocalDate.now()),
         cb.equal(incompleteMembershipCountSubquery, 0L),
-        hasAtLeastOneMembership(query, cb, root),
+        hasAtLeastOneMembershipIncludingDeleted(query, cb, root),
       )
     }
   }
+}
+
+fun hasAtLeastOneMembershipIncludingDeleted(
+  query: CriteriaQuery<*>,
+  cb: CriteriaBuilder,
+  root: Root<ProgrammeGroupEntity>,
+): Predicate {
+  val membershipExistsSubquery = query.subquery(Long::class.java)
+  val membershipRoot = membershipExistsSubquery.from(ProgrammeGroupMembershipEntity::class.java)
+
+  membershipExistsSubquery.select(cb.literal(1L))
+  membershipExistsSubquery.where(
+    cb.equal(membershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
+  )
+
+  return cb.exists(membershipExistsSubquery)
 }


### PR DESCRIPTION
- **Summary of Changes**
  - Updated `GetProgrammeGroupsSpecification` to improve membership filtering logic.
  - Added support for handling soft-deleted memberships.

