### PR TITLE
APG-2318 : Update SOURCED_FROM in imported data when event number is 0

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.mode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 
 @Service
+@Transactional
 class ReferralEventNumberResolverService(
   private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
   private val referralRepository: ReferralRepository,
@@ -31,63 +33,74 @@ class ReferralEventNumberResolverService(
    * we need to fetch this value from one of two delius endpoints
    *  - /case/${crn}/licence-conditions/{id}
    *  - /case/${crn}/requirement/{id}
+   *
+   *  We have also seen that sometimes the `SOURCED_FROM` is incorrectly set in Interventions Manager, therefore we also
+   *  need to try and fetch the opposite value to the current `SOURCED_FROM` if the call fails and update our referral value
+   *  to match if the second call succeeds.
    */
-  @Transactional
-  fun resolveIfEventNumberIsZero(referral: ReferralEntity): Int? {
-    if (referral.eventNumber != 0) {
-      return referral.eventNumber
-    }
+  fun resolveIfEventNumberIsZero(referral: ReferralEntity): ReferralEntity? {
+    if (referral.eventNumber != 0) return referral
 
     val eventId = referral.eventId ?: run {
       log.error("EventId for referral ${referral.id} is null.")
-      return referral.eventNumber
+      return referral
     }
 
-    log.info(
-      "Referral with ID '${referral.id}' has event number 0. Attempting to resolve by checking nDelius sentence endpoint for CRN '${referral.crn}'.",
-    )
+    log.info("Referral '${referral.id}' has event number 0. Attempting to resolve for CRN '${referral.crn}'.")
 
-    val eventNumberResponse = when (referral.sourcedFrom) {
-      ReferralEntitySourcedFrom.REQUIREMENT -> {
-        log.info("...attempting to retrieve a Requirement for Referral with ID: ${referral.id}")
-        when (
-          val response =
-            nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, eventId)
-        ) {
-          is ClientResult.Success -> {
-            telemetryClient.logToAppInsights(
-              "${GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.eventName}.success",
-              mapOf(
-                "integrationActionType" to GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.name,
-                "outcome" to "success",
-              ),
-            )
+    val resolved = resolveSource(referral, eventId)
 
-            response.body
-          }
+    if (resolved != null) {
+      referral.sourcedFrom = resolved.sourcedFrom
+      referral.eventNumber = resolved.response.eventNumber
+      referralRepository.save(referral)
+      logSuccess(referral, resolved.response.eventNumber)
+    } else {
+      logFailureEvent(referral)
+    }
 
-          else -> {
-            log.error("Could not fetch a Requirement with ID $eventId, for Referral with ID: ${referral.id}")
-            telemetryClient.logToAppInsights(
-              "${GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.eventName}.failure",
-              mapOf(
-                "integrationActionType" to GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.name,
-                "outcome" to "failure",
-              ),
-            )
+    return referral
+  }
 
-            null
-          }
+  private data class ResolvedSource(
+    val response: NDeliusCaseRequirementOrLicenceConditionResponse,
+    val sourcedFrom: ReferralEntitySourcedFrom,
+  )
+
+  private fun resolveSource(referral: ReferralEntity, eventId: String): ResolvedSource? {
+    val orderedCandidates: List<Pair<ReferralEntitySourcedFrom, () -> NDeliusCaseRequirementOrLicenceConditionResponse?>> =
+      when (referral.sourcedFrom) {
+        ReferralEntitySourcedFrom.REQUIREMENT -> listOf(
+          ReferralEntitySourcedFrom.REQUIREMENT to { getRequirement(referral, eventId) },
+          ReferralEntitySourcedFrom.LICENCE_CONDITION to { getLicenceCondition(referral, eventId) },
+        )
+
+        ReferralEntitySourcedFrom.LICENCE_CONDITION -> listOf(
+          ReferralEntitySourcedFrom.LICENCE_CONDITION to { getLicenceCondition(referral, eventId) },
+          ReferralEntitySourcedFrom.REQUIREMENT to { getRequirement(referral, eventId) },
+        )
+
+        else -> {
+          log.error("${referral.sourcedFrom} is not a valid value")
+          return null
         }
       }
 
-      ReferralEntitySourcedFrom.LICENCE_CONDITION -> {
-        log.info("...attempting to retrieve a Licence Condition for Referral with ID: ${referral.id}")
-        when (
-          val response =
-            nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, eventId)
-        ) {
-          is ClientResult.Success -> {
+    // Lazy function that only evaluates second call if the first is null
+    return orderedCandidates
+      .firstNotNullOfOrNull { (source, fetch) -> fetch()?.let { ResolvedSource(it, source) } }
+  }
+
+  private fun getLicenceCondition(
+    referral: ReferralEntity,
+    eventId: String,
+  ): NDeliusCaseRequirementOrLicenceConditionResponse? {
+    log.info("...attempting to retrieve a Licence Condition for Referral with ID: ${referral.id}")
+    return when (
+      val response =
+        nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, eventId)
+    ) {
+      is ClientResult.Success -> {
             telemetryClient.logToAppInsights(
               "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.success",
               mapOf(
@@ -99,36 +112,35 @@ class ReferralEventNumberResolverService(
             response.body
           }
 
-          else -> {
-            log.error("Could not fetch a Licence condition with ID $eventId, for Referral with ID: ${referral.id}")
-            telemetryClient.logToAppInsights(
+      else -> {
+        log.error("Could not fetch a Licence condition with ID $eventId, for Referral with ID: ${referral.id}")
+        telemetryClient.logToAppInsights(
               "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.failure",
               mapOf(
                 "integrationActionType" to GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.name,
                 "outcome" to "failure",
               ),
-            )
-
-            null
-          }
-        }
+            )null
       }
+    }
+  }
+
+  private fun getRequirement(
+    referral: ReferralEntity,
+    eventId: String,
+  ): NDeliusCaseRequirementOrLicenceConditionResponse? {
+    log.info("...attempting to retrieve a Requirement for Referral with ID: ${referral.id}")
+    return when (
+      val response =
+        nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, eventId)
+    ) {
+      is ClientResult.Success -> response.body
 
       else -> {
-        log.error("${referral.sourcedFrom} is not a valid value")
+        log.error("Could not fetch a Requirement with ID $eventId, for Referral with ID: ${referral.id}")
         null
       }
     }
-
-    if (eventNumberResponse != null) {
-      referral.eventNumber = eventNumberResponse.eventNumber
-      referralRepository.save(referral)
-      logSuccess(referral, eventNumberResponse.eventNumber)
-    } else {
-      logFailureEvent(referral)
-    }
-
-    return referral.eventNumber
   }
 
   private fun logFailureEvent(referral: ReferralEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.conf
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 
 @Service
@@ -101,26 +100,27 @@ class ReferralEventNumberResolverService(
         nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, eventId)
     ) {
       is ClientResult.Success -> {
-            telemetryClient.logToAppInsights(
-              "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.success",
-              mapOf(
-                "integrationActionType" to GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.name,
-                "outcome" to "success",
-              ),
-            )
+        telemetryClient.logToAppInsights(
+          "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.success",
+          mapOf(
+            "integrationActionType" to GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.name,
+            "outcome" to "success",
+          ),
+        )
 
-            response.body
-          }
+        response.body
+      }
 
       else -> {
         log.error("Could not fetch a Licence condition with ID $eventId, for Referral with ID: ${referral.id}")
         telemetryClient.logToAppInsights(
-              "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.failure",
-              mapOf(
-                "integrationActionType" to GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.name,
-                "outcome" to "failure",
-              ),
-            )null
+          "${GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.eventName}.failure",
+          mapOf(
+            "integrationActionType" to GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS.name,
+            "outcome" to "failure",
+          ),
+        )
+        null
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 
@@ -134,10 +135,26 @@ class ReferralEventNumberResolverService(
       val response =
         nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, eventId)
     ) {
-      is ClientResult.Success -> response.body
+      is ClientResult.Success -> {
+        telemetryClient.logToAppInsights(
+          "${IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.eventName}.success",
+          mapOf(
+            "integrationActionType" to IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.name,
+            "outcome" to "success",
+          ),
+        )
+        response.body
+      }
 
       else -> {
         log.error("Could not fetch a Requirement with ID $eventId, for Referral with ID: ${referral.id}")
+        telemetryClient.logToAppInsights(
+          "${IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.eventName}.failure",
+          mapOf(
+            "integrationActionType" to IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS.name,
+            "outcome" to "failure",
+          ),
+        )
         null
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverServiceTest.kt
@@ -38,12 +38,14 @@ class ReferralEventNumberResolverServiceTest {
 
   @Test
   fun `does not attempt resolution when event number is already non-zero`() {
-    val referral = ReferralEntityFactory().withEventNumber(4).produce()
+    val referral =
+      ReferralEntityFactory().withEventNumber(4).withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
     val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
 
     val result = service.resolveIfEventNumberIsZero(referral)
 
-    assertThat(result).isEqualTo(4)
+    assertThat(result!!.eventNumber).isEqualTo(4)
+    assertThat(result.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.REQUIREMENT)
     verifyNoInteractions(nDeliusIntegrationApiClient)
     verifyNoInteractions(referralRepository)
     verifyNoInteractions(telemetryClient)
@@ -52,19 +54,21 @@ class ReferralEventNumberResolverServiceTest {
   @Test
   fun `updates referral event number when a valid number is found`() {
     val referral =
-      ReferralEntityFactory().withEventNumber(0).withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
+      ReferralEntityFactory().withEventNumber(0).withSourcedFrom(ReferralEntitySourcedFrom.LICENCE_CONDITION).produce()
     val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
 
-    `when`(nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, referral.eventId!!)).thenReturn(
+    `when`(nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, referral.eventId!!)).thenReturn(
       ClientResult.Success(HttpStatusCode.valueOf(200), mockRequirementLicResponse()),
     )
 
     val result = service.resolveIfEventNumberIsZero(referral)
 
-    assertThat(result).isEqualTo(3)
+    assertThat(result!!.eventNumber).isEqualTo(3)
     assertThat(referral.eventNumber).isEqualTo(3)
+    assertThat(result.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
     verify(referralRepository).save(referral)
-    verify(nDeliusIntegrationApiClient).getRequirementManagerDetails(referral.crn, referral.eventId!!)
+    verify(nDeliusIntegrationApiClient, times(1)).getLicenceConditionManagerDetails(referral.crn, referral.eventId!!)
+    verify(nDeliusIntegrationApiClient, times(0)).getRequirementManagerDetails(referral.crn, referral.eventId!!)
   }
 
   @Test
@@ -83,10 +87,43 @@ class ReferralEventNumberResolverServiceTest {
     )
     val result = service.resolveIfEventNumberIsZero(referral)
 
-    assertThat(result).isEqualTo(0)
-    assertThat(referral.eventNumber).isEqualTo(0)
+    assertThat(result!!.eventNumber).isEqualTo(0)
+    assertThat(result.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.REQUIREMENT)
     verify(referralRepository, times(0)).save(referral)
+    verify(nDeliusIntegrationApiClient, times(1)).getRequirementManagerDetails(referral.crn, referral.eventId!!)
+    verify(nDeliusIntegrationApiClient, times(1)).getLicenceConditionManagerDetails(referral.crn, referral.eventId!!)
+  }
+
+  @Test
+  fun `updates referral sourcedFrom if first call is null and second call succeeds`() {
+    val referral =
+      ReferralEntityFactory().withEventNumber(0).withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
+    val service = ReferralEventNumberResolverService(nDeliusIntegrationApiClient, referralRepository, telemetryClient)
+
+    `when`(nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, referral.eventId!!)).thenReturn(
+      ClientResult.Failure.Other(
+        HttpMethod.GET,
+        "/case/${referral.crn}/requirement/${referral.eventId}",
+        RuntimeException("Connection refused"),
+        "nDelius",
+      ),
+    )
+
+    `when`(
+      nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(
+        referral.crn,
+        referral.eventId!!,
+      ),
+    ).thenReturn(
+      ClientResult.Success(HttpStatusCode.valueOf(200), mockRequirementLicResponse()),
+    )
+    val result = service.resolveIfEventNumberIsZero(referral)
+
+    assertThat(result!!.eventNumber).isEqualTo(3)
+    assertThat(result.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+    verify(referralRepository, times(1)).save(referral)
     verify(nDeliusIntegrationApiClient).getRequirementManagerDetails(referral.crn, referral.eventId!!)
+    verify(nDeliusIntegrationApiClient).getLicenceConditionManagerDetails(referral.crn, referral.eventId!!)
   }
 
   private fun mockRequirementLicResponse(): NDeliusCaseRequirementOrLicenceConditionResponse {


### PR DESCRIPTION
When we import data from IM some referrals have the wrong `SOURCED_FROM` this is a data quality issue from IM not an importer issue. We can resolve this when we make the call to resolve the event number and we call out to the respective `getLicenceCondition` or `getRequirement` endpoint. 

This PR implements the functionality to update the `sourced_from` for a referral when the first call fails and we try the second one and it succeeds then update the referral.