### PR TITLE
Update materialized views with option to turn off refresh

### DIFF
--- a/src/main/resources/db/migration/R__create_group_wait_list_view.sql
+++ b/src/main/resources/db/migration/R__create_group_wait_list_view.sql
@@ -71,6 +71,11 @@ CREATE OR REPLACE FUNCTION refresh_group_wait_list_item_view()
     RETURNS TRIGGER AS
 $$
 BEGIN
+    -- This is set to false when doing batch imports from IM so we don't try to refresh multiple thousand times at once
+    IF current_setting('app.skip_mv_refresh', true) = 'true' THEN
+        RETURN NEW;
+    END IF;
+
     REFRESH MATERIALIZED VIEW CONCURRENTLY group_waitlist_item_view;
     RETURN NULL;
 END;

--- a/src/main/resources/db/migration/R__create_referral_caselist_item_view.sql
+++ b/src/main/resources/db/migration/R__create_referral_caselist_item_view.sql
@@ -51,6 +51,11 @@ CREATE OR REPLACE FUNCTION refresh_caselist_item_view()
     RETURNS TRIGGER AS
 $$
 BEGIN
+    -- This is set to false when doing batch imports from IM so we don't try to refresh multiple thousand times at once
+    IF current_setting('app.skip_mv_refresh', true) = 'true' THEN
+        RETURN NEW;
+    END IF;
+
     REFRESH MATERIALIZED VIEW CONCURRENTLY referral_caselist_item_view;
     RETURN NULL;
 END;


### PR DESCRIPTION
When we are importing referrals from IM we are going to batch inserting 1000 referrals at once. The currently implementation of the filters means that when we do this the materialised views will try to update every single time which causes out of memory issues and db locks. 

This change allows us to disable the trigger as part of our transaction when we are inserting from the data importer service. 