### PR TITLE
adjust time in past sessions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
@@ -177,7 +177,7 @@ class SessionController(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Bad request - The session session duration cannot be longer than originally scheduled",
+        description = "Bad request - For past sessions (end time has passed), the duration cannot be longer than currently scheduled",
         content = [
           Content(
             mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -115,6 +115,12 @@ class SessionService(
     val requestedStartTime = LocalDateTime.of(request.sessionStartDate, request.sessionStartTime.toLocalTime())
     val startOffset = Duration.between(session.startsAt, requestedStartTime)
     val requestedEndTime = LocalDateTime.of(request.sessionStartDate, request.sessionEndTime?.toLocalTime() ?: session.endsAt.plus(startOffset).toLocalTime())
+
+    if (!requestedEndTime.isAfter(requestedStartTime)) {
+      log.warn("Invalid reschedule request received for session with id: $sessionId. Requested end time $requestedEndTime is not after requested start time $requestedStartTime")
+      throw BusinessException("The session end time must be after the session start time.")
+    }
+
     val currentSessionDuration = Duration.between(session.startsAt, session.endsAt)
     val requestedSessionDuration = Duration.between(requestedStartTime, requestedEndTime)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -129,7 +129,7 @@ class SessionService(
     // Past sessions (end time has passed) may not be lengthened; shortening is allowed
     if (session.endsAt.isBefore(LocalDateTime.now()) && requestedSessionDuration > currentSessionDuration) {
       log.warn("Invalid reschedule request received for past session with id: $sessionId. Requested duration $requestedSessionDuration exceeds current duration $currentSessionDuration")
-      throw BusinessException("The session duration cannot be longer than the current scheduled duration. Change the start or end time.")
+      throw BusinessException("For sessions in the past, the session duration cannot be longer than the current scheduled duration. Change the start or end time.")
     }
 
     // update the start and end times of the requested session

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -115,14 +115,15 @@ class SessionService(
     val requestedStartTime = LocalDateTime.of(request.sessionStartDate, request.sessionStartTime.toLocalTime())
     val startOffset = Duration.between(session.startsAt, requestedStartTime)
     val requestedEndTime = LocalDateTime.of(request.sessionStartDate, request.sessionEndTime?.toLocalTime() ?: session.endsAt.plus(startOffset).toLocalTime())
-    val sessionDurationHasChanged = Duration.between(session.startsAt, session.endsAt) != Duration.between(requestedStartTime, requestedEndTime)
+    val currentSessionDuration = Duration.between(session.startsAt, session.endsAt)
+    val requestedSessionDuration = Duration.between(requestedStartTime, requestedEndTime)
 
     val originalSessionStartsAt = session.startsAt
 
-    // validate that the reschedule request is valid - session duration cannot be changed for past sessions
-    if (session.startsAt.isBefore(LocalDateTime.now()) && sessionDurationHasChanged) {
-      log.warn("Invalid reschedule request received for past session with id: $sessionId. Requested session start date must be in the future")
-      throw BusinessException("The session session duration cannot be longer than originally scheduled. Change the start or end time.")
+    // Past sessions (end time has passed) may not be lengthened; shortening is allowed
+    if (session.endsAt.isBefore(LocalDateTime.now()) && requestedSessionDuration > currentSessionDuration) {
+      log.warn("Invalid reschedule request received for past session with id: $sessionId. Requested duration $requestedSessionDuration exceeds current duration $currentSessionDuration")
+      throw BusinessException("The session duration cannot be longer than the current scheduled duration. Change the start or end time.")
     }
 
     // update the start and end times of the requested session

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -357,6 +357,56 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return HTTP 400 when requested session end time is before start time`() {
+    // Given
+    val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+    val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
+    val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+      ModuleSessionTemplateEntity(
+        module = module,
+        sessionNumber = 2,
+        sessionType = SessionType.GROUP,
+        pathway = Pathway.MODERATE_INTENSITY,
+        name = "Test Session Template",
+        durationMinutes = 120,
+      ),
+    )
+    val group = testDataGenerator.createGroup(
+      ProgrammeGroupFactory()
+        .withAccreditedProgrammeTemplate(programmeTemplate)
+        .withCode("RESCHED")
+        .produce(),
+    )
+    val session = testDataGenerator.createSession(
+      SessionFactory()
+        .withProgrammeGroup(group)
+        .withModuleSessionTemplate(sessionTemplate)
+        .withStartsAt(LocalDateTime.now().plusDays(1).withHour(13).withMinute(30).withSecond(0).withNano(0))
+        .withEndsAt(LocalDateTime.now().plusDays(1).withHour(14).withMinute(30).withSecond(0).withNano(0))
+        .produce(),
+    )
+
+    val rescheduleRequest = RescheduleSessionRequest(
+      sessionStartDate = LocalDate.now().plusDays(2),
+      sessionStartTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+      sessionEndTime = SessionTime(hour = 9, minutes = 0, amOrPm = AmOrPm.AM),
+      rescheduleOtherSessions = false,
+    )
+
+    // When
+    val response = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.PUT,
+      uri = "/session/${session.id}/reschedule",
+      body = rescheduleRequest,
+      returnType = object : ParameterizedTypeReference<ErrorResponse>() {},
+      expectedResponseStatus = HttpStatus.BAD_REQUEST.value(),
+    )
+
+    // Then
+    assertThat(response.userMessage).isEqualTo("Bad request: The session end time must be after the session start time.")
+  }
+
+  @Test
   fun `should allow the rescheduling of a session in the past, without modifying the duration of the session`() {
     // Given
     val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
@@ -411,6 +461,60 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
     val expectedEnd = expectedStart.plusHours(1) // original duration preserved
     assertThat(updatedSession.startsAt).isEqualTo(expectedStart)
     assertThat(updatedSession.endsAt).isEqualTo(expectedEnd)
+  }
+
+  @Test
+  fun `should allow shortening the duration of a completed session`() {
+    // Given
+    val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+    val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
+    val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+      ModuleSessionTemplateEntity(
+        module = module,
+        sessionNumber = 2,
+        sessionType = SessionType.GROUP,
+        pathway = Pathway.MODERATE_INTENSITY,
+        name = "Test Session Template",
+        durationMinutes = 120,
+      ),
+    )
+    val group = testDataGenerator.createGroup(
+      ProgrammeGroupFactory()
+        .withAccreditedProgrammeTemplate(programmeTemplate)
+        .withCode("RESCHED")
+        .produce(),
+    )
+    val session = testDataGenerator.createSession(
+      SessionFactory()
+        .withProgrammeGroup(group)
+        .withModuleSessionTemplate(sessionTemplate)
+        .withStartsAt(LocalDateTime.now().minusDays(2).withHour(15).withMinute(51).withSecond(0).withNano(0))
+        .withEndsAt(LocalDateTime.now().minusDays(2).withHour(15).withMinute(59).withSecond(0).withNano(0))
+        .produce(),
+    )
+
+    val targetDate = LocalDate.now().plusDays(2)
+    val rescheduleRequest = RescheduleSessionRequest(
+      sessionStartDate = targetDate,
+      sessionStartTime = SessionTime(hour = 3, minutes = 51, amOrPm = AmOrPm.PM),
+      sessionEndTime = SessionTime(hour = 3, minutes = 58, amOrPm = AmOrPm.PM),
+      rescheduleOtherSessions = false,
+    )
+
+    // When
+    val response = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.PUT,
+      uri = "/session/${session.id}/reschedule",
+      body = rescheduleRequest,
+      returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+      expectedResponseStatus = HttpStatus.OK.value(),
+    )
+
+    // Then
+    assertThat(response.message).isEqualTo("The date and time have been updated.")
+    val updatedSession = sessionRepository.findById(session.id!!).get()
+    assertThat(updatedSession.startsAt).isEqualTo(LocalDateTime.of(targetDate, LocalTime.of(15, 51)))
+    assertThat(updatedSession.endsAt).isEqualTo(LocalDateTime.of(targetDate, LocalTime.of(15, 58)))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -353,7 +353,7 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
     )
 
     // Then
-    assertThat(response.userMessage).isEqualTo("Bad request: The session duration cannot be longer than the current scheduled duration. Change the start or end time.")
+    assertThat(response.userMessage).isEqualTo("Bad request: For sessions in the past, the session duration cannot be longer than the current scheduled duration. Change the start or end time.")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -353,7 +353,7 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
     )
 
     // Then
-    assertThat(response.userMessage).isEqualTo("Bad request: The session session duration cannot be longer than originally scheduled. Change the start or end time.")
+    assertThat(response.userMessage).isEqualTo("Bad request: The session duration cannot be longer than the current scheduled duration. Change the start or end time.")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionControllerIntegrationTest.kt
@@ -518,6 +518,63 @@ class SessionControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should allow lengthening the duration of a session that has started but not yet ended`() {
+    // Given
+    val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")
+    val module = testDataGenerator.createModule(programmeTemplate, "Test Module", 1)
+    val sessionTemplate = testDataGenerator.createModuleSessionTemplate(
+      ModuleSessionTemplateEntity(
+        module = module,
+        sessionNumber = 2,
+        sessionType = SessionType.GROUP,
+        pathway = Pathway.MODERATE_INTENSITY,
+        name = "Test Session Template",
+        durationMinutes = 60,
+      ),
+    )
+    val group = testDataGenerator.createGroup(
+      ProgrammeGroupFactory()
+        .withAccreditedProgrammeTemplate(programmeTemplate)
+        .withCode("RESCHED")
+        .produce(),
+    )
+
+    val now = LocalDateTime.now().withSecond(0).withNano(0)
+    val session = testDataGenerator.createSession(
+      SessionFactory()
+        .withProgrammeGroup(group)
+        .withModuleSessionTemplate(sessionTemplate)
+        .withStartsAt(now.minusMinutes(30))
+        .withEndsAt(now.plusMinutes(30))
+        .produce(),
+    )
+
+    // Move to a future date and lengthen duration from 60 to 90 minutes.
+    val targetDate = LocalDate.now().plusDays(2)
+    val rescheduleRequest = RescheduleSessionRequest(
+      sessionStartDate = targetDate,
+      sessionStartTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+      sessionEndTime = SessionTime(hour = 11, minutes = 30, amOrPm = AmOrPm.AM),
+      rescheduleOtherSessions = false,
+    )
+
+    // When
+    val response = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.PUT,
+      uri = "/session/${session.id}/reschedule",
+      body = rescheduleRequest,
+      returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+      expectedResponseStatus = HttpStatus.OK.value(),
+    )
+
+    // Then
+    assertThat(response.message).isEqualTo("The date and time have been updated.")
+    val updatedSession = sessionRepository.findById(session.id!!).get()
+    assertThat(updatedSession.startsAt).isEqualTo(LocalDateTime.of(targetDate, LocalTime.of(10, 0)))
+    assertThat(updatedSession.endsAt).isEqualTo(LocalDateTime.of(targetDate, LocalTime.of(11, 30)))
+  }
+
+  @Test
   fun `rescheduleSession returns 200 and updates session without rescheduling other sessions`() {
     // Given
     val programmeTemplate = testDataGenerator.createAccreditedProgrammeTemplate("Test Programme")


### PR DESCRIPTION
Sessions in the past can have the time shortened or the start and end times changed as long as the session is never made longer.