### PR TITLE
Update active membership logic in `GetProgrammeGroupsSpecification`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -35,7 +35,6 @@ fun hasAtLeastOneActiveMembership(
   membershipExistsSubquery.select(cb.literal(1L))
   membershipExistsSubquery.where(
     cb.equal(membershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
-    cb.isNull(membershipRoot.get<LocalDateTime>("deletedAt")),
   )
   return cb.exists(membershipExistsSubquery)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -211,7 +211,7 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.or(
         notStartedOrInProgressDateSpec,
         cb.greaterThan(incompleteMembershipCountSubquery, 0L),
-        cb.isTrue(hasAtLeastOneActiveMembership(query, cb, root)),
+        cb.not(hasAtLeastOneActiveMembership(query, cb, root)),
       )
     }
 
@@ -219,13 +219,13 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.and(
         cb.lessThanOrEqualTo(datePath, LocalDate.now()),
         cb.equal(incompleteMembershipCountSubquery, 0L),
-        hasAtLeastOneMembershipIncludingDeleted(query, cb, root),
+        hasAtLeastOneMembership(query, cb, root),
       )
     }
   }
 }
 
-fun hasAtLeastOneMembershipIncludingDeleted(
+fun hasAtLeastOneMembership(
   query: CriteriaQuery<*>,
   cb: CriteriaBuilder,
   root: Root<ProgrammeGroupEntity>,
@@ -236,6 +236,7 @@ fun hasAtLeastOneMembershipIncludingDeleted(
   membershipExistsSubquery.select(cb.literal(1L))
   membershipExistsSubquery.where(
     cb.equal(membershipRoot.get<ProgrammeGroupEntity>("programmeGroup"), root),
+    cb.isNotNull(membershipRoot.get<LocalDateTime>("deletedAt")),
   )
 
   return cb.exists(membershipExistsSubquery)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetProgrammeGroupsSpecification.kt
@@ -218,13 +218,13 @@ fun getProgrammeGroupsByRegionTabSpecification(
       cb.and(
         cb.lessThanOrEqualTo(datePath, LocalDate.now()),
         cb.equal(incompleteMembershipCountSubquery, 0L),
-        hasAtLeastOneMembership(query, cb, root),
+        hasAtLeastOneMembershipIncludingDeleted(query, cb, root),
       )
     }
   }
 }
 
-fun hasAtLeastOneMembership(
+fun hasAtLeastOneMembershipIncludingDeleted(
   query: CriteriaQuery<*>,
   cb: CriteriaBuilder,
   root: Root<ProgrammeGroupEntity>,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.awaitility.kotlin.untilCallTo
 import org.awaitility.kotlin.withPollDelay
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -632,6 +633,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setupOutcomes() {
+      testDataCleaner.cleanAllTables()
       attendedCompliedOutcome = sessionAttendanceOutcomeTypeRepository.findByCode(ATTC)!!
       unacceptableAbsenceOutcome = sessionAttendanceOutcomeTypeRepository.findByCode(UAAB)!!
     }
@@ -659,6 +661,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    @Disabled("Whilst fixing bug, as functionality already covered in other tests")
     fun `should return NOT_STARTED OR IN PROGRESS groups only with correct otherTabTotal`() {
       // Given
       stubAuthTokenEndpoint()
@@ -698,6 +701,14 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val referral3 = testDataGenerator.createReferral(personName = "Person3", crn = "X123458")
       val referral4 = testDataGenerator.createReferral(personName = "Person4", crn = "X123459")
 
+      val programmeCompleteReferralStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
+      testDataGenerator.creatReferralStatusHistory(
+        ReferralStatusHistoryEntityFactory().produce(
+          referral3,
+          programmeCompleteReferralStatus,
+        ),
+      )
+
       val groupMembership1 = testDataGenerator.allocateReferralsToGroup(listOf(referral1), group4).first()
       val groupMembership2 = testDataGenerator.allocateReferralsToGroup(listOf(referral2), group4).first()
       val groupMembership3 = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group6, isDeleted = true).first()
@@ -708,7 +719,6 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Set up PPR for group4 (Started group) but one member has not attended
       setupPostProgrammeReviewForGroup(group4, listOf(groupMembership1, groupMembership2), attended = false)
 
-      val programmeCompleteReferralStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
       val onProgrammeReferralStatus = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
@@ -725,12 +735,6 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       testDataGenerator.creatReferralStatusHistory(
         ReferralStatusHistoryEntityFactory().produce(
           referral2,
-          onProgrammeReferralStatus,
-        ),
-      )
-      testDataGenerator.creatReferralStatusHistory(
-        ReferralStatusHistoryEntityFactory().produce(
-          referral3,
           onProgrammeReferralStatus,
         ),
       )
@@ -787,7 +791,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       val referral3 = testDataGenerator.createReferral(personName = "Person 3", crn = "X123458")
 
       val group3Membership = testDataGenerator.allocateReferralsToGroup(listOf(referral1, referral2), group3).first()
-      val group5Membership = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group5).first()
+      val group5Membership = testDataGenerator.allocateReferralsToGroup(listOf(referral3), group5, deletedAt = LocalDateTime.now()).first()
 
       // Set up PPR attendance
       setupPostProgrammeReviewForGroup(group5, listOf(group5Membership), attended = true)
@@ -888,7 +892,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         .withEarliestStartDate(LocalDate.now().minusDays(10)).produce()
       testDataGenerator.createGroup(groupComplete)
       val completeReferral = testDataGenerator.createReferral(personName = "John Doe", crn = "X000004")
-      val completedGroupMembership = testDataGenerator.allocateReferralsToGroup(listOf(completeReferral), groupComplete).first()
+      val completedGroupMembership = testDataGenerator.allocateReferralsToGroup(listOf(completeReferral), groupComplete, deletedAt = LocalDateTime.now()).first()
       testDataGenerator.creatReferralStatusHistory(ReferralStatusHistoryEntityFactory().produce(completeReferral, programmeCompleteStatus))
       setupPostProgrammeReviewForGroup(groupComplete, listOf(completedGroupMembership), attended = true)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.awaitility.kotlin.untilCallTo
 import org.awaitility.kotlin.withPollDelay
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -661,7 +660,6 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    @Disabled("Whilst fixing bug, as functionality already covered in other tests")
     fun `should return NOT_STARTED OR IN PROGRESS groups only with correct otherTabTotal`() {
       // Given
       stubAuthTokenEndpoint()


### PR DESCRIPTION
Refines the logic for determining active memberships in `GetProgrammeGroupsSpecification` and improves the handling of soft-delete functionality within related tests.