### PR TITLE
Adding a field to RecordSessionAttendance endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -27,6 +27,11 @@ data class RecordSessionAttendance(
     description = "List of attendees",
   )
   val people: List<SessionAttendancePerson>,
+ 
+  @Schema(
+    description = "Is it a catch-up session?",
+  )
+  val isCatchup: Boolean,
 )
 
 @Schema(description = "Details of an Attendee")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/recordAttendance/RecordSessionAttendance.kt
@@ -27,7 +27,7 @@ data class RecordSessionAttendance(
     description = "List of attendees",
   )
   val people: List<SessionAttendancePerson>,
- 
+
   @Schema(
     description = "Is it a catch-up session?",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -448,6 +448,7 @@ class SessionService(
       sessionTitle = session.sessionName,
       sessionModule = sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance),
       groupRegionName = programmeGroup.regionName,
+      isCatchup = session.isCatchup,
       people = filteredAttendees.map { attendee ->
         val latestAttendance = latestAttendanceByReferralId[attendee.referralId]
         val latestNotes = latestAttendance?.notesHistory

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -446,7 +446,7 @@ class SessionService(
 
     return RecordSessionAttendance(
       sessionTitle = session.sessionName,
-      sessionModule = sessionNameFormatter.format(session, SessionNameContext.ScheduleOverview),
+      sessionModule = sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance),
       groupRegionName = programmeGroup.regionName,
       people = filteredAttendees.map { attendee ->
         val latestAttendance = latestAttendanceByReferralId[attendee.referralId]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
@@ -50,6 +50,11 @@ sealed class SessionNameContext {
    * Formatting for the Attendance History page.
    */
   object AttendanceHistory : SessionNameContext()
+
+  /**
+   * Formatting for the Record Session Attendance page.
+   */
+  object RecordSessionAttendance : SessionNameContext()
 }
 
 /**
@@ -84,6 +89,7 @@ class SessionNameFormatter {
     is SessionNameContext.SessionDetails -> sessionDetails(session)
     is SessionNameContext.SessionNotes -> sessionNotes(session, context.popName)
     is SessionNameContext.AttendanceHistory -> attendanceHistory(session)
+    is SessionNameContext.RecordSessionAttendance -> recordSessionAttendance(session)
   }
 
   /**
@@ -234,5 +240,20 @@ class SessionNameFormatter {
 
       else -> "$prefix$catchupSuffix"
     }
+  }
+
+  /**
+   * Formats the session name for the Record Session Attendance page.
+   *
+   * - Pre-group sessions: returns [SessionEntity.moduleName] as-is.
+   * - Post-programme sessions: `"<sessionName>"`
+   * - ONE_TO_ONE: `"<moduleName> one-to-one"`
+   * - GROUP: `"<moduleName> <sessionNumber>"`
+   */
+  private fun recordSessionAttendance(session: SessionEntity): String = when {
+    session.moduleName.startsWith("Pre-group") -> session.moduleName
+    session.moduleName.startsWith("Post-programme") -> session.sessionName
+    session.sessionType == SessionType.ONE_TO_ONE -> "${session.moduleName} one-to-one"
+    else -> "${session.moduleName} ${session.sessionNumber}"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatter.kt
@@ -245,15 +245,31 @@ class SessionNameFormatter {
   /**
    * Formats the session name for the Record Session Attendance page.
    *
-   * - Pre-group sessions: returns [SessionEntity.moduleName] as-is.
+   * - Pre-group ONE_TO_ONE sessions: `"Pre-group one-to-one"`
+   * - Other pre-group sessions: returns [SessionEntity.moduleName] as-is.
    * - Post-programme sessions: `"<sessionName>"`
    * - ONE_TO_ONE: `"<moduleName> one-to-one"`
    * - GROUP: `"<moduleName> <sessionNumber>"`
    */
   private fun recordSessionAttendance(session: SessionEntity): String = when {
-    session.moduleName.startsWith("Pre-group") -> session.moduleName
+    session.moduleName.startsWith("Pre-group") -> {
+      if (session.sessionType == SessionType.ONE_TO_ONE) {
+        singularizeOneToOneSuffix(session.moduleName)
+      } else {
+        session.moduleName
+      }
+    }
     session.moduleName.startsWith("Post-programme") -> session.sessionName
     session.sessionType == SessionType.ONE_TO_ONE -> "${session.moduleName} one-to-one"
     else -> "${session.moduleName} ${session.sessionNumber}"
+  }
+
+  private fun singularizeOneToOneSuffix(name: String): String {
+    val pluralSuffix = "one-to-ones"
+    return if (name.endsWith(pluralSuffix)) {
+      name.removeSuffix("s")
+    } else {
+      name
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -1739,6 +1739,7 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response.sessionModule).isEqualTo("${session.moduleSessionTemplate.module.name} ${session.sessionNumber}")
       assertThat(response.groupRegionName).isEqualTo(group.regionName)
       assertThat(response.people).isNotEmpty()
+      assertThat(response.isCatchup).isEqualTo(session.isCatchup)
 
       val person = response.people[0]
       val attendance = person.attendance

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
@@ -584,6 +584,130 @@ class SessionNameFormatterTest : IntegrationTestBase() {
   }
 
   @Nested
+  inner class RecordSessionAttendance {
+
+    @Test
+    fun `returns moduleName as-is for pre-group session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Pre-group one-to-ones", 1)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 1,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Pre-group one-to-one",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance))
+        .isEqualTo("Pre-group one-to-ones")
+    }
+
+    @Test
+    fun `returns sessionName without deadline for post-programme session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Post-programme reviews", 7)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 1,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Post-programme review",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance))
+        .isEqualTo("Post-programme review")
+    }
+
+    @Test
+    fun `returns moduleName singular one-to-one for one-to-one session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 3,
+          sessionType = SessionType.ONE_TO_ONE,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Getting started one-to-one",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance))
+        .isEqualTo("Getting started one-to-one")
+    }
+
+    @Test
+    fun `returns moduleName sessionNumber for group session`() {
+      val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+      val module = testDataGenerator.createModule(programmeTemplate, "Getting started", 2)
+      val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+        ModuleSessionTemplateEntity(
+          module = module,
+          sessionNumber = 1,
+          sessionType = SessionType.GROUP,
+          pathway = Pathway.MODERATE_INTENSITY,
+          name = "Introduction to Building Choices",
+          durationMinutes = 120,
+        ),
+      )
+      val group = testDataGenerator.createGroup(
+        ProgrammeGroupFactory()
+          .withAccreditedProgrammeTemplate(programmeTemplate)
+          .produce(),
+      )
+      val session = testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(sessionTemplate)
+          .produce(),
+      )
+
+      assertThat(sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance))
+        .isEqualTo("Getting started 1")
+    }
+  }
+
+  @Nested
   inner class SessionDetails {
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/SessionNameFormatterTest.kt
@@ -299,7 +299,7 @@ class SessionNameFormatterTest : IntegrationTestBase() {
   inner class ScheduleOverview {
 
     @Test
-    fun `returns moduleName as-is for pre-group session`() {
+    fun `returns singular one-to-one for pre-group one-to-one session`() {
       val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
       val module = testDataGenerator.createModule(programmeTemplate, "Pre-group one-to-ones", 1)
       val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
@@ -613,7 +613,7 @@ class SessionNameFormatterTest : IntegrationTestBase() {
       )
 
       assertThat(sessionNameFormatter.format(session, SessionNameContext.RecordSessionAttendance))
-        .isEqualTo("Pre-group one-to-ones")
+        .isEqualTo("Pre-group one-to-one")
     }
 
     @Test


### PR DESCRIPTION
adding the field 'isCatchup' to RecordSessionAttendance' endpoint
Allowing 'one-to-one' and 'one-to-ones' to be output where appropriate