### PR TITLE
APG-2324 : Update referral completed event body to contain sourcedFromEntity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsController.kt
@@ -1,11 +1,18 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusInfo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.eventDetails.ReferralCompletionData
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralStatusService
@@ -23,16 +30,78 @@ class EventDetailsController(
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
+  @Operation(
+    tags = ["Event Details"],
+    summary = "Retrieve status change details for a referral",
+    operationId = "getStatusChangeDetails",
+    description = "Returns details of the most recent status change for a given referral. Secured with a read-only role for use by external services.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Status change details for the referral",
+        content = [Content(schema = Schema(implementation = ReferralStatusInfo::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden. The client is not authorised to access this referral.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The referral does not exist",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
   @GetMapping("/referral/{referralId}/status-change-details")
-  fun getStatusChangeDetails(@PathVariable referralId: UUID): ResponseEntity<ReferralStatusInfo> {
+  fun getStatusChangeDetails(
+    @PathVariable @Parameter(description = "The id (UUID) of a referral", required = true) referralId: UUID,
+  ): ResponseEntity<ReferralStatusInfo> {
     log.info("Request to retrieve details of status change for referral with id: $referralId")
     val statusInfo = referralStatusService.getStatusChangeDetailsForReferral(referralId)
 
     return ResponseEntity.ok(statusInfo)
   }
 
+  @Operation(
+    tags = ["Event Details"],
+    summary = "Retrieve completion data for a referral",
+    operationId = "getCompletionData",
+    description = "Returns completion data for a given referral. Secured with a read-only role for use by external services.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Completion data for the referral",
+        content = [Content(schema = Schema(implementation = ReferralCompletionData::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The request was unauthorised",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden. The client is not authorised to access this referral.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The referral does not exist",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+    security = [SecurityRequirement(name = "bearerAuth")],
+  )
   @GetMapping("/referral/{referralId}/completion-data")
-  fun getCompletionData(@PathVariable referralId: UUID): ResponseEntity<ReferralCompletionData> {
+  fun getCompletionData(
+    @PathVariable @Parameter(description = "The id (UUID) of a referral", required = true) referralId: UUID,
+  ): ResponseEntity<ReferralCompletionData> {
     log.info("Request to retrieve completion data for referral with id: $referralId")
     val statusInfo = referralStatusService.getCompletionDataForReferral(referralId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/ReferralStatusInfo.kt
@@ -1,76 +1,91 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 
+@Schema(description = "Details of a referral status change event")
 data class ReferralStatusInfo(
+  @Schema(description = "The new status of the referral", required = true)
   val newStatus: Status,
+  @Schema(description = "The type of entity from which this status change was sourced", required = true)
   val sourcedFromEntityType: ReferralEntitySourcedFrom,
+  @Schema(description = "The ID of the entity from which this status change was sourced", required = true)
   val sourcedFromEntityId: Long,
+  @Schema(description = "Optional notes associated with the status change")
   val notes: String?,
+  @Schema(description = "A human-readable description of the status change", required = true)
   val description: String,
 ) {
+  @Schema(description = "The status of a referral")
   enum class Status(
+    @Schema(description = "The human-readable display name of the status")
     val displayName: String,
+    @Schema(description = "A description of what the status means")
     val description: String,
   ) {
-    AWAITING_ALLOCATION(
-      "Awaiting allocation",
-      "The person is ready to be allocated to a programme group.",
-    ),
+    @Schema(description = "The person is ready to be allocated to a programme group.")
+    AWAITING_ALLOCATION("Awaiting allocation", "The person is ready to be allocated to a programme group."),
+
+    @Schema(description = "The person has a requirement to complete the programme. Their suitability and readiness will be assessed by the programme team.")
     AWAITING_ASSESSMENT(
       "Awaiting assessment",
       "The person has a requirement to complete the programme. Their suitability and readiness will be assessed by the programme team.",
     ),
+
+    @Schema(description = "The person has breached their conditions through non-attendance of the programme.")
     BREACH(
       "Breach (non-attendance)",
       "The person has breached their conditions through non-attendance of the programme.",
     ),
+
+    @Schema(description = "The person is suitable but does not currently meet the prioritisation criteria. The referral will be paused.")
     DEPRIORITISED(
       "Deprioritised",
       "The person is suitable but does not currently meet the prioritisation criteria. The referral will be paused.",
     ),
+
+    @Schema(description = "The court has agreed that the programme requirement should be deferred until the person can continue.")
     DEFERRED(
       "Deferred",
       "The court has agreed that the programme requirement should be deferred until the person can continue.",
     ),
-    ON_PROGRAMME(
-      "On programme",
-      "The person has started the programme. They have attended a pre-group one-to-one.",
-    ),
+
+    @Schema(description = "The person has started the programme. They have attended a pre-group one-to-one.")
+    ON_PROGRAMME("On programme", "The person has started the programme. They have attended a pre-group one-to-one."),
+
+    @Schema(description = "The person has completed the programme and their post-programme review has taken place.")
     PROGRAMME_COMPLETE(
       "Programme complete",
       "The person has completed the programme and their post-programme review has taken place.",
     ),
-    RECALL(
-      "Recall",
-      "The person has been recalled.",
-    ),
+
+    @Schema(description = "The person has been recalled.")
+    RECALL("Recall", "The person has been recalled."),
+
+    @Schema(description = "The person is not suitable for the programme or cannot continue with it. The case will be returned to court.")
     RETURN_TO_COURT(
       "Return to court",
       "The person is not suitable for the programme or cannot continue with it. The case will be returned to court.",
     ),
-    SCHEDULED(
-      "Scheduled",
-      "The person has been allocated to a group.",
-    ),
+
+    @Schema(description = "The person has been allocated to a group.")
+    SCHEDULED("Scheduled", "The person has been allocated to a group."),
+
+    @Schema(description = "The person is suitable for the programme but not ready to start it or continue with it.")
     SUITABLE_BUT_NOT_READY(
       "Suitable but not ready",
       "The person is suitable for the programme but not ready to start it or continue with it.",
     ),
-    WITHDRAWN(
-      "Withdrawn",
-      "The referral has been closed because the person cannot complete the programme.",
-    ),
+
+    @Schema(description = "The referral has been closed because the person cannot complete the programme.")
+    WITHDRAWN("Withdrawn", "The referral has been closed because the person cannot complete the programme."),
     ;
 
     companion object {
-      private val byDisplayName =
-        entries.associateBy { it.displayName.lowercase() }
+      private val byDisplayName = entries.associateBy { it.displayName.lowercase() }
 
       fun fromDisplayName(displayName: String): Status = byDisplayName[displayName.lowercase()]
-        ?: throw IllegalArgumentException(
-          "Unknown referral status description: $displayName",
-        )
+        ?: throw IllegalArgumentException("Unknown referral status description: $displayName")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/eventDetails/ReferralCompletionData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/eventDetails/ReferralCompletionData.kt
@@ -1,10 +1,21 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.eventDetails
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import java.time.LocalDateTime
 
+@Schema(description = "Completion data for a referral")
 data class ReferralCompletionData(
-  val requirementId: String,
+  @Schema(description = "The ID of the requirement or licence-condition associated with this referral", required = true)
+  val licReqId: String,
+  @Schema(
+    description = "The date and time at which the requirement was completed",
+    required = true,
+    example = "2025-04-01T09:30:00.000Z",
+  )
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  val requirementCompletedAt: LocalDateTime,
+  val licReqCompletedAt: LocalDateTime,
+  @Schema(description = "The type of entity from which this status change was sourced", required = true)
+  val sourcedFromEntityType: ReferralEntitySourcedFrom,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
-import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller.OpenOrClosed
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusInfo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.ReferralStatusTransitions
@@ -127,14 +127,13 @@ class ReferralStatusService(
     if (!attended || !complied) {
       throw BusinessException("Referral $referralId did not attend or comply with the post-programme review session")
     }
-
-    val completedAt = requireNotNull(attendance.recordedAt) {
-      "Attendance record for referral $referralId does not have a recordedAt timestamp"
-    }
+    // Requirement or Licence-condition is completed on the date the post programme review session happened
+    val completedAt = postProgrammeReviewSession.startsAt
 
     return ReferralCompletionData(
-      requirementId = eventId,
-      requirementCompletedAt = completedAt,
+      licReqId = eventId,
+      licReqCompletedAt = completedAt,
+      sourcedFromEntityType = referral.sourcedFrom!!,
     )
   }
 
@@ -144,11 +143,13 @@ class ReferralStatusService(
     // Check if the referral status is "Programme complete"
     val currentStatus = referralStatusHistoryRepository.findFirstByReferralIdOrderByCreatedAtDesc(referralId)
     if (currentStatus?.referralStatusDescription?.description != ReferralStatusType.PROGRAMME_COMPLETE.description) {
+      log.debug("Referral is not in Programme complete status, not publishing completion event for referral: $referralId")
       return false
     }
 
     // Check if the referral has attended and complied with the post-programme review
     if (!hasValidPostProgrammeReviewAttendance(referral)) {
+      log.debug("No valid post programme review attendance, not publishing completion event for referral: $referralId")
       return false
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsControllerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.controller
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,7 +26,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.serv
 import java.time.LocalDate
 import java.util.UUID
 
-class StatusChangeDetailsControllerIntegrationTest : IntegrationTestBase() {
+class EventDetailsControllerIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var referralStatusDescriptionRepository: ReferralStatusDescriptionRepository
@@ -82,6 +83,12 @@ class StatusChangeDetailsControllerIntegrationTest : IntegrationTestBase() {
 
   @Nested
   inner class GetCompletionData {
+
+    @BeforeEach
+    fun beforeEach() {
+      nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
+    }
+
     @Test
     fun `should return completion data when referral attended and complied with post-programme review`() {
       val group = testGroupHelper.createGroup()
@@ -131,8 +138,8 @@ class StatusChangeDetailsControllerIntegrationTest : IntegrationTestBase() {
       )
 
       assertThat(response).isNotNull
-      assertThat(response.requirementId).isEqualTo(referral.eventId)
-      assertThat(response.requirementCompletedAt).isNotNull()
+      assertThat(response.licReqId).isEqualTo(referral.eventId)
+      assertThat(response.licReqCompletedAt).isNotNull()
     }
 
     @Test
@@ -289,8 +296,8 @@ class StatusChangeDetailsControllerIntegrationTest : IntegrationTestBase() {
       )
 
       assertThat(response).isNotNull
-      assertThat(response.requirementId).isEqualTo(referral.eventId)
-      assertThat(response.requirementCompletedAt).isNotNull()
+      assertThat(response.licReqId).isEqualTo(referral.eventId)
+      assertThat(response.licReqCompletedAt).isNotNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/EventDetailsControllerIntegrationTest.kt
@@ -140,6 +140,7 @@ class EventDetailsControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response).isNotNull
       assertThat(response.licReqId).isEqualTo(referral.eventId)
       assertThat(response.licReqCompletedAt).isNotNull()
+      assertThat(response.sourcedFromEntityType).isEqualTo(referral.sourcedFrom)
     }
 
     @Test
@@ -298,6 +299,7 @@ class EventDetailsControllerIntegrationTest : IntegrationTestBase() {
       assertThat(response).isNotNull
       assertThat(response.licReqId).isEqualTo(referral.eventId)
       assertThat(response.licReqCompletedAt).isNotNull()
+      assertThat(response.sourcedFromEntityType).isEqualTo(referral.sourcedFrom)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCompleteEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCompleteEventTest.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.awaitility.kotlin.withPollDelay
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.attendance.SessionAttendance
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.attendance.SessionAttendee
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.eventDetails.ReferralCompletionData
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.AmOrPm
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.ScheduleSessionRequest
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.SessionTime
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.CreateGroupTeamMemberType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionAttendanceNDeliusCode
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.model.SQSMessage
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupTeamMemberFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ScheduleService
+import java.time.Duration.ofMillis
+import java.time.LocalDate
+import java.util.UUID
+
+class ReferralCompleteEventTest(
+  @Autowired private val sessionRepository: SessionRepository,
+  @Autowired private val referralStatusDescriptionRepository: ReferralStatusDescriptionRepository,
+  @Autowired private val moduleSessionTemplateRepository: ModuleSessionTemplateRepository,
+  @Autowired private val scheduleService: ScheduleService,
+) : IntegrationTestBase() {
+
+  @Test
+  fun `publish a referral completed event and retrieve details via rest endpoint`() {
+    nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulDeleteAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
+
+    // Go through referral journey update status -> assign to group
+    val awaitingAllocationStatus = referralStatusDescriptionRepository.getAwaitingAllocationStatusDescription()
+    val onProgrammeStatus = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
+    val programmeCompleteStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
+    var referral = testReferralHelper.createReferral()
+    referral = testReferralHelper.updateReferralStatus(referral, awaitingAllocationStatus)
+
+    val programmeGroup = testGroupHelper.createGroup(earliestStartDate = LocalDate.now())
+    referral = testGroupHelper.allocateToGroup(programmeGroup, referral)
+    referral = testReferralHelper.updateReferralStatus(referral, onProgrammeStatus)
+
+    val postProgrammeReviewTemplate =
+      moduleSessionTemplateRepository.findByModuleId(UUID.fromString("ac581f6c-1d81-45a2-af1e-7e3a041ae756")).first()
+
+    val scheduleSessionRequest = ScheduleSessionRequest(
+      sessionTemplateId = postProgrammeReviewTemplate.id!!,
+      referralIds = listOf(referral.id!!),
+      facilitators = listOf(
+        CreateGroupTeamMemberFactory().withTeamMemberType(CreateGroupTeamMemberType.REGULAR_FACILITATOR).produce(),
+      ),
+      startDate = LocalDate.now().minusWeeks(1),
+      startTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+      endTime = SessionTime(hour = 11, minutes = 30, amOrPm = AmOrPm.AM),
+    )
+    val postProgrammeSession = scheduleService.scheduleIndividualSession(programmeGroup.id!!, scheduleSessionRequest)
+    val freshSession = sessionRepository.findByIdOrNull(postProgrammeSession.id!!)!!
+    val attendee = freshSession.attendees.find { it.referralId == referral.id }!!
+
+    // Record attendance as attended and complied
+    val attendanceRequest = SessionAttendance(
+      attendees = listOf(
+        SessionAttendee(
+          referralId = attendee.referralId,
+          outcomeCode = SessionAttendanceNDeliusCode.ATTC,
+          sessionNotes = "Post-programme review completed successfully",
+        ),
+      ),
+    )
+    val attendanceResult = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.POST,
+      uri = "/session/${freshSession.id}/attendance",
+      body = attendanceRequest,
+      returnType = object : ParameterizedTypeReference<SessionAttendance>() {},
+      expectedResponseStatus = HttpStatus.CREATED.value(),
+    )
+
+    assertThat(attendanceResult.attendees).isNotEmpty
+
+    domainEventsQueueConfig.purgeAllQueues()
+
+    referral = testReferralHelper.updateReferralStatus(referral, programmeCompleteStatus)
+
+    // Wait for message to be processed
+    await withPollDelay ofMillis(100) untilCallTo { with(domainEventsQueueConfig) { interventionsQueue.countAllMessagesOnQueue() } } matches { it == 2 }
+    val messages = (1..2).map {
+      with(domainEventsQueueConfig) {
+        objectMapper.readValue<SQSMessage>(interventionsQueue.receiveMessageOnQueue().body())
+      }
+    }
+    val secondEvent = messages.first {
+      it.eventType.equals(HmppsDomainEventTypes.ACP_COMMUNITY_PROGRAMME_COMPLETE.value)
+    }
+    assertThat(secondEvent).isNotNull
+    val response = performRequestAndExpectOk(
+      httpMethod = HttpMethod.GET,
+      uri = "/referral/${referral.id}/completion-data",
+      returnType = object : ParameterizedTypeReference<ReferralCompletionData>() {},
+    )
+
+    assertThat(response).isNotNull
+    assertThat(response.licReqId).isEqualTo(referral.eventId)
+    assertThat(response.licReqCompletedAt).isEqualTo(postProgrammeSession.startsAt)
+    assertThat(response.sourcedFromEntityType).isEqualTo(referral.sourcedFrom)
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,7 +32,7 @@ hmpps:
         queueName: interventionseventtestqueue
         dlqName: interventionseventtestqueuedlq
         subscribeTopicId: hmppseventtopic
-        subscribeFilter: '{"eventType":[ "accredited-programmes-community.referral.status-updated" ]}'
+        subscribeFilter: '{"eventType":[ "accredited-programmes-community.referral.status-updated", "accredited-programmes-community.programme.complete" ]}'
       hmppsdomaineventsqueue:
         queueName: hmpps_domain_events_queue
         dlqName: hmpps_domain_events_dlq


### PR DESCRIPTION
As part of the integration with delius for terminating a Licence condition or requirement we provide an endpoint which is called after an event is published. This endpoints needs to contain the `SourcedFromType` as in delius they use sequential IDs for `Licence-conditions` or `Requirements` and need a way to differentiate between which type the referral is as there could be overlap.

## Other notes
Added a full integration test where;
1. Create referral
2. Change status to `Awaiting Allocation`
3. Assign to group
4. Schedule a post programme review session
5. Mark this session as attended
6. Change status to `Programme Complete`
7. Check that event is published
8. Check that details endpoint returns correct data