### PR TITLE
APG-2319 Ensure referral events are published after committed transactions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/listener/ReferralEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/listener/ReferralEvent.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener
+
+import java.util.UUID
+
+sealed class ReferralEvent(
+  open val referralId: UUID,
+)
+
+data class ReferralStatusUpdateEvent(override val referralId: UUID) : ReferralEvent(referralId)
+data class ReferralProgrammeCompleteEvent(override val referralId: UUID) : ReferralEvent(referralId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/listener/ReferralEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/listener/ReferralEventListener.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service.ReferralEventService
+
+/**
+ * This listener ensures that we only publish our referral events AFTER we have commited a transaction
+ */
+@Component
+class ReferralEventListener(private val referralEventService: ReferralEventService) {
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  fun onReferralStatusUpdate(event: ReferralStatusUpdateEvent) {
+    referralEventService.publishReferralStatusUpdatedEvent(event.referralId)
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  fun onReferralProgrammeComplete(event: ReferralProgrammeCompleteEvent) {
+    referralEventService.publishReferralCompletedEvent(event.referralId)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ser
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.UserActivityType.ASSIGN_REFERRAL_TO_GROUP
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.UserActivityType.REMOVE_REFERRAL_FROM_GROUP
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupMembershipRepository
@@ -34,8 +36,8 @@ class ProgrammeGroupMembershipService(
   private val referralStatusDescriptionRepository: ReferralStatusDescriptionRepository,
   private val programmeGroupMembershipRepository: ProgrammeGroupMembershipRepository,
   private val scheduleService: ScheduleService,
-  private val referralEventService: ReferralEventService,
   private val telemetryClient: TelemetryClient,
+  private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -91,19 +93,21 @@ class ProgrammeGroupMembershipService(
     // Create appointments in NDelius for each session object
     scheduleService.createNdeliusAppointmentsForSessions(newAttendees)
 
-    referralEventService.publishReferralStatusUpdatedEvent(referral)
+    val savedReferral = referralRepository.save(referral)
+
+    applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId))
 
     telemetryClient.logToAppInsights(
       "Referral.allocate-to-group.success",
       mapOf(
         "activityType" to ASSIGN_REFERRAL_TO_GROUP.name,
-        "regionName" to (referral.referralReportingLocation?.regionName ?: ""),
-        "deliveryUnitCode" to (referral.referralReportingLocation?.pduName ?: ""),
+        "regionName" to (savedReferral.referralReportingLocation?.regionName ?: ""),
+        "deliveryUnitCode" to (savedReferral.referralReportingLocation?.pduName ?: ""),
         "deliveryLocation" to group.deliveryLocationName,
       ),
     )
 
-    return referralRepository.save(referral)
+    return savedReferral
   }
 
   fun getCurrentlyAllocatedGroup(referral: ReferralEntity): ProgrammeGroupMembershipEntity? {
@@ -147,21 +151,21 @@ class ProgrammeGroupMembershipService(
       )
 
     referral.statusHistories.add(statusHistory)
-    referralRepository.save(referral)
-    referralEventService.publishReferralStatusUpdatedEvent(referral)
+    val savedReferral = referralRepository.save(referral)
+    applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId))
 
     telemetryClient.logToAppInsights(
       "Referral.remove-from-group.success",
       mapOf(
         "activityType" to REMOVE_REFERRAL_FROM_GROUP.name,
-        "regionName" to (referral.referralReportingLocation?.regionName ?: ""),
-        "deliveryUnitCode" to (referral.referralReportingLocation?.pduName ?: ""),
+        "regionName" to (savedReferral.referralReportingLocation?.regionName ?: ""),
+        "deliveryUnitCode" to (savedReferral.referralReportingLocation?.pduName ?: ""),
         "deliveryLocation" to group.deliveryLocationName,
       ),
     )
 
     return RemoveFromGroupResponse(
-      message = "${referral.personName} was removed from this group. Their referral status is now ${desiredStatus.description}",
+      message = "${savedReferral.personName} was removed from this group. Their referral status is now ${desiredStatus.description}",
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventService.kt
@@ -14,18 +14,21 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.even
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.REFERRAL_COMPLETED_N_DELIUS
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.UPDATE_REFERRAL_STATUS_N_DELIUS
 import java.time.ZonedDateTime
+import java.util.UUID
 
 @Service
 class ReferralEventService(
   private val domainEventPublisher: DomainEventPublisher,
   private val telemetryClient: TelemetryClient,
   @Value("\${services.manage-and-deliver-api.base-url}") private val madBaseUrl: String,
+  private val referralService: ReferralService,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun publishReferralStatusUpdatedEvent(referral: ReferralEntity) {
+  fun publishReferralStatusUpdatedEvent(referralId: UUID) {
+    val referral = referralService.getReferralById(referralId)
     val message = DomainEventsMessage(
       eventType = ACP_COMMUNITY_REFERRAL_STATUS_UPDATED.value,
       version = 1,
@@ -44,7 +47,8 @@ class ReferralEventService(
     )
   }
 
-  fun publishReferralCompletedEvent(referral: ReferralEntity) {
+  fun publishReferralCompletedEvent(referralId: UUID) {
+    val referral = referralService.getReferralById(referralId)
     val message = DomainEventsMessage(
       eventType = HmppsDomainEventTypes.ACP_COMMUNITY_PROGRAMME_COMPLETE.value,
       version = 1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
@@ -35,6 +36,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralLdcHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralReportingLocationEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_LICENCE_CONDITION_MANAGER_DETAILS_N_DELIUS
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_PERSONAL_DETAILS_N_DELIUS
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.IntegrationActivityType.GET_REQUIREMENT_MANAGER_DETAILS_N_DELIUS
@@ -77,10 +79,10 @@ class ReferralService(
   private val programmeGroupService: ProgrammeGroupService,
   private val sessionNameFormatter: SessionNameFormatter,
   private val referralStatusService: ReferralStatusService,
-  private val referralEventService: ReferralEventService,
   private val referralCohortHistoryRepository: ReferralCohortHistoryRepository,
   private val telemetryClient: TelemetryClient,
   private val referralEventNumberResolverService: ReferralEventNumberResolverService,
+  private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -494,7 +496,7 @@ class ReferralService(
       ),
     )
 
-    referralEventService.publishReferralStatusUpdatedEvent(referral)
+    applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referral.id!!))
 
     // If status changed to "Programme complete", check if completion event should be published
     if (incomingReferralStatusDescription.description == "Programme complete") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ser
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.comm
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralProgrammeCompleteEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupMembershipRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusDescriptionRepository
@@ -35,7 +37,7 @@ class ReferralStatusService(
   private val programmeGroupMembershipRepository: ProgrammeGroupMembershipRepository,
   private val referralRepository: ReferralRepository,
   private val sessionAttendanceRepository: SessionAttendanceRepository,
-  private val referralEventService: ReferralEventService,
+  private val applicationEventPublisher: ApplicationEventPublisher,
   @Value("\${services.manage-and-deliver-api.base-url}") private val madBaseUrl: String,
 ) {
 
@@ -148,7 +150,7 @@ class ReferralStatusService(
       return false
     }
     // Publish the completion event
-    referralEventService.publishReferralCompletedEvent(referral)
+    applicationEventPublisher.publishEvent(ReferralProgrammeCompleteEvent(referral.id!!))
 
     return true
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
@@ -7,8 +7,10 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FacilitatorEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralStatusDescriptionEntityFactory
@@ -27,8 +29,8 @@ class ProgrammeGroupMembershipServiceTest {
   private val referralStatusDescriptionRepository = mockk<ReferralStatusDescriptionRepository>()
   private val programmeGroupMembershipRepository = mockk<ProgrammeGroupMembershipRepository>()
   private val scheduleService = mockk<ScheduleService>()
-  private val referralEventService = mockk<ReferralEventService>()
   private val telemetryClient = mockk<TelemetryClient>()
+  private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
   private lateinit var service: ProgrammeGroupMembershipService
 
   @BeforeEach
@@ -39,8 +41,8 @@ class ProgrammeGroupMembershipServiceTest {
       referralStatusDescriptionRepository = referralStatusDescriptionRepository,
       programmeGroupMembershipRepository = programmeGroupMembershipRepository,
       scheduleService = scheduleService,
-      referralEventService = referralEventService,
       telemetryClient = telemetryClient,
+      applicationEventPublisher = applicationEventPublisher,
     )
   }
 
@@ -64,7 +66,7 @@ class ProgrammeGroupMembershipServiceTest {
     every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
     every { referralRepository.save(referralEntity) } returns referralEntity
     every { scheduleService.createNdeliusAppointmentsForSessions(any()) } returns Unit
-    every { referralEventService.publishReferralStatusUpdatedEvent(referralEntity) } returns Unit
+    every { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) } returns Unit
     every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
 
     // When
@@ -80,7 +82,7 @@ class ProgrammeGroupMembershipServiceTest {
     verify { referralStatusDescriptionRepository.getScheduledStatusDescription() }
     verify { referralRepository.save(referralEntity) }
     verify { scheduleService.createNdeliusAppointmentsForSessions(any()) }
-    verify { referralEventService.publishReferralStatusUpdatedEvent(referralEntity) }
+    verify { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) }
     verify { telemetryClient.logToAppInsights(any(), any()) }
   }
 
@@ -110,7 +112,7 @@ class ProgrammeGroupMembershipServiceTest {
     every { programmeGroupRepository.save(programmeGroupEntity) } returns programmeGroupEntity
     every { referralStatusDescriptionRepository.findByIdOrNull(referralStatusDescriptionId) } returns referralStatusDescriptionEntity
     every { referralRepository.save(referralEntity) } returns referralEntity
-    every { referralEventService.publishReferralStatusUpdatedEvent(referralEntity) } returns Unit
+    every { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) } returns Unit
     every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
 
     // When
@@ -126,7 +128,7 @@ class ProgrammeGroupMembershipServiceTest {
     verify { programmeGroupRepository.save(programmeGroupEntity) }
     verify { referralStatusDescriptionRepository.findByIdOrNull(referralStatusDescriptionId) }
     verify { referralRepository.save(referralEntity) }
-    verify { referralEventService.publishReferralStatusUpdatedEvent(referralEntity) }
+    verify { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) }
     verify { telemetryClient.logToAppInsights(any(), any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
@@ -83,7 +84,7 @@ class ReferralServiceTest {
   private lateinit var programmeGroupService: ProgrammeGroupService
 
   @Mock
-  private lateinit var referralEventService: ReferralEventService
+  private lateinit var applicationEventPublisher: ApplicationEventPublisher
 
   @Mock
   private lateinit var sessionNameFormatter: SessionNameFormatter
@@ -120,10 +121,10 @@ class ReferralServiceTest {
       programmeGroupService = programmeGroupService,
       sessionNameFormatter = sessionNameFormatter,
       referralStatusService = referralStatusService,
-      referralEventService = referralEventService,
       referralCohortHistoryRepository = referralCohortHistoryRepository,
       telemetryClient = telemetryClient,
       referralEventNumberResolverService = referralEventNumberResolverService,
+      applicationEventPublisher = applicationEventPublisher,
     )
   }
 


### PR DESCRIPTION
This PR ensures that we only send our events after the transaction has been completed. We are seeing some events in delius be populated with out of date information which looks to be from a race condition of us sending the event and committing the row to the db.