### PR TITLE
Update session rescheduling logic to prevent past session changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -115,11 +115,12 @@ class SessionService(
     val requestedStartTime = LocalDateTime.of(request.sessionStartDate, request.sessionStartTime.toLocalTime())
     val startOffset = Duration.between(session.startsAt, requestedStartTime)
     val requestedEndTime = LocalDateTime.of(request.sessionStartDate, request.sessionEndTime?.toLocalTime() ?: session.endsAt.plus(startOffset).toLocalTime())
+    val sessionDurationHasChanged = Duration.between(session.startsAt, session.endsAt) != Duration.between(requestedStartTime, requestedEndTime)
 
     val originalSessionStartsAt = session.startsAt
 
     // validate that the reschedule request is valid - session duration cannot be changed for past sessions
-    if (session.startsAt.isBefore(LocalDateTime.now())) {
+    if (session.startsAt.isBefore(LocalDateTime.now()) && sessionDurationHasChanged) {
       log.warn("Invalid reschedule request received for past session with id: $sessionId. Requested session start date must be in the future")
       throw BusinessException("The session session duration cannot be longer than originally scheduled. Change the start or end time.")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -309,7 +309,7 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should return HTTP 400 code when attempting to amend the duration of a session in the past `() {
     // Given
-    val programmeTemplate = accreditedProgrammeTemplateRepository.getBuildingChoicesTemplate()
+    val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
     val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
     val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
       ModuleSessionTemplateEntity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -381,8 +381,8 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
       SessionFactory()
         .withProgrammeGroup(group)
         .withModuleSessionTemplate(sessionTemplate)
-        .withStartsAt(LocalDateTime.now().minusDays(2).withHour(13).withMinute(30))
-        .withEndsAt(LocalDateTime.now().minusDays(2).withHour(14).withMinute(30))
+        .withStartsAt(LocalDateTime.now().minusDays(2).withHour(13).withMinute(30).withSecond(0).withNano(0))
+        .withEndsAt(LocalDateTime.now().minusDays(2).withHour(14).withMinute(30).withSecond(0).withNano(0))
         .produce(),
     )
 
@@ -404,6 +404,13 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
 
     // Then
     assertThat(response.message).isEqualTo("The date and time have been updated.")
+
+    // Verify the session was rescheduled and duration was preserved (original was 1hr: 13:30–14:30)
+    val updatedSession = sessionRepository.findById(session.id!!).get()
+    val expectedStart = LocalDateTime.of(LocalDate.now().plusDays(2), LocalTime.of(10, 0))
+    val expectedEnd = expectedStart.plusHours(1) // original duration preserved
+    assertThat(updatedSession.startsAt).isEqualTo(expectedStart)
+    assertThat(updatedSession.endsAt).isEqualTo(expectedEnd)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -307,7 +307,57 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return HTTP 400 code when attempting to reschedule a session in the past`() {
+  fun `should return HTTP 400 code when attempting to amend the duration of a session in the past `() {
+    // Given
+    val programmeTemplate = accreditedProgrammeTemplateRepository.getBuildingChoicesTemplate()
+    val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
+    val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+      ModuleSessionTemplateEntity(
+        module = module,
+        sessionNumber = 2,
+        sessionType = SessionType.GROUP,
+        pathway = Pathway.MODERATE_INTENSITY,
+        name = "Test Session Template",
+        durationMinutes = 120,
+      ),
+    )
+    val group = testDataGenerator.createGroup(
+      ProgrammeGroupFactory()
+        .withAccreditedProgrammeTemplate(programmeTemplate)
+        .withCode("RESCHED")
+        .produce(),
+    )
+    val session = testDataGenerator.createSession(
+      SessionFactory()
+        .withProgrammeGroup(group)
+        .withModuleSessionTemplate(sessionTemplate)
+        .withStartsAt(LocalDateTime.now().minusDays(2).withHour(13).withMinute(30))
+        .withEndsAt(LocalDateTime.now().minusDays(2).withHour(14).withMinute(30))
+        .produce(),
+    )
+
+    val rescheduleRequest = RescheduleSessionRequest(
+      sessionStartDate = LocalDate.now().plusDays(2),
+      sessionStartTime = SessionTime(hour = 9, minutes = 0, amOrPm = AmOrPm.AM),
+      sessionEndTime = SessionTime(hour = 11, minutes = 30, amOrPm = AmOrPm.AM),
+      rescheduleOtherSessions = false,
+    )
+
+    // When
+    val response = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.PUT,
+      uri = "/session/${session.id}/reschedule",
+      body = rescheduleRequest,
+      returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
+      expectedResponseStatus = HttpStatus.BAD_REQUEST.value(),
+    )
+
+    // Then
+    assertThat(response.userMessage).isEqualTo("Bad request: The session session duration cannot be longer than originally scheduled. Change the start or end time.")
+  }
+
+  @Test
+  fun `should allow the rescheduling of a session in the past, without modifying the duration of the session`() {
     // Given
     val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
     val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
@@ -348,12 +398,12 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
       httpMethod = HttpMethod.PUT,
       uri = "/session/${session.id}/reschedule",
       body = rescheduleRequest,
-      returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
-      expectedResponseStatus = HttpStatus.BAD_REQUEST.value(),
+      returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+      expectedResponseStatus = HttpStatus.OK.value(),
     )
 
     // Then
-    assertThat(response.userMessage).isEqualTo("Bad request: The session session duration cannot be longer than originally scheduled. Change the start or end time.")
+    assertThat(response.message).isEqualTo("The date and time have been updated.")
   }
 
   @Test


### PR DESCRIPTION
Update the session rescheduling logic to ensure that duration changes are prevented for sessions that have already occurred, but allowing past sessions to be rescheduled where the duration remains the same. 