### PR TITLE
Update `allocateReferralsToGroup` to use `deletedAt` parameter

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -700,7 +700,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
       val groupMembership1 = testDataGenerator.allocateReferralsToGroup(listOf(referral1), group4).first()
       val groupMembership2 = testDataGenerator.allocateReferralsToGroup(listOf(referral2), group4).first()
-      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6, isDeleted = true).first()
+      val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6, deletedAt = LocalDateTime.now()).first()
       testDataGenerator.allocateReferralsToGroup(listOf(referral4), group5).first()
 
       // Set up PPR for group6/referral3 (Completed group)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/common/TestDataGenerator.kt
@@ -282,13 +282,13 @@ class TestDataGenerator {
   fun allocateReferralsToGroup(
     referrals: List<ReferralEntity>,
     group: ProgrammeGroupEntity,
-    isDeleted: Boolean = false,
+    deletedAt: LocalDateTime? = null,
   ): List<ProgrammeGroupMembershipEntity> {
     val groupMembershipEntities = referrals.map {
       ProgrammeGroupMembershipEntity(
         referral = it,
         programmeGroup = group,
-        deletedAt = if (isDeleted) LocalDateTime.now() else null,
+        deletedAt = deletedAt,
       )
     }
     return programmeGroupMembershipRepository.saveAll(groupMembershipEntities)


### PR DESCRIPTION
This pull request updates the `allocateReferralsToGroup` method to explicitly include a `deletedAt` parameter, improving clarity and control over soft deletions. Related tests have also been adjusted accordingly.