### PR TITLE
fix(APG-2307): add daily PNI caching and graceful nDelius/sentence fa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,12 @@ sonar-project.properties
 wiremock_mappings/seeded/
 
 .snyk
+
+# Local development
+.vscode/
+bin/
+node_modules/
+package.json
+package-lock.json
+output.txt
+*.local.md

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralDetails.kt
@@ -169,5 +169,34 @@ data class ReferralDetails(
       pdu = nDeliusPersonalDetails.probationDeliveryUnit.description,
       reportingTeam = nDeliusPersonalDetails.team.description,
     )
+
+    /**
+     * Fallback when nDelius personal details are unavailable — uses stored referral data.
+     * The page still loads with whatever data was previously persisted.
+     */
+    fun toModelFromStoredData(
+      referral: ReferralEntity,
+      hasLdc: Boolean? = false,
+      latestReferralStatus: ReferralStatusDescriptionEntity,
+      currentlyAllocatedGroup: ProgrammeGroupMembershipEntity?,
+      cohort: OffenceCohort?,
+    ): ReferralDetails = ReferralDetails(
+      id = referral.id!!,
+      crn = referral.crn,
+      personName = referral.personName,
+      interventionName = referral.interventionName ?: "UNKNOWN_INTERVENTION",
+      createdAt = referral.createdAt.toLocalDate(),
+      dateOfBirth = referral.dateOfBirth ?: LocalDate.EPOCH,
+      probationPractitionerName = null,
+      probationPractitionerEmail = null,
+      cohort = cohort ?: OffenceCohort.GENERAL_OFFENCE,
+      hasLdc = LdcStatus.fromBoolean(hasLdc).value,
+      hasLdcDisplayText = LdcStatus.getDisplayText(hasLdc),
+      currentStatusDescription = latestReferralStatus.description,
+      currentlyAllocatedGroupCode = currentlyAllocatedGroup?.programmeGroup?.code,
+      currentlyAllocatedGroupId = currentlyAllocatedGroup?.programmeGroup?.id,
+      pdu = referral.referralReportingLocation?.pduName ?: "Unknown",
+      reportingTeam = referral.referralReportingLocation?.reportingTeam ?: "Unknown",
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniService.kt
@@ -1,18 +1,28 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.OasysApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.PniResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.toPniScore
+import java.time.LocalDate
 
 @Service
 class PniService(
   private val oasysApiClient: OasysApiClient,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
+
+  /**
+   * Returns the PNI calculation for a CRN, caching the result once per day.
+   * The cache key is [crn, date].
+   * If OASys is unavailable or returns no data, returns null (not cached).
+   */
+  @Cacheable(value = ["pni-daily"], key = "#crn + '-' + #date", unless = "#result == null")
+  fun getDailyPniCalculation(crn: String, date: LocalDate = LocalDate.now()): PniScore? = getPniResponse(crn)?.toPniScore()
 
   fun getPniCalculation(crn: String): PniScore = getPniResponse(crn)?.toPniScore() ?: PniScore.empty()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -6,9 +6,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.PniScore
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralDetails
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusHistory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.StatusUpdateResponse
@@ -85,42 +85,62 @@ class ReferralService(
   suspend fun refreshPersonalDetailsForReferral(referralId: UUID): ReferralDetails? = coroutineScope {
     val referral = referralRepository.findByIdWithMemberships(referralId) ?: return@coroutineScope null
 
-    val pniDeferred = async(Dispatchers.IO) {
-      pniService.getPniCalculation(referral.crn)
+    // Check overrides BEFORE calling OASys — skip PNI entirely if both are overridden
+    val cohortOverridden = cohortService.hasOverriddenCohort(referralId)
+    val ldcOverridden = ldcService.hasOverriddenLdcStatus(referralId)
+
+    if (!cohortOverridden || !ldcOverridden) {
+      val pniScore = pniService.getDailyPniCalculation(referral.crn)
+      if (pniScore != null) {
+        if (!ldcOverridden) {
+          ldcService.updateLdcStatusForReferral(referral, UpdateLdc(pniScore.hasLdc), "SYSTEM")
+        }
+        if (!cohortOverridden) {
+          cohortService.updateCohortForReferral(
+            referral,
+            cohortService.determineOffenceCohort(pniScore),
+            "SYSTEM",
+          )
+        }
+      }
     }
 
     val personalDetailsDeferred = async(Dispatchers.IO) {
-      userService.getPersonalDetailsByIdentifier(referral.crn)
+      try {
+        userService.getPersonalDetailsByIdentifier(referral.crn)
+      } catch (ex: AccessDeniedException) {
+        throw ex // Re-throw security exceptions — these must propagate as 403
+      } catch (ex: Exception) {
+        log.warn("Failed to fetch personal details from nDelius for CRN ${referral.crn}: ${ex.message}")
+        null
+      }
     }
 
     val sentenceEndDateDeferred = async(Dispatchers.IO) {
-      sentenceService.getSentenceEndDate(
-        referral.crn,
-        referral.eventNumber,
-        referral.sourcedFrom,
-      )
-    }
-
-    val pniScore = pniDeferred.await()
-    val hasLdc = pniScore.hasLdc
-    val newCohort = cohortService.determineOffenceCohort(pniScore)
-
-    if (!ldcService.hasOverriddenLdcStatus(referralId)) {
-      ldcService.updateLdcStatusForReferral(referral, UpdateLdc(hasLdc), "SYSTEM")
-    }
-
-    // Only update cohort if PNI response is not empty (OASys available).
-    // This ensures that if OASys/PNI is unavailable or returns empty, we do NOT overwrite the cohort,
-    // even if other data sources (e.g., nDelius) are available and return valid data. This protects
-    // against accidental loss of manually set or previously determined cohort information.
-    if (pniScore != PniScore.empty() && !cohortService.hasOverriddenCohort(referralId)) {
-      cohortService.updateCohortForReferral(referral, newCohort, "SYSTEM")
+      try {
+        sentenceService.getSentenceEndDate(
+          referral.crn,
+          referral.eventNumber,
+          referral.sourcedFrom,
+        )
+      } catch (ex: Exception) {
+        log.warn("Failed to fetch sentence end date from nDelius for CRN ${referral.crn}: ${ex.message}")
+        null
+      }
     }
 
     val personalDetails = personalDetailsDeferred.await()
     val sentenceEndDate = sentenceEndDateDeferred.await()
 
-    updateReferralDetails(referral, personalDetails, sentenceEndDate)
+    if (personalDetails != null) {
+      updateReferralDetails(referral, personalDetails, sentenceEndDate)
+    } else {
+      // If we at least have a sentence end date but no personal details, update just the sentence
+      if (sentenceEndDate != null && sentenceEndDate != referral.sentenceEndDate) {
+        referral.sentenceEndDate = sentenceEndDate
+        referralRepository.save(referral)
+      }
+    }
 
     val referralLdc = referralLdcHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralId)?.hasLdc
     val latestReferralStatus = referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId)
@@ -128,14 +148,24 @@ class ReferralService(
       referralCohortHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralId)?.cohort
     val allocatedGroup = programmeGroupMembershipService.getCurrentlyAllocatedGroup(referral)
 
-    ReferralDetails.toModel(
-      referral,
-      personalDetails,
-      referralLdc,
-      latestReferralStatus!!,
-      allocatedGroup,
-      latestReferralCohort,
-    )
+    if (personalDetails != null) {
+      ReferralDetails.toModel(
+        referral,
+        personalDetails,
+        referralLdc,
+        latestReferralStatus!!,
+        allocatedGroup,
+        latestReferralCohort,
+      )
+    } else {
+      ReferralDetails.toModelFromStoredData(
+        referral,
+        referralLdc,
+        latestReferralStatus!!,
+        allocatedGroup,
+        latestReferralCohort,
+      )
+    }
   }
 
   fun getFindAndReferReferralDetails(referralId: UUID): FindAndReferReferralDetails {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/OnboardingControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/OnboardingControllerIntegrationTest.kt
@@ -52,9 +52,9 @@ class OnboardingControllerIntegrationTest : IntegrationTestBase() {
       expectedResponseStatus = 200,
     )
 
-    // Then
-    assertEquals(listOf(secondReferralId.toString()), response.successIds)
+    // Then — both referrals succeed because sentence 404 is handled gracefully (returns null sentenceEndDate)
+    assertEquals(setOf(firstReferralId.toString(), secondReferralId.toString()), response.successIds.toSet())
     assertEquals(listOf(randomReferralId.toString()), response.notFoundIds)
-    assertEquals(listOf(firstReferralId.toString()), response.failureIds)
+    assertEquals(emptyList<String>(), response.failureIds)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
@@ -116,6 +116,17 @@ class NDeliusApiStubs {
     )
   }
 
+  fun stubServiceUnavailablePersonalDetailsResponse(crn: String? = null) {
+    wiremock.stubFor(
+      get(urlEqualTo("/case/$crn/personal-details"))
+        .willReturn(
+          aResponse()
+            .withStatus(503)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+
   fun stubSuccessfulOffencesResponse(
     crn: String,
     eventNumber: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/OasysApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/OasysApiStubs.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestComponent
@@ -543,5 +544,9 @@ class OasysApiStubs {
             .withHeader("Content-Type", "application/json"),
         ),
     )
+  }
+
+  fun verifyPniCallCount(crn: String, expectedCount: Int) {
+    wiremock.verify(expectedCount, getRequestedFor(urlEqualTo("/assessments/pni/$crn?community=true")))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/PniServiceTest.kt
@@ -85,4 +85,54 @@ class PniServiceTest {
     assertThat(result).isEqualTo(PniScore.empty())
     assertThat(result.overallIntensity).isEqualTo(OverallIntensity.MISSING_INFORMATION)
   }
+
+  @Test
+  fun `getDailyPniCalculation returns PniScore when OASys has data`() {
+    val crn = randomCrn()
+    val pniResponse = PniResponseFactory().produce()
+    `when`(oasysApiClient.getPniCalculation(crn)).thenReturn(
+      ClientResult.Success(status = HttpStatus.OK, body = pniResponse),
+    )
+    val result = pniService.getDailyPniCalculation(crn)
+    assertThat(result).isNotNull
+    assertThat(result!!.overallIntensity).isEqualTo(Type.toIntensity(pniResponse.pniCalculation?.pni))
+  }
+
+  @Test
+  fun `getDailyPniCalculation returns null when OASys returns 404`() {
+    val crn = randomCrn()
+    `when`(oasysApiClient.getPniCalculation(crn)).thenReturn(
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/assessments/pni/$crn?community=true",
+        HttpStatus.NOT_FOUND,
+        "",
+      ),
+    )
+    val result = pniService.getDailyPniCalculation(crn)
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `getDailyPniCalculation returns null when OASys returns 503`() {
+    val crn = randomCrn()
+    `when`(oasysApiClient.getPniCalculation(crn)).thenReturn(
+      ClientResult.Failure.StatusCode(
+        HttpMethod.GET,
+        "/assessments/pni/$crn?community=true",
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "",
+      ),
+    )
+    val result = pniService.getDailyPniCalculation(crn)
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `getDailyPniCalculation returns null when OASys throws exception`() {
+    val crn = randomCrn()
+    `when`(oasysApiClient.getPniCalculation(crn)).thenThrow(RuntimeException("Network error"))
+    val result = pniService.getDailyPniCalculation(crn)
+    assertThat(result).isNull()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -918,6 +918,27 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `retrieve referralDetails gracefully when nDelius personal details returns 503`() = runTest {
+      val referral = ReferralEntityFactory().produce()
+      testDataGenerator.createReferralWithStatusHistory(referral)
+      oasysApiStubs.stubServiceUnavailablePniResponse(referral.crn)
+      nDeliusApiStubs.stubServiceUnavailablePersonalDetailsResponse(referral.crn)
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referral.crn,
+        referral.eventNumber,
+        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+      )
+      nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
+
+      val referralDetails = referralService.refreshPersonalDetailsForReferral(referral.id!!)!!
+
+      // Page should still load with stored data — no 500 error
+      assertThat(referralDetails.id).isEqualTo(referral.id!!)
+      assertThat(referralDetails.crn).isEqualTo(referral.crn)
+      assertThat(referralDetails.personName).isEqualTo(referral.personName)
+    }
+
+    @Test
     fun `refreshPersonalDetailsForReferral does not overwrite existing cohort if OASys is unavailable`() = runTest {
       // Given: referral with cohort SEXUAL_OFFENCE
       val referral = ReferralEntityFactory().produce()
@@ -1030,6 +1051,70 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       assertThat(referralDetails.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
       val savedReferral = referralRepository.findById(referral.id!!).get()
       assertThat(savedReferral.referralCohortHistories.first().cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
+    }
+
+    @Test
+    fun `refreshPersonalDetailsForReferral does not overwrite sexual offence cohort when OASys PNI returns 404`() = runTest {
+      // Given: referral with cohort SEXUAL_OFFENCE
+      val referral = ReferralEntityFactory().produce()
+      val cohortHistory = ReferralCohortHistoryFactory().withReferral(referral).withCohort(OffenceCohort.SEXUAL_OFFENCE).produce()
+      val statusHistory = ReferralStatusHistoryEntityFactory().produce(
+        referral,
+        referralStatusDescriptionRepository.getAwaitingAssessmentStatusDescription(),
+      )
+      testDataGenerator.createReferralWithFields(referral, listOf(statusHistory, cohortHistory))
+
+      // OASys/PNI returns not found
+      oasysApiStubs.stubNotFoundPniResponse(referral.crn)
+
+      nDeliusApiStubs.stubPersonalDetailsResponse(
+        NDeliusPersonalDetailsFactory().produce(),
+      )
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referral.crn,
+        referral.eventNumber,
+        NDeliusSentenceResponseFactory().produce(),
+      )
+      nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
+
+      // When: refresh is called
+      val referralDetails = referralService.refreshPersonalDetailsForReferral(referral.id!!)!!
+
+      // Then: cohort remains as previously set (SEXUAL_OFFENCE)
+      assertThat(referralDetails.cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
+      val savedReferral = referralRepository.findById(referral.id!!).get()
+      assertThat(savedReferral.referralCohortHistories.first().cohort).isEqualTo(OffenceCohort.SEXUAL_OFFENCE)
+    }
+
+    @Test
+    fun `should not call OASys PNI on second page view when already enriched`() = runTest {
+      val referral = ReferralEntityFactory().produce()
+      val name = randomFullName()
+      val dateOfBirth = randomDateOfBirth()
+      testDataGenerator.createReferralWithStatusHistory(referral)
+      oasysApiStubs.stubSuccessfulPniResponse(referral.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(
+        NDeliusPersonalDetailsFactory()
+          .withName(name)
+          .withDateOfBirth(dateOfBirth)
+          .produce(),
+      )
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referral.crn,
+        referral.eventNumber,
+        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+      )
+      nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
+
+      // First call - enriches from OASys
+      referralService.refreshPersonalDetailsForReferral(referral.id!!)
+
+      // Second call - should use cached PNI (not call OASys again)
+      val referralDetails = referralService.refreshPersonalDetailsForReferral(referral.id!!)!!
+
+      // Verify OASys was only called once (cached on second call)
+      oasysApiStubs.verifyPniCallCount(referral.crn, 1)
+      assertThat(referralDetails.personName).isEqualTo(name.getNameAsString())
     }
   }
 }


### PR DESCRIPTION
## fix(APG-2307): Add daily PNI caching and graceful nDelius/sentence failure handling

### Problem

After the merged OASys graceful handling fix (`d24b6945`), production still showed 500 errors on the referral details page. The delivery manager reported:

> "Any CRNs that haven't been opened since first import throw up a 'something went wrong' error. Refreshing every 10-15 seconds will eventually load the referral details page. CRNs that have previously been opened/refreshed load fine."

This worked on dev/preprod but failed on prod (~17,591 unique CRNs).

### Root Cause

Two issues:

1. **nDelius failures crash the page** — `BaseHMPPSClient` throws `ServiceUnavailableException` directly for any 5xx response (doesn't return `ClientResult.Failure`). In Kotlin's `coroutineScope`, if any child `async` block throws an unhandled exception, it cancels ALL sibling coroutines and the parent scope — a `try-catch` around `await()` is never reached.

2. **OASys called on every page view** — No caching meant 200k+ unnecessary calls/week to OASys, most returning 404.

### Changes

#### `PniService.kt`
- Added `getDailyPniCalculation(crn, date)` with `@Cacheable("pni-daily")` — OASys is called at most once per CRN per day
- Existing `getPniCalculation()` unchanged (used by `createReferral`)

#### `ReferralService.kt`
- **Override check BEFORE PNI call** — if both cohort and LDC are manually overridden, skip OASys entirely
- **Try-catch inside async blocks** (not around `await()`) for `personalDetails` and `sentenceEndDate` — prevents `ServiceUnavailableException` from crashing the coroutine scope
- **Re-throw `AccessDeniedException`** — LAO security checks still return 403
- When nDelius fails: page loads with stored data (previously persisted name, DOB, PDU)
- When sentence returns 404: gracefully returns null (no longer crashes enrichment)

#### `ReferralDetails.kt`
- Added `toModelFromStoredData()` — fallback that uses persisted referral entity data when nDelius is unavailable

#### `.gitignore`
- Added `.vscode/`, `bin/`, `node_modules/`, `package.json`, `package-lock.json`, `output.txt`, `*.local.md`

### Tests

| Test | What it verifies |
|------|-----------------|
| `retrieve referralDetails gracefully when nDelius personal details returns 503` | Page loads with stored data when nDelius is down |
| `refreshPersonalDetailsForReferral does not overwrite sexual offence cohort when OASys PNI returns 404` | Cohort preserved when OASys has no data |
| `should not call OASys PNI on second page view when already enriched` | Daily caching works — OASys called once not twice |
| `getDailyPniCalculation returns PniScore when OASys has data` | Unit test — happy path |
| `getDailyPniCalculation returns null when OASys returns 404` | Unit test — no data |
| `getDailyPniCalculation returns null when OASys returns 503` | Unit test — service down |
| `getDailyPniCalculation returns null when OASys throws exception` | Unit test — network failure |
| `OnboardingControllerIntegrationTest` (updated) | Sentence 404 no longer classified as failure |

### Impact

| Metric | Before | After |
|--------|--------|-------|
| OASys calls per referral per day | Every page view | Once per day (cached) |
| Page crash on nDelius 503 | 500 error | Page loads with stored data |
| Page crash on sentence 404 | 500 error | Page loads with null sentenceEndDate |
| AccessDeniedException (LAO) | 403 | 403 (unchanged) |

### Relates to
- APG-2307
- Follows: `d24b6945` (graceful OASys PNI failure)
- Aligns with: `APG-2307/pni-fix-500-error` branch patterns (daily caching, override-first check)

### Not included (follow-up)
- Caffeine cache with TTL (currently uses Spring default ConcurrentHashMap — no eviction) https://dsdmoj.atlassian.net/browse/APG-2321

- Resilience4j retry for 503s
https://dsdmoj.atlassian.net/browse/APG-2323

- Stop live-refreshing nDelius on every page view (team decision needed)

### Bug found
Low priority defence coding for data corruption https://dsdmoj.atlassian.net/browse/APG-2322
