### PR TITLE
Ensure when creating referrals they are unique by CRN, eventId and SourcedFrom

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListener.kt
@@ -17,12 +17,8 @@ class DomainEventsListener(
   fun receive(sqsMessage: SQSMessage) {
     logger.info("Received Event of type: ${sqsMessage.eventType}")
     when (sqsMessage.eventType) {
-      REFERRAL_CREATED -> referralCreatedHandler.handle(sqsMessage)
+      HmppsDomainEventTypes.INTERVENTIONS_COMMUNITY_REFERRAL_CREATED.value -> referralCreatedHandler.handle(sqsMessage)
       else -> logger.info("Unknown event type ${sqsMessage.eventType}")
     }
-  }
-
-  companion object {
-    const val REFERRAL_CREATED = "interventions.community-referral.created"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/HmppsDomainEventTypes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/HmppsDomainEventTypes.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.eve
 enum class HmppsDomainEventTypes(val value: String) {
   ACP_COMMUNITY_PROGRAMME_COMPLETE("accredited-programmes-community.programme.complete"),
   ACP_COMMUNITY_REFERRAL_STATUS_UPDATED("accredited-programmes-community.referral.status-updated"),
+  INTERVENTIONS_COMMUNITY_REFERRAL_CREATED("interventions.community-referral.created"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCreatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCreatedHandler.kt
@@ -33,8 +33,8 @@ class ReferralCreatedHandler(
     if (domainEventMessage.detailUrl == null) {
       return log.info("Detail url is null for event with messageId: ${sqsMessage.messageId}")
     }
-    val referralId = extractReferralId(domainEventMessage.detailUrl)
-    log.info("Received referral created event for referral id: $referralId")
+    val referralId = UUID.fromString(domainEventMessage.detailUrl.split("/").last())
+    log.info("Received referral created event for referral id: $referralId for CRN: ${domainEventMessage.personReference.findCrn()}")
 
     telemetryClient.logToAppInsights(
       "Probation.case-requirement.created event received",
@@ -45,11 +45,13 @@ class ReferralCreatedHandler(
       ),
     )
 
-    messageHistoryRepository.save(domainEventMessage.toEntity(objectMapper.writeValueAsString(domainEventMessage)))
+    val savedMessage =
+      messageHistoryRepository.save(domainEventMessage.toEntity(objectMapper.writeValueAsString(domainEventMessage)))
 
     val referralDetails = referralService.getFindAndReferReferralDetails(referralId)
-    referralService.createReferral(referralDetails)
-  }
+    val savedReferral = referralService.createReferral(referralDetails)
 
-  private fun extractReferralId(detailUrl: String) = UUID.fromString(detailUrl.split("/").last())
+    savedMessage.referral = savedReferral
+    messageHistoryRepository.save(savedMessage)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
@@ -21,6 +22,12 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
 
   @EntityGraph(attributePaths = ["statusHistories"])
   fun findByCrn(crn: String): List<ReferralEntity>
+
+  fun findByCrnAndEventIdAndSourcedFrom(
+    crn: String,
+    eventId: String,
+    sourcedFrom: ReferralEntitySourcedFrom,
+  ): ReferralEntity?
 
   fun findAllByCreatedAtBefore(createdAtBefore: LocalDateTime): MutableList<ReferralEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -193,6 +193,16 @@ class ReferralService(
   }
 
   fun createReferral(findAndReferReferralDetails: FindAndReferReferralDetails): ReferralEntity {
+    // Check referral does not already exist in our system
+    val existingReferral = referralRepository.findByCrnAndEventIdAndSourcedFrom(
+      crn = findAndReferReferralDetails.personReference,
+      eventId = findAndReferReferralDetails.sourcedFromReference,
+      sourcedFrom = findAndReferReferralDetails.sourcedFromReferenceType,
+    )
+    if (existingReferral != null) {
+      return existingReferral
+    }
+
     val pniScore = pniService.getPniCalculation(findAndReferReferralDetails.personReference)
     val sentenceEndDate = sentenceService.getSentenceEndDate(
       findAndReferReferralDetails.personReference,
@@ -254,8 +264,7 @@ class ReferralService(
     }
 
     log.info("Inserting referral for Intervention: '${referralEntity.interventionName}' and Crn: '${referralEntity.crn}' with cohort: $cohort and Ldc status: '$hasLdc'")
-    referralRepository.save(referralEntity)
-    return getReferralById(referral.id!!)
+    return referralRepository.save(referralEntity)
   }
 
   fun getReferralById(referralId: UUID): ReferralEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralService.kt
@@ -200,6 +200,7 @@ class ReferralService(
       sourcedFrom = findAndReferReferralDetails.sourcedFromReferenceType,
     )
     if (existingReferral != null) {
+      log.debug("Referral with eventId: ${findAndReferReferralDetails.sourcedFromReference}, CRN: ${findAndReferReferralDetails.personReference} and sourcedFrom: ${findAndReferReferralDetails.sourcedFromReference} already exists in our system.")
       return existingReferral
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -508,7 +508,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       .produce()
 
     val requirementMessage = DomainEventsMessageFactory()
-      .withDetailUrl("http://find-and-refer/referral/$farLicenceConditionReferralId")
+      .withDetailUrl("http://find-and-refer/referral/$farRequirementReferralId")
       .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
       .produce()
 
@@ -526,7 +526,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
 
     val savedReferrals = referralRepository.findByCrn(crn)
 
-    assertThat(savedReferrals).hasSize(1)
+    assertThat(savedReferrals).hasSize(2)
 
     val savedMessages = messageHistoryRepository.findAll()
     assertThat(savedMessages).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -437,7 +437,6 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
             .withBody(objectMapper.writeValueAsString(findAndReferReferralDetails)),
         ),
     )
-    oasysApiStubs.stubSuccessfulPniResponse(crn)
     val domainEventsMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
       .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
@@ -454,12 +453,13 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       }
     } matches { it == 0 }
 
-    val savedReferrals = referralRepository.findByCrn(crn)
+    await untilCallTo {
+      referralRepository.findByCrn(crn)
+    } matches { it?.size == 1 }
 
-    assertThat(savedReferrals).hasSize(1)
-
-    val savedMessages = messageHistoryRepository.findAll()
-    assertThat(savedMessages).hasSize(2)
+    await untilCallTo {
+      messageHistoryRepository.findAll()
+    } matches { it?.size == 2 }
   }
 
   @Test
@@ -468,14 +468,14 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     val farLicenceConditionReferralId = UUID.randomUUID()
     val farRequirementReferralId = UUID.randomUUID()
     val farLicenceConditionDetails = FindAndReferReferralDetailsFactory()
-      .withReferralId(sourceReferralId)
+      .withReferralId(farLicenceConditionReferralId)
       .withPersonReference(crn)
       .withPersonReferenceType(PersonReferenceType.CRN)
       .withSourcedFromReferenceType(ReferralEntitySourcedFrom.LICENCE_CONDITION)
       .withEventNumber(eventNumber)
       .produce()
     val farRequirementDetails = FindAndReferReferralDetailsFactory()
-      .withReferralId(sourceReferralId)
+      .withReferralId(farRequirementReferralId)
       .withPersonReference(crn)
       .withPersonReferenceType(PersonReferenceType.CRN)
       .withSourcedFromReferenceType(ReferralEntitySourcedFrom.REQUIREMENT)
@@ -500,7 +500,6 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
             .withBody(objectMapper.writeValueAsString(farRequirementDetails)),
         ),
     )
-    oasysApiStubs.stubSuccessfulPniResponse(crn)
     val licenceConditionMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$farLicenceConditionReferralId")
       .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
@@ -523,11 +522,12 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       }
     } matches { it == 0 }
 
-    val savedReferrals = referralRepository.findByCrn(crn)
+    await untilCallTo {
+      referralRepository.findByCrn(crn)
+    } matches { it?.size == 2 }
 
-    assertThat(savedReferrals).hasSize(2)
-
-    val savedMessages = messageHistoryRepository.findAll()
-    assertThat(savedMessages).hasSize(2)
+    await untilCallTo {
+      messageHistoryRepository.findAll()
+    } matches { it?.size == 2 }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -53,6 +53,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     crn = randomCrn()
     eventNumber = randomNumberAsInt(11)
     testDataCleaner.cleanAllTables()
+    wiremock.resetAll()
 
     sourceReferralId = UUID.randomUUID()
     stubAuthTokenEndpoint()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Ldc
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomCrn
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumberAsInt
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
@@ -33,9 +35,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
 
-// TODO remove this suppression when this issue is fixed
-// https://youtrack.jetbrains.com/issue/KT-78352/False-positive-IDENTITYSENSITIVEOPERATIONSWITHVALUETYPE-when-comparing-with-equality-operator
-@Suppress("IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE")
 class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
 
   companion object {
@@ -50,16 +49,15 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
 
   lateinit var sourceReferralId: UUID
 
+  val crn = randomCrn()
+  val eventNumber = randomNumberAsInt()
+
   @BeforeEach
   fun setUp() {
     testDataCleaner.cleanAllTables()
 
     sourceReferralId = UUID.randomUUID()
     stubAuthTokenEndpoint()
-    log.info("Setting up ReferralDetails with id: $sourceReferralId")
-
-    val crn = "X123456"
-    val eventNumber = 1
 
     val findAndReferReferralDetails = FindAndReferReferralDetailsFactory()
       .withInterventionName("Test Intervention")
@@ -82,7 +80,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
         ),
     )
 
-    oasysApiStubs.stubSuccessfulPniResponse("X123456")
+    oasysApiStubs.stubSuccessfulPniResponse(crn)
 
     val personalDetails = NDeliusPersonalDetailsFactory()
       .withName(
@@ -181,7 +179,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     // Given
     val domainEventsMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
-      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", "X957673"))))
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
       .produce()
 
     // When
@@ -198,19 +196,21 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       referralRepository.findAll().firstOrNull()
     } matches {
       assertThat(it).isNotNull()
-      it!!.setting == SettingType.COMMUNITY
-      it.crn == "X123456"
-      it.interventionName == "Test Intervention"
-      it.interventionType == InterventionType.ACP
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
-      it.eventId == "LIC-12345"
-      it.personName == "John Alex Doe"
-      it.sex == "Male"
-      it.dateOfBirth == LocalDate.parse("2000-10-01")
-      it.referralReportingLocation!!.reportingTeam == "TEAM_1"
-      it.referralReportingLocation!!.pduName == "PDU_1"
-      it.referralReportingLocation!!.regionName == "REGION_1"
-      it.sentenceEndDate!! == LocalDate.parse("2025-10-01")
+      assertThat(it).isNotNull()
+      assertThat(it!!.setting).isEqualTo(SettingType.COMMUNITY)
+      assertThat(it.crn).isEqualTo(crn)
+      assertThat(it.interventionName).isEqualTo("Test Intervention")
+      assertThat(it.interventionType).isEqualTo(InterventionType.ACP)
+      assertThat(it.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      assertThat(it.eventId).isEqualTo("LIC-12345")
+      assertThat(it.personName).isEqualTo("John Alex Doe")
+      assertThat(it.sex).isEqualTo("Male")
+      assertThat(it.dateOfBirth).isEqualTo(LocalDate.parse("2000-10-01"))
+      assertThat(it.referralReportingLocation!!.reportingTeam).isEqualTo("TEAM_1")
+      assertThat(it.referralReportingLocation!!.pduName).isEqualTo("PDU_1")
+      assertThat(it.referralReportingLocation!!.regionName).isEqualTo("REGION_1")
+      assertThat(it.sentenceEndDate).isEqualTo(LocalDate.parse("2025-10-01"))
+      true
     }
 
     messageHistoryRepository.findAll().first().let {
@@ -230,7 +230,6 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should create referral and automatically assign ldc status true when score greater than or equal to 3 and on receipt of community referral creation message`() {
     // Given
-    val crn = "X123456"
     val ldc = Ldc(
       score = 4,
       subTotal = 4,
@@ -238,7 +237,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     oasysApiStubs.stubSuccessfulPniResponseWithLdc(crn, ldc)
     val domainEventsMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
-      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", "X957673"))))
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
       .produce()
 
     // When
@@ -255,20 +254,21 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       referralRepository.findAll().firstOrNull()
     } matches {
       assertThat(it).isNotNull()
-      it!!.setting == SettingType.COMMUNITY
-      it.crn == "X123456"
-      it.interventionName == "Test Intervention"
-      it.interventionType == InterventionType.ACP
-      it.statusHistories.first().referralStatusDescription.description == "Awaiting assessment"
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
-      it.eventId == "LIC-12345"
-      it.personName == "John Alex Doe"
-      it.sex == "Male"
-      it.dateOfBirth == LocalDate.parse("2000-10-01")
-      it.referralLdcHistories.first().hasLdc
-      it.referralReportingLocation!!.reportingTeam == "TEAM_1"
-      it.referralReportingLocation!!.pduName == "PDU_1"
-      it.sentenceEndDate!! == LocalDate.parse("2025-10-01")
+      assertThat(it!!.setting).isEqualTo(SettingType.COMMUNITY)
+      assertThat(it.crn).isEqualTo(crn)
+      assertThat(it.interventionName).isEqualTo("Test Intervention")
+      assertThat(it.interventionType).isEqualTo(InterventionType.ACP)
+      assertThat(it.statusHistories.first().referralStatusDescription.description).isEqualTo("Awaiting assessment")
+      assertThat(it.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      assertThat(it.eventId).isEqualTo("LIC-12345")
+      assertThat(it.personName).isEqualTo("John Alex Doe")
+      assertThat(it.sex).isEqualTo("Male")
+      assertThat(it.dateOfBirth).isEqualTo(LocalDate.parse("2000-10-01"))
+      assertThat(it.referralLdcHistories.first().hasLdc).isTrue
+      assertThat(it.referralReportingLocation!!.reportingTeam).isEqualTo("TEAM_1")
+      assertThat(it.referralReportingLocation!!.pduName).isEqualTo("PDU_1")
+      assertThat(it.sentenceEndDate!!).isEqualTo(LocalDate.parse("2025-10-01"))
+      true
     }
 
     messageHistoryRepository.findAll().first().let {
@@ -288,7 +288,6 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should create referral and automatically assign ldc status false when score less than 3 and on receipt of community referral creation message`() {
     // Given
-    val crn = "X123456"
     val ldc = Ldc(
       score = 2,
       subTotal = 2,
@@ -296,7 +295,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
     oasysApiStubs.stubSuccessfulPniResponseWithLdc(crn, ldc)
     val domainEventsMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
-      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", "X957673"))))
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
       .produce()
 
     // When
@@ -313,21 +312,22 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       referralRepository.findAll().firstOrNull()
     } matches {
       assertThat(it).isNotNull()
-      it!!.setting == SettingType.COMMUNITY
-      it.crn == "X123456"
-      it.interventionName == "Test Intervention"
-      it.interventionType == InterventionType.ACP
-      it.statusHistories.first().referralStatusDescription.description == "Awaiting assessment"
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
-      it.eventId == "LIC-12345"
-      it.sex == "Male"
-      it.dateOfBirth == LocalDate.parse("2000-10-01")
-      !it.referralLdcHistories.first().hasLdc
-      it.referralLdcHistories.first().createdBy == "SYSTEM"
-      it.personName == "John Alex Doe"
-      it.referralReportingLocation!!.reportingTeam == "TEAM_1"
-      it.referralReportingLocation!!.pduName == "PDU_1"
-      it.sentenceEndDate!! == LocalDate.parse("2025-10-01")
+      assertThat(it!!.setting).isEqualTo(SettingType.COMMUNITY)
+      assertThat(it.crn).isEqualTo(crn)
+      assertThat(it.interventionName).isEqualTo("Test Intervention")
+      assertThat(it.interventionType).isEqualTo(InterventionType.ACP)
+      assertThat(it.statusHistories.first().referralStatusDescription.description).isEqualTo("Awaiting assessment")
+      assertThat(it.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      assertThat(it.eventId).isEqualTo("LIC-12345")
+      assertThat(it.sex).isEqualTo("Male")
+      assertThat(it.dateOfBirth).isEqualTo(LocalDate.parse("2000-10-01"))
+      assertThat(it.referralLdcHistories.first().hasLdc).isFalse()
+      assertThat(it.referralLdcHistories.first().createdBy).isEqualTo("SYSTEM")
+      assertThat(it.personName).isEqualTo("John Alex Doe")
+      assertThat(it.referralReportingLocation!!.reportingTeam).isEqualTo("TEAM_1")
+      assertThat(it.referralReportingLocation!!.pduName).isEqualTo("PDU_1")
+      assertThat(it.sentenceEndDate).isEqualTo(LocalDate.parse("2025-10-01"))
+      true
     }
 
     messageHistoryRepository.findAll().first().let {
@@ -347,12 +347,11 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should create referral and automatically assign ldc status false on receipt of community referral creation message when PNI doesn't exist`() {
     // Given
-    val crn = "X123456"
 
     oasysApiStubs.stubNotFoundPniResponse(crn)
     val domainEventsMessage = DomainEventsMessageFactory()
       .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
-      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", "X957673"))))
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
       .produce()
 
     // When
@@ -369,23 +368,23 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       referralRepository.findAll().firstOrNull()
     } matches {
       assertThat(it).isNotNull()
-      it!!.setting == SettingType.COMMUNITY
-      it.crn == "X123456"
-      it.interventionName == "Test Intervention"
-      it.interventionType == InterventionType.ACP
-      it.statusHistories.first().referralStatusDescription.description == "Awaiting assessment"
-      it.sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION
-      it.eventId == "LIC-12345"
-      it.sex == "Male"
-      it.dateOfBirth == LocalDate.parse("2000-10-01")
-      !it.referralLdcHistories.first().hasLdc
-      it.referralLdcHistories.first().createdBy == "SYSTEM"
-      it.personName == "John Alex Doe"
-      it.referralReportingLocation!!.reportingTeam == "TEAM_1"
-      it.referralReportingLocation!!.pduName == "PDU_1"
-      it.sentenceEndDate!! == LocalDate.parse("2025-10-01")
+      assertThat(it!!.setting).isEqualTo(SettingType.COMMUNITY)
+      assertThat(it.crn).isEqualTo(crn)
+      assertThat(it.interventionName).isEqualTo("Test Intervention")
+      assertThat(it.interventionType).isEqualTo(InterventionType.ACP)
+      assertThat(it.statusHistories.first().referralStatusDescription.description).isEqualTo("Awaiting assessment")
+      assertThat(it.sourcedFrom).isEqualTo(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      assertThat(it.eventId).isEqualTo("LIC-12345")
+      assertThat(it.sex).isEqualTo("Male")
+      assertThat(it.dateOfBirth).isEqualTo(LocalDate.parse("2000-10-01"))
+      assertThat(it.referralLdcHistories.first().hasLdc).isFalse()
+      assertThat(it.referralLdcHistories.first().createdBy).isEqualTo("SYSTEM")
+      assertThat(it.personName).isEqualTo("John Alex Doe")
+      assertThat(it.referralReportingLocation!!.reportingTeam).isEqualTo("TEAM_1")
+      assertThat(it.referralReportingLocation!!.pduName).isEqualTo("PDU_1")
+      assertThat(it.sentenceEndDate).isEqualTo(LocalDate.parse("2025-10-01"))
+      true
     }
-
     messageHistoryRepository.findAll().first().let {
       assertThat(it.id).isNotNull
       assertThat(it.eventType).isEqualTo(domainEventsMessage.eventType)
@@ -417,5 +416,119 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
         e.message
       }
     } matches { it == "Unexpected event type received: unknown.event.type.created" }
+  }
+
+  @Test
+  fun `should not duplicate referral when eventId, CRN and sourcedFrom are identical to existing referral`() {
+    // Given
+    val findAndReferReferralDetails = FindAndReferReferralDetailsFactory()
+      .withReferralId(sourceReferralId)
+      .withPersonReference(crn)
+      .withPersonReferenceType(PersonReferenceType.CRN)
+      .withSourcedFromReferenceType(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      .withEventNumber(eventNumber)
+      .produce()
+
+    wiremock.stubFor(
+      get(urlEqualTo("/referral/$sourceReferralId"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(findAndReferReferralDetails)),
+        ),
+    )
+    oasysApiStubs.stubSuccessfulPniResponse(crn)
+    val domainEventsMessage = DomainEventsMessageFactory()
+      .withDetailUrl("http://find-and-refer/referral/$sourceReferralId")
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
+      .produce()
+
+    // When
+    // Send identical event twice
+    repeat(2) { domainEventsQueueConfig.sendDomainEvent(domainEventsMessage) }
+
+    // Then
+    await withPollDelay ofMillis(100) untilCallTo {
+      with(domainEventsQueueConfig) {
+        domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+      }
+    } matches { it == 0 }
+
+    val savedReferrals = referralRepository.findByCrn(crn)
+
+    assertThat(savedReferrals).hasSize(1)
+
+    val savedMessages = messageHistoryRepository.findAll()
+    assertThat(savedMessages).hasSize(2)
+  }
+
+  @Test
+  fun `should insert referral when eventId and CRN are identical but sourcedFrom is different to existing referral`() {
+    // Given
+    val farLicenceConditionReferralId = UUID.randomUUID()
+    val farRequirementReferralId = UUID.randomUUID()
+    val farLicenceConditionDetails = FindAndReferReferralDetailsFactory()
+      .withReferralId(sourceReferralId)
+      .withPersonReference(crn)
+      .withPersonReferenceType(PersonReferenceType.CRN)
+      .withSourcedFromReferenceType(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      .withEventNumber(eventNumber)
+      .produce()
+    val farRequirementDetails = FindAndReferReferralDetailsFactory()
+      .withReferralId(sourceReferralId)
+      .withPersonReference(crn)
+      .withPersonReferenceType(PersonReferenceType.CRN)
+      .withSourcedFromReferenceType(ReferralEntitySourcedFrom.REQUIREMENT)
+      .withEventNumber(eventNumber)
+      .produce()
+
+    wiremock.stubFor(
+      get(urlEqualTo("/referral/$farLicenceConditionReferralId"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(farLicenceConditionDetails)),
+        ),
+    )
+    wiremock.stubFor(
+      get(urlEqualTo("/referral/$farRequirementReferralId"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(farRequirementDetails)),
+        ),
+    )
+    oasysApiStubs.stubSuccessfulPniResponse(crn)
+    val licenceConditionMessage = DomainEventsMessageFactory()
+      .withDetailUrl("http://find-and-refer/referral/$farLicenceConditionReferralId")
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
+      .produce()
+
+    val requirementMessage = DomainEventsMessageFactory()
+      .withDetailUrl("http://find-and-refer/referral/$farLicenceConditionReferralId")
+      .withPersonReference(PersonReference(listOf(PersonReference.Identifier("CRN", crn))))
+      .produce()
+
+    // When
+    // Send separate events with same eventId but different sourcedFrom types
+    domainEventsQueueConfig.sendDomainEvent(licenceConditionMessage)
+    domainEventsQueueConfig.sendDomainEvent(requirementMessage)
+
+    // Then
+    await withPollDelay ofMillis(100) untilCallTo {
+      with(domainEventsQueueConfig) {
+        domainEventQueueClient.countMessagesOnQueue(domainEventQueue.queueUrl).get()
+      }
+    } matches { it == 0 }
+
+    val savedReferrals = referralRepository.findByCrn(crn)
+
+    assertThat(savedReferrals).hasSize(1)
+
+    val savedMessages = messageHistoryRepository.findAll()
+    assertThat(savedMessages).hasSize(2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.awaitility.kotlin.untilCallTo
 import org.awaitility.kotlin.withPollDelay
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
@@ -34,12 +33,9 @@ import java.time.Duration.ofMillis
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
+import kotlin.properties.Delegates
 
 class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
-
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
 
   @Autowired
   lateinit var messageHistoryRepository: MessageHistoryRepository
@@ -49,11 +45,13 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
 
   lateinit var sourceReferralId: UUID
 
-  val crn = randomCrn()
-  val eventNumber = randomNumberAsInt()
+  lateinit var crn: String
+  var eventNumber by Delegates.notNull<Int>()
 
   @BeforeEach
   fun setUp() {
+    crn = randomCrn()
+    eventNumber = randomNumberAsInt(11)
     testDataCleaner.cleanAllTables()
 
     sourceReferralId = UUID.randomUUID()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.toFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Osp
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.RiskScoreLevel
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomAlphanumericString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomCrn
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
@@ -113,6 +114,7 @@ class TestReferralHelper {
     cohort: OffenceCohort = OffenceCohort.GENERAL_OFFENCE,
     dateOfBirth: LocalDate? = null,
     sentenceEndDate: LocalDate? = null,
+    sourcedFromReference: String = randomAlphanumericString(11),
   ): ReferralEntity {
     val findAndReferReferralDetails = FindAndReferReferralDetailsFactory()
       .withInterventionName("Test Intervention")
@@ -121,7 +123,7 @@ class TestReferralHelper {
       .withPersonReference(crn)
       .withPersonReferenceType(PersonReferenceType.CRN)
       .withSourcedFromReferenceType(sourcedFrom)
-      .withSourcedFromReference("2500876919")
+      .withSourcedFromReference(sourcedFromReference)
       .withEventNumber(1)
       .produce()
 
@@ -260,7 +262,10 @@ class TestReferralHelper {
    * @param statusEntity The status to set. If null, defaults to AWAITING_ALLOCATION status.
    * @return The created and updated [ReferralEntity]
    */
-  fun createReferralAndUpdateStatus(statusEntity: ReferralStatusDescriptionEntity? = null, personName: String? = null): ReferralEntity {
+  fun createReferralAndUpdateStatus(
+    statusEntity: ReferralStatusDescriptionEntity? = null,
+    personName: String? = null,
+  ): ReferralEntity {
     val status = statusEntity ?: referralStatusDescriptionRepository.getAwaitingAllocationStatusDescription()
     val referral = if (personName != null) createReferral(personName = personName) else createReferral()
     referralService.updateStatus(referral, status.id, null, "AUTH_USER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -12,9 +12,9 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.toFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Osp
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.RiskScoreLevel
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomAlphanumericString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomCrn
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomFullName
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomNumberAsInt
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomUppercaseString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
@@ -114,7 +114,7 @@ class TestReferralHelper {
     cohort: OffenceCohort = OffenceCohort.GENERAL_OFFENCE,
     dateOfBirth: LocalDate? = null,
     sentenceEndDate: LocalDate? = null,
-    sourcedFromReference: String = randomAlphanumericString(11),
+    sourcedFromReference: String = randomNumberAsInt(11).toString(),
   ): ReferralEntity {
     val findAndReferReferralDetails = FindAndReferReferralDetailsFactory()
       .withInterventionName("Test Intervention")


### PR DESCRIPTION
## WHAT 

When referrals are created in our system via event we currently do not check whether they already exist. The Find and Refer Service has duplicate detection but it looks like in some rare cases we have sent multiple events and therefore created multiple referrals in the Manage and Deliver service.

This PR ensures that all newly created referrals are unique by `CRN`, `EventId` and `SourcedFrom`. The `SourcedFrom` is needed as in theory there could be identical `eventIds` for the same crn for either a `LICENCE_CONDITION` or `Requirement` as these values can overlap in delius.