### PR TITLE
perf: cache getUserRegions() with Caffeine (5 min TTL)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-cache")
+  implementation("com.github.ben-manes.caffeine:caffeine")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
   implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusRegionWithMembers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/client/nDeliusIntegrationApi/model/NDeliusRegionWithMembers.kt
@@ -12,7 +12,7 @@ data class NDeliusRegionWithMembers(
   data class NDeliusPduWithTeam(
     val code: String,
     val description: String,
-    val team: List<NDeliusUserTeamWithMembers>,
+    val team: List<NDeliusUserTeamWithMembers> = emptyList(),
   )
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/CacheConfiguration.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class CacheConfiguration {
+
+  @Bean
+  fun cacheManager(): CacheManager {
+    val cacheManager = CaffeineCacheManager()
+    cacheManager.registerCustomCache(
+      "user-regions",
+      Caffeine.newBuilder()
+        .expireAfterWrite(5, TimeUnit.MINUTES)
+        .maximumSize(500)
+        .build(),
+    )
+    cacheManager.registerCustomCache(
+      "bank-holidays",
+      Caffeine.newBuilder()
+        .expireAfterWrite(24, TimeUnit.HOURS)
+        .maximumSize(1)
+        .build(),
+    )
+    cacheManager.registerCustomCache(
+      "pni-daily",
+      Caffeine.newBuilder()
+        .expireAfterWrite(24, TimeUnit.HOURS)
+        .maximumSize(20000)
+        .build(),
+    )
+    return cacheManager
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -351,7 +351,9 @@ class ProgrammeGroupService(
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
 
-    val (userRegion) = userService.getUserRegions(username)
+    val (userRegion) = userService.getUserRegions(username).ifEmpty {
+      throw NotFoundException("Cannot find any regions (or teams) for user $username")
+    }
     val userRegionName = userRegion.description
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -351,8 +351,8 @@ class ProgrammeGroupService(
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
 
-    val userRegionName = userService.getUserRegions(username)
-      .firstOrNull()?.description ?: "Unknown region"
+    val (userRegion) = userService.getUserRegions(username)
+    val userRegionName = userRegion.description
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -351,10 +351,8 @@ class ProgrammeGroupService(
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
 
-    val (userRegion) = userService.getUserRegions(username).ifEmpty {
-      throw NotFoundException("Cannot find any regions (or teams) for user $username")
-    }
-    val userRegionName = userRegion.description
+    val userRegionName = userService.getUserRegions(username)
+      .firstOrNull()?.description ?: "Unknown region"
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ser
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
@@ -109,6 +110,7 @@ class UserService(
    * @param username The username to fetch regions for
    * @return List of region codes and names (descriptions) the user has access to
    */
+  @Cacheable(value = ["user-regions"], key = "#username", unless = "#result.isEmpty()")
   fun getUserRegions(username: String): List<CodeDescription> = when (val result = nDeliusIntegrationApiClient.getTeamsForUser(username)) {
     is ClientResult.Success -> {
       telemetryClient.logToAppInsights(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/UserService.kt
@@ -107,6 +107,10 @@ class UserService(
   /**
    * Fetches the list of region names that the given user has access to via their teams in nDelius.
    *
+   * Note: @Cacheable only works when called from outside this class (via Spring proxy).
+   * Calls from within this class (e.g. getFirstUserRegionDescription) bypass the cache.
+   * This is acceptable — most call sites invoke getUserRegions() directly from other services.
+   *
    * @param username The username to fetch regions for
    * @return List of region codes and names (descriptions) the user has access to
    */

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -3550,10 +3550,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     @Test
     fun `should return 200 when updating earliest start date`() {
       // Given
+      nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
       val group = testGroupHelper.createGroup()
-      val newStartDate = LocalDate.now().plusDays(10)
-      val updateRequest =
-        UpdateGroupRequest(earliestStartDate = newStartDate, automaticallyRescheduleOtherSessions = false)
 
       // When
       val response = performRequestAndExpectStatusWithBody(
@@ -3789,6 +3787,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     @Test
     fun `should return 200 when updating multiple fields at once`() {
       // Given
+      nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
       val group = testGroupHelper.createGroup()
       val updateRequest = UpdateGroupRequest(
         groupCode = "UPDATED_GROUP_CODE",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -150,6 +150,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
 
   @BeforeEach
   override fun beforeEach() {
+    super.beforeEach()
     testDataCleaner.cleanAllTables()
     nDeliusApiStubs.clearAllStubs()
     govUkApiStubs.stubBankHolidaysResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -3552,6 +3552,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
       val group = testGroupHelper.createGroup()
+      val newStartDate = LocalDate.now().plusDays(10)
+      val updateRequest = UpdateGroupRequest(earliestStartDate = newStartDate, automaticallyRescheduleOtherSessions = false)
 
       // When
       val response = performRequestAndExpectStatusWithBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/IntegrationTestBase.kt
@@ -106,6 +106,7 @@ abstract class IntegrationTestBase {
   fun beforeEach() {
     domainEventsQueueConfig.purgeAllQueues()
     cacheManager.getCache("bank-holidays")?.clear()
+    cacheManager.getCache("user-regions")?.clear()
   }
 
   companion object {


### PR DESCRIPTION
## [APG-2329] Cache getUserRegions() with Caffeine TTL

### What

- Added `@Cacheable` to `getUserRegions()` in `UserService.kt` — caches user region lookups by username, avoiding repeated nDelius calls for the same user within a session. Uses the `user-regions` cache with 5 min TTL.
- Added Caffeine cache dependency to `build.gradle.kts` with `CacheConfiguration.kt` defining named caches:
  - `user-regions`: 5 min TTL, max 500 entries
  - `bank-holidays`: 24h TTL, max 1 entry (existing cache, now with eviction)
  - `pni-daily`: 24h TTL, max 20k entries (existing cache, now with eviction)

### Why

Production logs show `ReadTimeoutException` on `GET /user/{username}/teams` (nDelius). Every page that needs user region data makes a live nDelius call — group allocations, caselist, PDU lookups, etc. Under load this causes socket timeouts in the UI.

Caching eliminates repeated nDelius calls for the same user within a 5-minute window. Empty results are **not** cached (`unless = "#result.isEmpty()"`) so transient failures don't poison the cache.

### Why Caffeine (not plain Spring cache)

Spring's built-in `ConcurrentMapCache` has **no TTL support** — cached values never expire. We need TTL so that:
- Region data refreshes automatically (user region changes visible within 5 min)
- Stale data doesn't persist indefinitely until app restart

The `@Bean` approach (vs `spring.cache.caffeine.spec`) is required because our three caches have different TTLs and sizes.

### Evidence from prod logs
io.netty.handler.timeout.ReadTimeoutException → UserService: Failed to fetch teams for user GLM19A

### Testing

- Existing tests pass
- Empty results are excluded from cache
- TTL ensures stale data refreshes within 5 minutes

### Related

- Companion PR: `APG-2329/guard-all-getUserRegions-call-sites` (guards all call sites against empty list crash)

[APG-2329]: https://dsdmoj.atlassian.net/browse/APG-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ