### PR TITLE
Add `BankHolidayEntity` and `BankHolidayRepository` for bank holiday management

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/BankHolidayEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/BankHolidayEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "bank_holiday")
+class BankHolidayEntity(
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  var id: UUID? = null,
+
+  @NotNull
+  @Column(name = "title")
+  var title: String,
+
+  @NotNull
+  @Column(name = "holiday_date")
+  var holidayDate: LocalDate,
+
+  @Column(name = "notes")
+  var notes: String? = null,
+
+  @NotNull
+  @Column(name = "bunting")
+  var bunting: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/BankHolidayRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/BankHolidayRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.BankHolidayEntity
+import java.util.UUID
+
+@Repository
+interface BankHolidayRepository : JpaRepository<BankHolidayEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.toNdeliusAppointmentEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType.ONE_TO_ONE
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.toFacilitatorType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.BankHolidayRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.NDeliusAppointmentRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupMembershipRepository
@@ -57,6 +58,7 @@ class ScheduleService(
   private val referralRepository: ReferralRepository,
   private val sessionRepository: SessionRepository,
   private val sessionNameFormatter: SessionNameFormatter,
+  private val bankHolidayRepository: BankHolidayRepository,
 ) {
 
   private companion object {
@@ -438,7 +440,11 @@ class ScheduleService(
     val nextDate: LocalDate,
   )
 
-  private fun englandAndWalesHolidayDates(): Set<LocalDate> = when (val response = govUkApiClient.getHolidays()) {
+  private fun englandAndWalesHolidayDates(): Set<LocalDate> = bankHolidayRepository.findAll()
+    .map { it.holidayDate }
+    .toSet()
+
+  private fun englandAndWalesHolidayDatesFromApi(): Set<LocalDate> = when (val response = govUkApiClient.getHolidays()) {
     is ClientResult.Failure.StatusCode -> {
       log.warn("Failed to retrieve UK bank holidays - Status: ${response.status}, Path: ${response.path}, Body: ${response.body}")
       throw BusinessException(

--- a/src/main/resources/db/migration/V103__create_bank_holiday_table.sql
+++ b/src/main/resources/db/migration/V103__create_bank_holiday_table.sql
@@ -1,0 +1,93 @@
+CREATE TABLE bank_holiday (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title VARCHAR(255) NOT NULL,
+    holiday_date DATE NOT NULL,
+    notes VARCHAR(255),
+    bunting BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX idx_bank_holiday_date ON bank_holiday (holiday_date);
+
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2019-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2019-04-19', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2019-04-22', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2019-05-06', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2019-05-27', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2019-08-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2019-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2019-12-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2020-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2020-04-10', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2020-04-13', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday (VE day)', '2020-05-08', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2020-05-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2020-08-31', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2020-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2020-12-28', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2021-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2021-04-02', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2021-04-05', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2021-05-03', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2021-05-31', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2021-08-30', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2021-12-27', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2021-12-28', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2022-01-03', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2022-04-15', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2022-04-18', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2022-05-02', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2022-06-02', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Platinum Jubilee bank holiday', '2022-06-03', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2022-08-29', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Bank Holiday for the State Funeral of Queen Elizabeth II', '2022-09-19', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2022-12-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2022-12-27', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2023-01-02', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2023-04-07', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2023-04-10', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2023-05-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Bank holiday for the coronation of King Charles III', '2023-05-08', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2023-05-29', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2023-08-28', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2023-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2023-12-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2024-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2024-03-29', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2024-04-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2024-05-06', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2024-05-27', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2024-08-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2024-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2024-12-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2025-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2025-04-18', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2025-04-21', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2025-05-05', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2025-05-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2025-08-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2025-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2025-12-26', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2026-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2026-04-03', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2026-04-06', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2026-05-04', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2026-05-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2026-08-31', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2026-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2026-12-28', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2027-01-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2027-03-26', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2027-03-29', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2027-05-03', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2027-05-31', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2027-08-30', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2027-12-27', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2027-12-28', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('New Year’s Day', '2028-01-03', 'Substitute day', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Good Friday', '2028-04-14', '', false);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Easter Monday', '2028-04-17', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Early May bank holiday', '2028-05-01', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Spring bank holiday', '2028-05-29', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Summer bank holiday', '2028-08-28', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Christmas Day', '2028-12-25', '', true);
+INSERT INTO bank_holiday (title, holiday_date, notes, bunting) VALUES ('Boxing Day', '2028-12-26', '', true);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/sar/SarContractIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/sar/SarContractIntegrationTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fact
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupTeamMemberFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.AvailabilityRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.BankHolidayRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.DeliveryLocationPreferenceRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.MessageHistoryRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.PreferredDeliveryLocationProbationDeliveryUnitRepository
@@ -95,6 +96,9 @@ class SarContractIntegrationTest :
   private lateinit var availabilityRepository: AvailabilityRepository
 
   @Autowired
+  private lateinit var bankHolidayRepository: BankHolidayRepository
+
+  @Autowired
   private lateinit var dataSource: DataSource
 
   @Autowired
@@ -116,7 +120,7 @@ class SarContractIntegrationTest :
       expectedApiResponsePath = "/sar/sar-api-response.json",
       expectedRenderResultPath = "/sar/sar-expected-render-result.html",
       attachmentsExpected = false,
-      expectedFlywaySchemaVersion = "102",
+      expectedFlywaySchemaVersion = "103",
       expectedJpaEntitySchemaPath = "/sar/entity-schema-snapshot.json",
     )
   }

--- a/src/test/resources/sar/entity-schema-snapshot.json
+++ b/src/test/resources/sar/entity-schema-snapshot.json
@@ -1,1 +1,336 @@
-{"AccreditedProgrammeTemplateEntity":{"id":"UUID","modules":"Set","name":"String","programmeGroups":"Set","validFrom":"LocalDate","validUntil":"LocalDate"},"AttendeeEntity":{"id":"UUID","referral":"ReferralEntity","session":"SessionEntity","updatedAt":"LocalDateTime"},"AvailabilityEntity":{"endDate":"LocalDate","id":"UUID","lastModifiedAt":"LocalDateTime","lastModifiedBy":"String","otherDetails":"String","referral":"ReferralEntity","slots":"Set","startDate":"LocalDate"},"AvailabilitySlotEntity":{"availability":"AvailabilityEntity","dayOfWeek":"DayOfWeek","id":"UUID","slotName":"SlotName"},"DataImportRecordEntity":{"entityType":"String","id":"UUID","importedAt":"OffsetDateTime","sourceId":"String","targetId":"UUID"},"DeliveryLocationPreferenceEntity":{"createdAt":"LocalDateTime","createdBy":"String","id":"UUID","lastUpdatedAt":"LocalDateTime","locationsCannotAttendText":"String","preferredDeliveryLocations":"Set","referral":"ReferralEntity"},"FacilitatorEntity":{"id":"UUID","ndeliusPersonCode":"String","ndeliusTeamCode":"String","ndeliusTeamName":"String","personName":"String"},"GroupWaitlistItemViewEntity":{"activeProgrammeGroupId":"UUID","cohort":"String","crn":"String","dateOfBirth":"LocalDate","hasLdc":"boolean","pduName":"String","personName":"String","referralId":"UUID","regionName":"String","reportingTeam":"String","sentenceEndDate":"LocalDate","sex":"String","sourcedFrom":"ReferralEntitySourcedFrom","status":"String","statusColour":"String"},"MessageHistoryEntity":{"createdAt":"LocalDateTime","description":"String","detailUrl":"String","eventType":"String","id":"UUID","message":"String","occurredAt":"LocalDateTime","referral":"ReferralEntity"},"ModuleEntity":{"accreditedProgrammeTemplate":"AccreditedProgrammeTemplateEntity","id":"UUID","moduleNumber":"int","name":"String","sessionTemplates":"Set"},"ModuleSessionTemplateEntity":{"description":"String","durationMinutes":"int","id":"UUID","module":"ModuleEntity","name":"String","pathway":"Pathway","sessionNumber":"int","sessionType":"SessionType"},"NDeliusAppointmentEntity":{"id":"UUID","ndeliusAppointmentId":"UUID","referral":"ReferralEntity","session":"SessionEntity"},"PreferredDeliveryLocationEntity":{"deliusCode":"String","deliusDescription":"String","id":"UUID","preferredDeliveryLocationProbationDeliveryUnit":"PreferredDeliveryLocationProbationDeliveryUnitEntity"},"PreferredDeliveryLocationProbationDeliveryUnitEntity":{"deliusCode":"String","deliusDescription":"String","id":"UUID"},"ProgrammeGroupEntity":{"accreditedProgrammeTemplate":"AccreditedProgrammeTemplateEntity","code":"String","cohort":"OffenceCohort","createdAt":"LocalDateTime","createdByUsername":"String","deletedAt":"LocalDateTime","deletedByUsername":"String","deliveryLocationCode":"String","deliveryLocationName":"String","earliestPossibleStartDate":"LocalDate","groupFacilitators":"Set","id":"UUID","isLdc":"boolean","probationDeliveryUnitCode":"String","probationDeliveryUnitName":"String","programmeGroupMemberships":"Set","programmeGroupSessionSlots":"Set","regionName":"String","sessions":"Set","sex":"ProgrammeGroupSexEnum","startedAtDate":"LocalDate","treatmentManager":"FacilitatorEntity","updatedAt":"LocalDateTime","updatedByUsername":"String"},"ProgrammeGroupFacilitatorEntity":{"addedAt":"LocalDateTime","facilitator":"FacilitatorEntity","facilitatorType":"FacilitatorType","id":"UUID","programmeGroup":"ProgrammeGroupEntity"},"ProgrammeGroupMembershipEntity":{"attendances":"Set","createdAt":"LocalDateTime","createdByUsername":"String","deletedAt":"LocalDateTime","deletedByUsername":"String","id":"UUID","programmeGroup":"ProgrammeGroupEntity","referral":"ReferralEntity"},"ProgrammeGroupSessionSlotEntity":{"dayOfWeek":"DayOfWeek","id":"UUID","programmeGroup":"ProgrammeGroupEntity","startTime":"LocalTime","updatedAt":"LocalDateTime"},"ReferralCaseListItemViewEntity":{"cohort":"String","crn":"String","hasLdc":"boolean","pduName":"String","personName":"String","referralId":"UUID","regionName":"String","reportingTeam":"String","sentenceEndDate":"LocalDate","sentenceEndDateSource":"ReferralEntitySourcedFrom","status":"String"},"ReferralCohortHistoryEntity":{"cohort":"OffenceCohort","createdAt":"LocalDateTime","createdBy":"String","id":"UUID","referral":"ReferralEntity"},"ReferralEntity":{"availability":"AvailabilityEntity","createdAt":"LocalDateTime","crn":"String","dateOfBirth":"LocalDate","deliveryLocationPreferences":"DeliveryLocationPreferenceEntity","eventId":"String","eventNumber":"Integer","id":"UUID","interventionName":"String","interventionType":"InterventionType","personName":"String","programmeGroupMemberships":"Set","referralCohortHistories":"Set","referralLdcHistories":"Set","referralMotivationBackgroundAndNonAssociations":"ReferralMotivationBackgroundAndNonAssociationsEntity","referralReportingLocation":"ReferralReportingLocationEntity","sentenceEndDate":"LocalDate","setting":"SettingType","sex":"String","sourcedFrom":"ReferralEntitySourcedFrom","statusHistories":"List","updatedAt":"LocalDateTime"},"ReferralLdcHistoryEntity":{"createdAt":"LocalDateTime","createdBy":"String","hasLdc":"boolean","id":"UUID","referral":"ReferralEntity"},"ReferralMotivationBackgroundAndNonAssociationsEntity":{"createdAt":"LocalDateTime","createdBy":"String","id":"UUID","lastUpdatedAt":"LocalDateTime","lastUpdatedBy":"String","maintainsInnocence":"Boolean","motivations":"String","nonAssociations":"String","otherConsiderations":"String","referral":"ReferralEntity"},"ReferralReportingLocationEntity":{"id":"UUID","pduName":"String","referral":"ReferralEntity","regionName":"String","reportingTeam":"String"},"ReferralStatusDescriptionEntity":{"createdAt":"LocalDateTime","deletedAt":"LocalDateTime","description":"String","id":"UUID","isClosed":"boolean","labelColour":"String","updatedAt":"LocalDateTime"},"ReferralStatusHistoryEntity":{"additionalDetails":"String","createdAt":"LocalDateTime","createdBy":"String","id":"UUID","referral":"ReferralEntity","referralStatusDescription":"ReferralStatusDescriptionEntity","startDate":"LocalDateTime"},"ReferralStatusTransitionEntity":{"createdAt":"LocalDateTime","deletedAt":"LocalDateTime","description":"String","fromStatus":"ReferralStatusDescriptionEntity","id":"UUID","isContinuing":"boolean","isSuggested":"boolean","isVisible":"boolean","priority":"int","toStatus":"ReferralStatusDescriptionEntity","updatedAt":"LocalDateTime"},"ReportingGroupSizeEntity":{"code":"String","cohort":"OffenceCohort","createdAt":"LocalDateTime","earliestPossibleStartDate":"LocalDate","facilitatorStaffCode":"String","groupSize":"int","id":"UUID","isLdc":"boolean","locationCode":"String","locationName":"String","pduCode":"String","pduName":"String","regionName":"String","sex":"ProgrammeGroupSexEnum"},"SessionAttendanceEntity":{"createdAt":"LocalDateTime","createdBy":"String","groupMembership":"ProgrammeGroupMembershipEntity","id":"UUID","legitimateAbsence":"Boolean","notesHistory":"List","outcomeType":"SessionAttendanceNDeliusOutcomeEntity","recordedAt":"LocalDateTime","recordedByFacilitator":"FacilitatorEntity","session":"SessionEntity"},"SessionAttendanceNDeliusOutcomeEntity":{"attendance":"Boolean","code":"SessionAttendanceNDeliusCode","compliant":"boolean","description":"String"},"SessionEntity":{"attendances":"Set","attendees":"List","createdAt":"LocalDateTime","createdByUsername":"String","endsAt":"LocalDateTime","id":"UUID","isCatchup":"boolean","isPlaceholder":"boolean","locationName":"String","moduleSessionTemplate":"ModuleSessionTemplateEntity","ndeliusAppointments":"Set","programmeGroup":"ProgrammeGroupEntity","sessionFacilitators":"Set","startsAt":"LocalDateTime","updatedAt":"LocalDateTime"},"SessionFacilitatorEntity":{"facilitatorType":"FacilitatorType","id":"SessionFacilitatorId"},"SessionNotesHistoryEntity":{"attendance":"SessionAttendanceEntity","createdAt":"LocalDateTime","createdBy":"String","id":"UUID","notes":"String"}}
+{
+  "AccreditedProgrammeTemplateEntity": {
+    "id": "UUID",
+    "modules": "Set",
+    "name": "String",
+    "programmeGroups": "Set",
+    "validFrom": "LocalDate",
+    "validUntil": "LocalDate"
+  },
+  "AttendeeEntity": {
+    "id": "UUID",
+    "referral": "ReferralEntity",
+    "session": "SessionEntity",
+    "updatedAt": "LocalDateTime"
+  },
+  "AvailabilityEntity": {
+    "endDate": "LocalDate",
+    "id": "UUID",
+    "lastModifiedAt": "LocalDateTime",
+    "lastModifiedBy": "String",
+    "otherDetails": "String",
+    "referral": "ReferralEntity",
+    "slots": "Set",
+    "startDate": "LocalDate"
+  },
+  "AvailabilitySlotEntity": {
+    "availability": "AvailabilityEntity",
+    "dayOfWeek": "DayOfWeek",
+    "id": "UUID",
+    "slotName": "SlotName"
+  },
+  "BankHolidayEntity": {
+    "id": "UUID",
+    "title": "String",
+    "holidayDate": "LocalDate",
+    "notes": "String",
+    "bunting": "boolean"
+  },
+  "DataImportRecordEntity": {
+    "entityType": "String",
+    "id": "UUID",
+    "importedAt": "OffsetDateTime",
+    "sourceId": "String",
+    "targetId": "UUID"
+  },
+  "DeliveryLocationPreferenceEntity": {
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "id": "UUID",
+    "lastUpdatedAt": "LocalDateTime",
+    "locationsCannotAttendText": "String",
+    "preferredDeliveryLocations": "Set",
+    "referral": "ReferralEntity"
+  },
+  "FacilitatorEntity": {
+    "id": "UUID",
+    "ndeliusPersonCode": "String",
+    "ndeliusTeamCode": "String",
+    "ndeliusTeamName": "String",
+    "personName": "String"
+  },
+  "GroupWaitlistItemViewEntity": {
+    "activeProgrammeGroupId": "UUID",
+    "cohort": "String",
+    "crn": "String",
+    "dateOfBirth": "LocalDate",
+    "hasLdc": "boolean",
+    "pduName": "String",
+    "personName": "String",
+    "referralId": "UUID",
+    "regionName": "String",
+    "reportingTeam": "String",
+    "sentenceEndDate": "LocalDate",
+    "sex": "String",
+    "sourcedFrom": "ReferralEntitySourcedFrom",
+    "status": "String",
+    "statusColour": "String"
+  },
+  "MessageHistoryEntity": {
+    "createdAt": "LocalDateTime",
+    "description": "String",
+    "detailUrl": "String",
+    "eventType": "String",
+    "id": "UUID",
+    "message": "String",
+    "occurredAt": "LocalDateTime",
+    "referral": "ReferralEntity"
+  },
+  "ModuleEntity": {
+    "accreditedProgrammeTemplate": "AccreditedProgrammeTemplateEntity",
+    "id": "UUID",
+    "moduleNumber": "int",
+    "name": "String",
+    "sessionTemplates": "Set"
+  },
+  "ModuleSessionTemplateEntity": {
+    "description": "String",
+    "durationMinutes": "int",
+    "id": "UUID",
+    "module": "ModuleEntity",
+    "name": "String",
+    "pathway": "Pathway",
+    "sessionNumber": "int",
+    "sessionType": "SessionType"
+  },
+  "NDeliusAppointmentEntity": {
+    "id": "UUID",
+    "ndeliusAppointmentId": "UUID",
+    "referral": "ReferralEntity",
+    "session": "SessionEntity"
+  },
+  "PreferredDeliveryLocationEntity": {
+    "deliusCode": "String",
+    "deliusDescription": "String",
+    "id": "UUID",
+    "preferredDeliveryLocationProbationDeliveryUnit": "PreferredDeliveryLocationProbationDeliveryUnitEntity"
+  },
+  "PreferredDeliveryLocationProbationDeliveryUnitEntity": {
+    "deliusCode": "String",
+    "deliusDescription": "String",
+    "id": "UUID"
+  },
+  "ProgrammeGroupEntity": {
+    "accreditedProgrammeTemplate": "AccreditedProgrammeTemplateEntity",
+    "code": "String",
+    "cohort": "OffenceCohort",
+    "createdAt": "LocalDateTime",
+    "createdByUsername": "String",
+    "deletedAt": "LocalDateTime",
+    "deletedByUsername": "String",
+    "deliveryLocationCode": "String",
+    "deliveryLocationName": "String",
+    "earliestPossibleStartDate": "LocalDate",
+    "groupFacilitators": "Set",
+    "id": "UUID",
+    "isLdc": "boolean",
+    "probationDeliveryUnitCode": "String",
+    "probationDeliveryUnitName": "String",
+    "programmeGroupMemberships": "Set",
+    "programmeGroupSessionSlots": "Set",
+    "regionName": "String",
+    "sessions": "Set",
+    "sex": "ProgrammeGroupSexEnum",
+    "startedAtDate": "LocalDate",
+    "treatmentManager": "FacilitatorEntity",
+    "updatedAt": "LocalDateTime",
+    "updatedByUsername": "String"
+  },
+  "ProgrammeGroupFacilitatorEntity": {
+    "addedAt": "LocalDateTime",
+    "facilitator": "FacilitatorEntity",
+    "facilitatorType": "FacilitatorType",
+    "id": "UUID",
+    "programmeGroup": "ProgrammeGroupEntity"
+  },
+  "ProgrammeGroupMembershipEntity": {
+    "attendances": "Set",
+    "createdAt": "LocalDateTime",
+    "createdByUsername": "String",
+    "deletedAt": "LocalDateTime",
+    "deletedByUsername": "String",
+    "id": "UUID",
+    "programmeGroup": "ProgrammeGroupEntity",
+    "referral": "ReferralEntity"
+  },
+  "ProgrammeGroupSessionSlotEntity": {
+    "dayOfWeek": "DayOfWeek",
+    "id": "UUID",
+    "programmeGroup": "ProgrammeGroupEntity",
+    "startTime": "LocalTime",
+    "updatedAt": "LocalDateTime"
+  },
+  "ReferralCaseListItemViewEntity": {
+    "cohort": "String",
+    "crn": "String",
+    "hasLdc": "boolean",
+    "pduName": "String",
+    "personName": "String",
+    "referralId": "UUID",
+    "regionName": "String",
+    "reportingTeam": "String",
+    "sentenceEndDate": "LocalDate",
+    "sentenceEndDateSource": "ReferralEntitySourcedFrom",
+    "status": "String"
+  },
+  "ReferralCohortHistoryEntity": {
+    "cohort": "OffenceCohort",
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "id": "UUID",
+    "referral": "ReferralEntity"
+  },
+  "ReferralEntity": {
+    "availability": "AvailabilityEntity",
+    "createdAt": "LocalDateTime",
+    "crn": "String",
+    "dateOfBirth": "LocalDate",
+    "deliveryLocationPreferences": "DeliveryLocationPreferenceEntity",
+    "eventId": "String",
+    "eventNumber": "Integer",
+    "id": "UUID",
+    "interventionName": "String",
+    "interventionType": "InterventionType",
+    "personName": "String",
+    "programmeGroupMemberships": "Set",
+    "referralCohortHistories": "Set",
+    "referralLdcHistories": "Set",
+    "referralMotivationBackgroundAndNonAssociations": "ReferralMotivationBackgroundAndNonAssociationsEntity",
+    "referralReportingLocation": "ReferralReportingLocationEntity",
+    "sentenceEndDate": "LocalDate",
+    "setting": "SettingType",
+    "sex": "String",
+    "sourcedFrom": "ReferralEntitySourcedFrom",
+    "statusHistories": "List",
+    "updatedAt": "LocalDateTime"
+  },
+  "ReferralLdcHistoryEntity": {
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "hasLdc": "boolean",
+    "id": "UUID",
+    "referral": "ReferralEntity"
+  },
+  "ReferralMotivationBackgroundAndNonAssociationsEntity": {
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "id": "UUID",
+    "lastUpdatedAt": "LocalDateTime",
+    "lastUpdatedBy": "String",
+    "maintainsInnocence": "Boolean",
+    "motivations": "String",
+    "nonAssociations": "String",
+    "otherConsiderations": "String",
+    "referral": "ReferralEntity"
+  },
+  "ReferralReportingLocationEntity": {
+    "id": "UUID",
+    "pduName": "String",
+    "referral": "ReferralEntity",
+    "regionName": "String",
+    "reportingTeam": "String"
+  },
+  "ReferralStatusDescriptionEntity": {
+    "createdAt": "LocalDateTime",
+    "deletedAt": "LocalDateTime",
+    "description": "String",
+    "id": "UUID",
+    "isClosed": "boolean",
+    "labelColour": "String",
+    "updatedAt": "LocalDateTime"
+  },
+  "ReferralStatusHistoryEntity": {
+    "additionalDetails": "String",
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "id": "UUID",
+    "referral": "ReferralEntity",
+    "referralStatusDescription": "ReferralStatusDescriptionEntity",
+    "startDate": "LocalDateTime"
+  },
+  "ReferralStatusTransitionEntity": {
+    "createdAt": "LocalDateTime",
+    "deletedAt": "LocalDateTime",
+    "description": "String",
+    "fromStatus": "ReferralStatusDescriptionEntity",
+    "id": "UUID",
+    "isContinuing": "boolean",
+    "isSuggested": "boolean",
+    "isVisible": "boolean",
+    "priority": "int",
+    "toStatus": "ReferralStatusDescriptionEntity",
+    "updatedAt": "LocalDateTime"
+  },
+  "ReportingGroupSizeEntity": {
+    "code": "String",
+    "cohort": "OffenceCohort",
+    "createdAt": "LocalDateTime",
+    "earliestPossibleStartDate": "LocalDate",
+    "facilitatorStaffCode": "String",
+    "groupSize": "int",
+    "id": "UUID",
+    "isLdc": "boolean",
+    "locationCode": "String",
+    "locationName": "String",
+    "pduCode": "String",
+    "pduName": "String",
+    "regionName": "String",
+    "sex": "ProgrammeGroupSexEnum"
+  },
+  "SessionAttendanceEntity": {
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "groupMembership": "ProgrammeGroupMembershipEntity",
+    "id": "UUID",
+    "legitimateAbsence": "Boolean",
+    "notesHistory": "List",
+    "outcomeType": "SessionAttendanceNDeliusOutcomeEntity",
+    "recordedAt": "LocalDateTime",
+    "recordedByFacilitator": "FacilitatorEntity",
+    "session": "SessionEntity"
+  },
+  "SessionAttendanceNDeliusOutcomeEntity": {
+    "attendance": "Boolean",
+    "code": "SessionAttendanceNDeliusCode",
+    "compliant": "boolean",
+    "description": "String"
+  },
+  "SessionEntity": {
+    "attendances": "Set",
+    "attendees": "List",
+    "createdAt": "LocalDateTime",
+    "createdByUsername": "String",
+    "endsAt": "LocalDateTime",
+    "id": "UUID",
+    "isCatchup": "boolean",
+    "isPlaceholder": "boolean",
+    "locationName": "String",
+    "moduleSessionTemplate": "ModuleSessionTemplateEntity",
+    "ndeliusAppointments": "Set",
+    "programmeGroup": "ProgrammeGroupEntity",
+    "sessionFacilitators": "Set",
+    "startsAt": "LocalDateTime",
+    "updatedAt": "LocalDateTime"
+  },
+  "SessionFacilitatorEntity": {
+    "facilitatorType": "FacilitatorType",
+    "id": "SessionFacilitatorId"
+  },
+  "SessionNotesHistoryEntity": {
+    "attendance": "SessionAttendanceEntity",
+    "createdAt": "LocalDateTime",
+    "createdBy": "String",
+    "id": "UUID",
+    "notes": "String"
+  }
+}


### PR DESCRIPTION
### Summary
- Created a new `bank_holiday` table and populated it with data from a JSON file (retrieved from https://www.gov.uk/bank-holidays.json)
- Implemented `BankHolidayEntity` and `BankHolidayRepository` to manage bank holiday data.
- Updated `ScheduleService` to fetch bank holidays from the database while keeping the API client intact, so we can use it further down the line from an admin API endpoint or similar to refresh the DB data periodically

### Changes
- Added Flyway migration script `V103__create_bank_holiday_table.sql` to create the `bank_holiday` table and insert 83 bank holiday records for England and Wales. This data set takes us up to Boxing Day, 2028 which should be ample for private beta.
- Created `BankHolidayEntity.kt` with fields for `id`, `title`, `holidayDate`, `notes`, and `bunting`.
- Created `BankHolidayRepository.kt` as a standard `JpaRepository`.
- Modified `ScheduleService.kt` to inject `BankHolidayRepository` and use it in `englandAndWalesHolidayDates()`.
- Renamed the previous API-based implementation to `englandAndWalesHolidayDatesFromApi()` in `ScheduleService.kt` to keep it available for future use.