### PR TITLE
fix: always refresh the Cohort if there isn't any history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/CohortService.kt
@@ -37,17 +37,18 @@ class CohortService(
     // Overwrite the username to be written when system is automatically updating this value
     AuditorContext.set(createdBy)
     try {
-      val latestCohortHistory =
-        referralCohortHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralEntity.id!!)
-      if (latestCohortHistory?.cohort != cohort) {
+      val latestCohortHistory = referralCohortHistoryRepository.findTopByReferralIdOrderByCreatedAtDesc(referralEntity.id!!)
+      val referralCohortHistory = ReferralCohortHistoryEntity(
+        referral = referralEntity,
+        cohort = cohort,
+        createdBy = createdBy,
+      )
+      if (latestCohortHistory == null) {
+        log.info("No ReferralCohortHistory record for referral with Id: '${referralEntity.id}', creating one...")
+        referralCohortHistoryRepository.save(referralCohortHistory)
+      } else if (latestCohortHistory.cohort != cohort) {
         log.info("Updating cohort to '$cohort' for referral with Id: '${referralEntity.id}'")
-        referralCohortHistoryRepository.save(
-          ReferralCohortHistoryEntity(
-            referral = referralEntity,
-            cohort = cohort,
-            createdBy = createdBy,
-          ),
-        )
+        referralCohortHistoryRepository.save(referralCohortHistory)
       }
     } finally {
       AuditorContext.clear()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminControllerIntegrationTest.kt
@@ -2,6 +2,11 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api
 
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.awaitility.kotlin.withPollDelay
+import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,6 +19,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.fact
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.model.create.PopulatePersonalDetailsRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
+import java.time.Duration.ofMillis
 
 class AdminControllerIntegrationTest : IntegrationTestBase() {
 
@@ -47,6 +53,44 @@ class AdminControllerIntegrationTest : IntegrationTestBase() {
 
     //    Then
     assertEquals(response.ids, listOf("*"))
+  }
+
+  @Test
+  fun `populatePersonalDetails creates cohort history when referral has no cohort history`() {
+    // Given
+    stubAuthTokenEndpoint()
+    val referralEntity = ReferralEntityFactory().produce()
+    testDataGenerator.createReferralWithStatusHistory(referralEntity)
+    nDeliusApiStubs.stubAccessCheck(granted = true, referralEntity.crn)
+    nDeliusApiStubs.stubPersonalDetailsResponse()
+    nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(referralEntity.crn, referralEntity.eventNumber)
+    oasysApiStubs.stubSuccessfulPniResponse(referralEntity.crn)
+
+    assertThat(countReferralCohortHistoryRows(referralEntity.id!!)).isZero()
+
+    // When
+    val response = performRequestAndExpectStatusWithBody(
+      HttpMethod.POST,
+      "/admin/populate-personal-details",
+      object : ParameterizedTypeReference<PopulatePersonalDetailsResponse>() {},
+      body = buildPopulatePersonalDetailsResponse(listOf(referralEntity.id.toString())),
+      expectedResponseStatus = 200,
+    )
+
+    // Then
+    assertThat(response.ids).containsExactly(referralEntity.id.toString())
+
+    await withPollDelay ofMillis(100) withPollInterval ofMillis(100) untilCallTo {
+      countReferralCohortHistoryRows(referralEntity.id!!)
+    } matches { it == 1 }
+
+    val latestCohortCreatedBy = jdbcTemplate.queryForObject(
+      "select created_by from referral_cohort_history where referral_id = ? order by created_at desc limit 1",
+      String::class.java,
+      referralEntity.id!!,
+    )
+
+    assertThat(latestCohortCreatedBy).isEqualTo("SYSTEM")
   }
 
   @Test
@@ -94,4 +138,10 @@ class AdminControllerIntegrationTest : IntegrationTestBase() {
   private fun buildPopulatePersonalDetailsResponse(
     ids: List<String>,
   ): PopulatePersonalDetailsRequest = PopulatePersonalDetailsRequest(referralIds = ids)
+
+  private fun countReferralCohortHistoryRows(referralId: java.util.UUID): Int = jdbcTemplate.queryForObject(
+    "select count(*) from referral_cohort_history where referral_id = ?",
+    Int::class.java,
+    referralId,
+  ) ?: 0
 }


### PR DESCRIPTION
**WHAT**

Update the ReferralService:refreshPersonalDetails method to always
create a new CohortHistory row if there isn't one.

**WHY**

When we import Referrals from IM, we don't get a Cohort information,
unlike when they are created from HMPPS Domain Events - which was the
world that existed when the original code was written.

This change means that we'll do a lot more checking of Cohort than
present.
