### PR TITLE
Add logging to nDelius get sentence information client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ReferralController.kt
@@ -235,7 +235,7 @@ class ReferralController(
       throw BusinessException("Referral with id $id has null eventNumber")
     }
     return sentenceService.getSentenceInformationByIdentifier(referral.crn, referral.eventNumber).let {
-      ResponseEntity.ok(it.toModel())
+      ResponseEntity.ok(it?.toModel())
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusSentenceResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import java.time.LocalDate
 
@@ -11,17 +13,30 @@ import java.time.LocalDate
 class SentenceService(
   private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
 ) {
+  private val log = LoggerFactory.getLogger(this::class.java)
 
-  fun getSentenceInformationByIdentifier(crn: String, eventNumber: Int?): NDeliusSentenceResponse = when (val result = nDeliusIntegrationApiClient.getSentenceInformation(crn, eventNumber)) {
-    is ClientResult.Success -> result.body
-    is ClientResult.Failure -> result.throwException()
+  fun getSentenceInformationByIdentifier(crn: String, eventNumber: Int?): NDeliusSentenceResponse? = when (val response = nDeliusIntegrationApiClient.getSentenceInformation(crn, eventNumber)) {
+    is ClientResult.Failure.StatusCode -> {
+      if (response.status.value() == 404) {
+        log.warn("No Sentence information found for crn : $crn and event number: $eventNumber")
+        throw NotFoundException("No Sentence information found for crn : $crn and event number: $eventNumber")
+      } else {
+        log.warn("Failure to retrieve Sentence information for crn : $crn and event number: $eventNumber with reason ${response.toException().cause} and status code: ${response.status.value()}", response.toException())
+        response.throwException()
+      }
+    }
+    is ClientResult.Success -> response.body
+    is ClientResult.Failure -> {
+      log.error("Failure to retrieve Sentence information for crn : $crn and event number: $eventNumber with reason ${response.toException().cause}", response.toException())
+      response.throwException()
+    }
   }
 
   fun getSentenceEndDate(crn: String, eventNumber: Int?, sentenceType: ReferralEntitySourcedFrom?): LocalDate? {
     val sentenceInfo = getSentenceInformationByIdentifier(crn, eventNumber)
     return when (sentenceType) {
-      ReferralEntitySourcedFrom.REQUIREMENT -> sentenceInfo.expectedEndDate
-      ReferralEntitySourcedFrom.LICENCE_CONDITION -> sentenceInfo.licenceExpiryDate
+      ReferralEntitySourcedFrom.REQUIREMENT -> sentenceInfo?.expectedEndDate
+      ReferralEntitySourcedFrom.LICENCE_CONDITION -> sentenceInfo?.licenceExpiryDate
       else -> null
     }
   }


### PR DESCRIPTION
### WHY
We're seeing a few failed calls to the `getSentenceInformationByIdentifier` endpoint in prod on receipt of a new referral.  This PR adds a bit of logging to the client code.

### HOW
Enhanced the `getSentenceInformationByIdentifier` method to explicitly handle 404 errors by logging warnings and throwing a `NotFoundException`. Updated the `ReferralController` response to improve null safety.