### PR TITLE
Add support for soft-deleted group memberships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -211,7 +211,7 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.or(
         notStartedOrInProgressDateSpec,
         cb.greaterThan(incompleteMembershipCountSubquery, 0L),
-        cb.not(hasAtLeastOneActiveMembership(query, cb, root)),
+        cb.isTrue(hasAtLeastOneActiveMembership(query, cb, root)),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -696,12 +696,14 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val referral1 = testDataGenerator.createReferral(personName = "Person1", crn = "X123456")
       val referral2 = testDataGenerator.createReferral(personName = "Person2", crn = "X123457")
       val referral3 = testDataGenerator.createReferral(personName = "Person3", crn = "X123458")
+      val referral4 = testDataGenerator.createReferral(personName = "Person4", crn = "X123459")
 
       val groupMembership1 = testDataGenerator.allocateReferralsToGroup(listOf(referral1), group4).first()
       val groupMembership2 = testDataGenerator.allocateReferralsToGroup(listOf(referral2), group4).first()
-      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6).first()
+      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6, isDeleted = true).first()
+      testDataGenerator.allocateReferralsToGroup(listOf(referral4), group5).first()
 
-      // Set up PPR for group6 (Completed group)
+      // Set up PPR for group6/referral3 (Completed group)
       setupPostProgrammeReviewForGroup(group6, listOf(groupMembership3), attended = true)
       // Set up PPR for group4 (Started group) but one member has not attended
       setupPostProgrammeReviewForGroup(group4, listOf(groupMembership1, groupMembership2), attended = false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
@@ -282,11 +282,13 @@ class TestDataGenerator {
   fun allocateReferralsToGroup(
     referrals: List<ReferralEntity>,
     group: ProgrammeGroupEntity,
+    isDeleted: Boolean = false,
   ): List<ProgrammeGroupMembershipEntity> {
     val groupMembershipEntities = referrals.map {
       ProgrammeGroupMembershipEntity(
         referral = it,
         programmeGroup = group,
+        deletedAt = if (isDeleted) LocalDateTime.now() else null,
       )
     }
     return programmeGroupMembershipRepository.saveAll(groupMembershipEntities)


### PR DESCRIPTION
### Summary of Changes
- Implemented support for handling soft-deleted group memberships.
- Updated associated tests to accommodate this change.

