### PR TITLE
Apg 2329/guard all get user regions call sites

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
@@ -482,7 +482,8 @@ class ProgrammeGroupController(
   @GetMapping("/bff/pdus-for-user-region")
   fun getPdusInUserRegion(): ResponseEntity<List<CodeDescription>> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(emptyList())
     val pdusForRegion =
       regionService.getPdusForRegion(userRegion.code).map { CodeDescription(it.code, it.description) }
     return ResponseEntity.ok(pdusForRegion)
@@ -546,7 +547,8 @@ class ProgrammeGroupController(
   @GetMapping("/bff/region/members")
   fun getMembersInUserRegion(): ResponseEntity<List<UserTeamMember>> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(emptyList())
     val teamMembers = regionService.getTeamMembersForPdu(userRegion.code)
     return ResponseEntity.ok(teamMembers)
   }
@@ -704,8 +706,8 @@ class ProgrammeGroupController(
     val suggestedDate = scheduleService.getNextSlotDate(groupId, moduleId)
 
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
-    val facilitators = regionService.getTeamMembersForPdu(userRegion.code)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+    val facilitators = userRegion?.let { regionService.getTeamMembersForPdu(it.code) } ?: emptyList()
 
     val memberships = programmeGroupMembershipService.getActiveGroupMemberships(groupId)
     val groupMembers = memberships.map { membership ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/SessionController.kt
@@ -494,9 +494,9 @@ class SessionController(
   @GetMapping("/bff/session/{sessionId}/session-facilitators", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun retrieveSessionFacilitators(@PathVariable sessionId: UUID): ResponseEntity<EditSessionFacilitatorsResponse> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
     val regionFacilitators: MutableList<UserTeamMember> =
-      regionService.getTeamMembersForPdu(userRegion.code).toMutableList()
+      (userRegion?.let { regionService.getTeamMembersForPdu(it.code) } ?: emptyList()).toMutableList()
 
     return ResponseEntity.ok(sessionService.getSessionFacilitators(sessionId, regionFacilitators))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/UserController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/UserController.kt
@@ -57,7 +57,8 @@ class UserController(
   @GetMapping("/current-user/region", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getCurrentUserRegion(): ResponseEntity<CodeDescription> {
     val username = authenticationUtils.getUsername()
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: return ResponseEntity.ok(CodeDescription("UNKNOWN", "Unknown region"))
     return ResponseEntity.ok(userRegion)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -88,7 +88,8 @@ class ProgrammeGroupService(
   val log = LoggerFactory.getLogger(this::class.java)
 
   fun createGroup(createGroupRequest: CreateGroupRequest, username: String): ProgrammeGroupEntity {
-    val (userRegion) = userService.getUserRegions(username)
+    val userRegion = userService.getUserRegions(username).firstOrNull()
+      ?: throw NotFoundException("Cannot find any regions for user $username")
     programmeGroupRepository.findByCodeAndRegionName(createGroupRequest.groupCode, userRegion.description)
       ?.let { throw ConflictException("Programme group with code ${createGroupRequest.groupCode} already exists in region") }
 
@@ -351,8 +352,8 @@ class ProgrammeGroupService(
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
 
-    val (userRegion) = userService.getUserRegions(username)
-    val userRegionName = userRegion.description
+    val userRegionName = userService.getUserRegions(username)
+      .firstOrNull()?.description ?: "Unknown region"
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST
 
@@ -380,8 +381,9 @@ class ProgrammeGroupService(
   }
 
   fun getGroupInRegion(groupCode: String, username: String): ProgrammeGroupEntity? {
-    val (userRegion) = userService.getUserRegions(username)
-    return programmeGroupRepository.findByCodeAndRegionName(groupCode, userRegion.description)
+    val userRegionName = userService.getUserRegions(username).firstOrNull()?.description
+      ?: return null
+    return programmeGroupRepository.findByCodeAndRegionName(groupCode, userRegionName)
   }
 
   fun getGroupDetails(groupId: UUID): GroupDetailsResponse {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -89,7 +89,7 @@ class ProgrammeGroupService(
 
   fun createGroup(createGroupRequest: CreateGroupRequest, username: String): ProgrammeGroupEntity {
     val userRegion = userService.getUserRegions(username).firstOrNull()
-      ?: throw NotFoundException("Cannot find any regions for user $username")
+      ?: throw NotFoundException("Region for username $username not found")
     programmeGroupRepository.findByCodeAndRegionName(createGroupRequest.groupCode, userRegion.description)
       ?.let { throw ConflictException("Programme group with code ${createGroupRequest.groupCode} already exists in region") }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
@@ -29,7 +29,7 @@ class UserService(
 
     if (distinctRegionDescriptions.isEmpty()) {
       log.warn("No regions found for user: $username")
-      throw NotFoundException("Cannot find any regions (or teams) for user $username")
+      throw NotFoundException("Region for username $username not found")
     } else if (distinctRegionDescriptions.size > 1) {
       log.warn("User $username has more than one region on their account, going to use '${distinctRegionDescriptions.first()}'")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceIntegrationTest.kt
@@ -174,7 +174,7 @@ class ProgrammeGroupServiceIntegrationTest : IntegrationTestBase() {
         )
       }
 
-      assertThat(exception).hasMessageContaining("Cannot find any regions (or teams) for user the_username")
+      assertThat(exception).hasMessageContaining("Region for username the_username not found")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ServiceUserServiceTest.kt
@@ -16,8 +16,12 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheck
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.LimitedAccessOffenderCheckResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusUserTeam
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusUserTeams
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
@@ -269,5 +273,49 @@ class ServiceUserServiceTest {
     assertTrue(exception.message!!.contains("Unable to complete POST request"))
     verify { nDeliusIntegrationApiClient.verifyLimitedAccessOffenderCheck(username, listOf(identifier)) }
     verify { telemetryClient.logToAppInsights(any(), any()) }
+  }
+
+  @Test
+  fun `getFirstUserRegionDescription should throw NotFoundException when getUserRegions returns empty list`() {
+    // Given
+    val username = "user-no-region"
+    every { nDeliusIntegrationApiClient.getTeamsForUser(username) } returns
+      ClientResult.Success(body = NDeliusUserTeams(teams = emptyList()), status = HttpStatusCode.valueOf(200))
+    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
+
+    // When
+    val exception = assertThrows<NotFoundException> {
+      service.getFirstUserRegionDescription(username)
+    }
+
+    // Then
+    assertTrue(exception.message!!.contains("Region for username $username not found"))
+  }
+
+  @Test
+  fun `getFirstUserRegionDescription should return region description when getUserRegions returns regions`() {
+    // Given
+    val username = "user-with-region"
+    every { nDeliusIntegrationApiClient.getTeamsForUser(username) } returns
+      ClientResult.Success(
+        body = NDeliusUserTeams(
+          teams = listOf(
+            NDeliusUserTeam(
+              code = "TEAM001",
+              description = "Test Team",
+              pdu = CodeDescription("PDU001", "Test PDU"),
+              region = CodeDescription("REGION001", "North West"),
+            ),
+          ),
+        ),
+        status = HttpStatusCode.valueOf(200),
+      )
+    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
+
+    // When
+    val result = service.getFirstUserRegionDescription(username)
+
+    // Then
+    assertEquals("North West", result)
   }
 }


### PR DESCRIPTION
## [APG-2329] Guard all getUserRegions() call sites against empty list crash

### What

Aligns error handling across all `getUserRegions()` call sites to prevent `IndexOutOfBoundsException` when nDelius returns an empty list (user has no region assigned).

### Why

When nDelius is slow/unavailable or a user genuinely has no region on their account, `getUserRegions()` returns an empty list. Previously, Kotlin destructuring (`val (userRegion) = ...`) called `.get(0)` on this empty list, crashing with an unhandled 500 error.

Miroslav's PR #715 fixed one call site (`getGroupWaitlistDataByCriteria`). This PR ensures **all 11 call sites** are consistently guarded using the same pattern.

### Pattern

Two approaches depending on context:

- **Write operations** (create group, caselist filtering): `throw NotFoundException("Region for username $username not found")` — can't proceed without a region
- **Read/BFF endpoints** (PDU lookup, facilitator list, user region): graceful fallback returning empty list or null — page still loads in degraded state

### Call sites audited

| # | Location | Guard |
|---|----------|-------|
| 1 | `ProgrammeGroupService.createGroup()` | `throw NotFoundException` |
| 2 | `ProgrammeGroupService.getGroupWaitlistDataByCriteria()` | `throw NotFoundException` |
| 3 | `ProgrammeGroupService.getGroupInRegion()` | `return null` |
| 4 | `ProgrammeGroupService.getProgrammeGroupsForRegion()` | `throw NotFoundException` (via `getFirstUserRegionDescription`) |
| 5 | `ProgrammeGroupController.getPdusInUserRegion()` | `return emptyList()` |
| 6 | `ProgrammeGroupController.getMembersInUserRegion()` | `return emptyList()` |
| 7 | `ProgrammeGroupController.scheduleSession()` | nullable safe (`?.let`) |
| 8 | `SessionController.retrieveSessionFacilitators()` | nullable safe (`?.let`) |
| 9 | `UserController.getCurrentUserRegion()` | `return CodeDescription("UNKNOWN", ...)` |
| 10 | `ReferralCaseListItemService` (line 45) | `throw NotFoundException` (via `getFirstUserRegionDescription`) |
| 11 | `ReferralCaseListItemService` (line 98) | `return empty page` |

### Error message alignment

Standardised to: `"Region for username $username not found"` (consistent with #715).

### Related

- Fixes: APG-2329
- Companion to: #711 (cache `getUserRegions` with Caffeine)
- Follows: #715 (Miroslav's fix for one call site)

[APG-2329]: https://dsdmoj.atlassian.net/browse/APG-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ