### PR TITLE
fix: guard all `getUserRegions()` call sites against empty list crash

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
@@ -482,7 +482,8 @@ class ProgrammeGroupController(
   @GetMapping("/bff/pdus-for-user-region")
   fun getPdusInUserRegion(): ResponseEntity<List<CodeDescription>> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(emptyList())
     val pdusForRegion =
       regionService.getPdusForRegion(userRegion.code).map { CodeDescription(it.code, it.description) }
     return ResponseEntity.ok(pdusForRegion)
@@ -546,7 +547,8 @@ class ProgrammeGroupController(
   @GetMapping("/bff/region/members")
   fun getMembersInUserRegion(): ResponseEntity<List<UserTeamMember>> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(emptyList())
     val teamMembers = regionService.getTeamMembersForPdu(userRegion.code)
     return ResponseEntity.ok(teamMembers)
   }
@@ -704,8 +706,8 @@ class ProgrammeGroupController(
     val suggestedDate = scheduleService.getNextSlotDate(groupId, moduleId)
 
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
-    val facilitators = regionService.getTeamMembersForPdu(userRegion.code)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+    val facilitators = userRegion?.let { regionService.getTeamMembersForPdu(it.code) } ?: emptyList()
 
     val memberships = programmeGroupMembershipService.getActiveGroupMemberships(groupId)
     val groupMembers = memberships.map { membership ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
@@ -494,9 +494,9 @@ class SessionController(
   @GetMapping("/bff/session/{sessionId}/session-facilitators", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun retrieveSessionFacilitators(@PathVariable sessionId: UUID): ResponseEntity<EditSessionFacilitatorsResponse> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
     val regionFacilitators: MutableList<UserTeamMember> =
-      regionService.getTeamMembersForPdu(userRegion.code).toMutableList()
+      (userRegion?.let { regionService.getTeamMembersForPdu(it.code) } ?: emptyList()).toMutableList()
 
     return ResponseEntity.ok(sessionService.getSessionFacilitators(sessionId, regionFacilitators))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/UserController.kt
@@ -57,7 +57,8 @@ class UserController(
   @GetMapping("/current-user/region", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getCurrentUserRegion(): ResponseEntity<CodeDescription> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(CodeDescription("UNKNOWN", "Unknown region"))
     return ResponseEntity.ok(userRegion)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -88,7 +88,8 @@ class ProgrammeGroupService(
   val log = LoggerFactory.getLogger(this::class.java)
 
   fun createGroup(createGroupRequest: CreateGroupRequest, username: String): ProgrammeGroupEntity {
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: throw NotFoundException("Cannot find any regions for user $username")
     programmeGroupRepository.findByCodeAndRegionName(createGroupRequest.groupCode, userRegion.description)
       ?.let { throw ConflictException("Programme group with code ${createGroupRequest.groupCode} already exists in region") }
 
@@ -351,8 +352,8 @@ class ProgrammeGroupService(
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
 
-    val (userRegion) = userService.getUserRegions(username)
-    val userRegionName = userRegion.description
+    val userRegionName = userService.getUserRegions(username)
+      .firstOrNull()?.description ?: "Unknown region"
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST
 
@@ -380,8 +381,9 @@ class ProgrammeGroupService(
   }
 
   fun getGroupInRegion(groupCode: String, username: String): ProgrammeGroupEntity? {
-    val (userRegion) = userService.getUserRegions(username)
-    return programmeGroupRepository.findByCodeAndRegionName(groupCode, userRegion.description)
+    val userRegionName = userService.getUserRegions(username).firstOrNull()?.description
+      ?: return null
+    return programmeGroupRepository.findByCodeAndRegionName(groupCode, userRegionName)
   }
 
   fun getGroupDetails(groupId: UUID): GroupDetailsResponse {


### PR DESCRIPTION
## fix: guard all `getUserRegions()` call sites against empty list crash

### Problem

When nDelius times out or is temporarily unavailable, `getUserRegions()` returns an empty list. All 8 call sites used Kotlin destructuring (`val (userRegion) = ...`) which calls `.get(0)` — crashing with `IndexOutOfBoundsException: Empty list doesn't contain element at index 0`.

This is the root cause of Sentry issue on `GET /bff/group/{id}/ALLOCATED`.

### Fix

Replaced all destructuring with `.firstOrNull()` + appropriate fallback per call site:

| Call site | Fallback behaviour |
|---|---|
| `ProgrammeGroupService.createGroup` | Throw `NotFoundException` (write op — needs real region) |
| `ProgrammeGroupService.getGroupPageDetails` | Use `"Unknown region"` — page still loads |
| `ProgrammeGroupService.getGroupInRegion` | Return `null` |
| `ProgrammeGroupController.getPdusInUserRegion` | Return empty list |
| `ProgrammeGroupController.getMembersInUserRegion` | Return empty list |
| `ProgrammeGroupController.getGroupMembers` | Empty facilitators list |
| `SessionController.retrieveSessionFacilitators` | Empty facilitators list |
| `UserController.getCurrentUserRegion` | Return `CodeDescription("UNKNOWN", "Unknown region")` |

### Context

- Related to PR #711 (`no-ticket/cache-user-regions`) which adds Caffeine caching to reduce the frequency of this issue
- This PR is the safety net: even if the cache misses and nDelius is down, pages degrade gracefully instead of crashing with 500

### Testing

- ktlint passes ✅
- No API contract changes (same response types, just graceful empty/fallback values instead of 500)