### PR TITLE
tweak: Set the timeout on WebClient from 20s -> 60s

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/WebClientConfiguration.kt
@@ -23,7 +23,7 @@ import java.time.Duration
 class WebClientConfiguration(
   @Value("\${hmpps-auth.url}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
-  @Value("\${api.timeout:20s}") val timeout: Duration,
+  @Value("\${api.timeout:60s}") val timeout: Duration, // Bumped from 20 -> 60 for private beta onboarding --TJWC 2026-06-03
   @Value("\${max-response-in-memory-size-bytes}") private val maxResponseInMemorySizeBytes: Int,
 ) {
   // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services


### PR DESCRIPTION
**WHAT**

Change the default `api.timeout` from `20` to `60` in the WebClient

**WHY**

As part of the onboarding for Referrals for private beta, we are
manually refreshing a lot of Referrals and are seeing a series of
timeouts as many calls are being made to third-party APIs.

This is a quick-and-easy way to reduce the number of time-out exceptions
we see as part of this process.

I expect we are being rate-limited by PI, or somewhere along the line.
