### PR TITLE
Apg 2332/populate ndelius call correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RemoveFromGroupRequest
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RemoveFromGroupResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.ConflictException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
@@ -16,6 +18,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusHistoryEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
@@ -36,6 +39,7 @@ class ProgrammeGroupMembershipService(
   private val referralStatusDescriptionRepository: ReferralStatusDescriptionRepository,
   private val programmeGroupMembershipRepository: ProgrammeGroupMembershipRepository,
   private val scheduleService: ScheduleService,
+  private val nDeliusIntegrationApiClient: NDeliusIntegrationApiClient,
   private val telemetryClient: TelemetryClient,
   private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
@@ -60,6 +64,11 @@ class ProgrammeGroupMembershipService(
 
     getCurrentlyAllocatedGroup(referral)
       ?.let { throw ConflictException("Referral with id ${referral.id} is already allocated to a group: ${it.programmeGroup.code}") }
+
+    // Validate the referral's requirement/licence condition exists in nDelius before mutating state.
+    // This is an intentional extra GET call on every allocation to fail fast with a clear error message
+    // rather than getting a cryptic 400 from POST /appointments after state has been partially mutated.
+    validateReferralSentenceDataExistsInNDelius(referral)
 
     log.info("Adding referral with id: $referralId to group with id: $groupId and groupCode: ${group.code}")
 
@@ -205,5 +214,94 @@ class ProgrammeGroupMembershipService(
 
     log.info("...Successfully found Referral (${referral.id}), Group (${group.id}), and Membership (${groupMembership.id}) to remove")
     return programmeGroupRepository.save(group)
+  }
+
+  /**
+   * Validates that the referral's requirement or licence condition still exists in nDelius
+   * before attempting to create appointments. This prevents 400 errors from nDelius when
+   * the sentence data is stale (e.g., after a transfer or sentence termination).
+   */
+  private fun validateReferralSentenceDataExistsInNDelius(referral: ReferralEntity) {
+    val eventId = referral.eventId
+    if (eventId == null) {
+      log.error("Cannot validate nDelius sentence data: eventId is null for referral ${referral.id}")
+      throw BusinessException(
+        "Cannot allocate referral to group: the referral has no associated requirement or licence condition ID. " +
+          "Please update the referral's sentence data before allocating to a group.",
+      )
+    }
+
+    val sourcedFrom = referral.sourcedFrom
+    if (sourcedFrom == null) {
+      log.error("Cannot validate nDelius sentence data: sourcedFrom is null for referral ${referral.id}")
+      throw BusinessException(
+        "Cannot allocate referral to group: the referral's sentence source type is not set. " +
+          "Please update the referral's sentence data before allocating to a group.",
+      )
+    }
+
+    val result = when (sourcedFrom) {
+      ReferralEntitySourcedFrom.REQUIREMENT ->
+        nDeliusIntegrationApiClient.getRequirementManagerDetails(referral.crn, eventId)
+
+      ReferralEntitySourcedFrom.LICENCE_CONDITION ->
+        nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(referral.crn, eventId)
+    }
+
+    val sourceType = when (sourcedFrom) {
+      ReferralEntitySourcedFrom.REQUIREMENT -> "requirement"
+      ReferralEntitySourcedFrom.LICENCE_CONDITION -> "licence condition"
+    }
+
+    when (result) {
+      is ClientResult.Success -> {
+        log.info("nDelius validation passed for referral ${referral.id}: ${sourcedFrom.name} $eventId exists")
+      }
+
+      is ClientResult.Failure.StatusCode -> {
+        log.error(
+          "nDelius validation failed for referral ${referral.id}: $sourceType with ID $eventId " +
+            "does not exist in nDelius for CRN ${referral.crn} (status: ${result.status})",
+        )
+        telemetryClient.logToAppInsights(
+          "Referral.allocate-to-group.ndelius-validation-failure",
+          mapOf(
+            "referralId" to referral.id.toString(),
+            "crn" to referral.crn,
+            "sourcedFrom" to sourcedFrom.name,
+            "eventId" to eventId,
+            "statusCode" to result.status.toString(),
+          ),
+        )
+        throw BusinessException(
+          "Cannot allocate referral to group: the $sourceType (ID: $eventId) for this referral " +
+            "no longer exists in nDelius. The sentence data may be stale following a transfer or termination. " +
+            "Please update the referral's sentence data before allocating to a group.",
+        )
+      }
+
+      is ClientResult.Failure.Other -> {
+        log.error(
+          "nDelius validation failed for referral ${referral.id}: unable to reach nDelius " +
+            "to verify $sourceType with ID $eventId for CRN ${referral.crn}",
+          result.exception,
+        )
+        telemetryClient.logToAppInsights(
+          "Referral.allocate-to-group.ndelius-validation-failure",
+          mapOf(
+            "referralId" to referral.id.toString(),
+            "crn" to referral.crn,
+            "sourcedFrom" to sourcedFrom.name,
+            "eventId" to eventId,
+            "errorType" to "network",
+            "errorMessage" to (result.exception.message ?: "unknown"),
+          ),
+        )
+        throw BusinessException(
+          "Cannot allocate referral to group: unable to reach nDelius to verify sentence data. " +
+            "Please try again later.",
+        )
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipService.kt
@@ -255,7 +255,7 @@ class ProgrammeGroupMembershipService(
 
     when (result) {
       is ClientResult.Success -> {
-        log.info("nDelius validation passed for referral ${referral.id}: ${sourcedFrom.name} $eventId exists")
+        log.debug("nDelius validation passed for referral ${referral.id}: ${sourcedFrom.name} $eventId exists")
       }
 
       is ClientResult.Failure.StatusCode -> {
@@ -274,9 +274,9 @@ class ProgrammeGroupMembershipService(
           ),
         )
         throw BusinessException(
-          "Cannot allocate referral to group: the $sourceType (ID: $eventId) for this referral " +
+          "Cannot allocate referral to group: the $sourceType linked to this referral " +
             "no longer exists in nDelius. The sentence data may be stale following a transfer or termination. " +
-            "Please update the referral's sentence data before allocating to a group.",
+            "Please contact your admin to update the referral's sentence data.",
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusCaseRequirementOrLicenceConditionResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusCaseRequirementOrLicenceConditionResponseFactory.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory
+
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnitWithOfficeLocations
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementStaff
+
+class NDeliusCaseRequirementOrLicenceConditionResponseFactory {
+  private var eventNumber: Int = 1
+  private var staffCode: String = "STAFF001"
+  private var staffName: FullName = FullName(forename = "Test", middleNames = null, surname = "Staff")
+  private var teamCode: String = "TEAM001"
+  private var teamDescription: String = "Test Team"
+  private var pduCode: String = "PDU001"
+  private var pduDescription: String = "Test PDU"
+  private var officeLocations: List<CodeDescription> = emptyList()
+  private var probationDeliveryUnits: List<NDeliusApiProbationDeliveryUnitWithOfficeLocations> = emptyList()
+
+  fun withEventNumber(eventNumber: Int) = apply { this.eventNumber = eventNumber }
+  fun withStaffCode(staffCode: String) = apply { this.staffCode = staffCode }
+  fun withStaffName(staffName: FullName) = apply { this.staffName = staffName }
+  fun withTeam(code: String, description: String) = apply {
+    this.teamCode = code
+    this.teamDescription = description
+  }
+  fun withPdu(code: String, description: String) = apply {
+    this.pduCode = code
+    this.pduDescription = description
+  }
+  fun withOfficeLocations(officeLocations: List<CodeDescription>) = apply { this.officeLocations = officeLocations }
+
+  fun produce() = NDeliusCaseRequirementOrLicenceConditionResponse(
+    eventNumber = eventNumber,
+    manager = RequirementOrLicenceConditionManager(
+      staff = RequirementStaff(code = staffCode, name = staffName),
+      team = CodeDescription(teamCode, teamDescription),
+      probationDeliveryUnit = NDeliusApiProbationDeliveryUnit(pduCode, pduDescription),
+      officeLocations = officeLocations,
+    ),
+    probationDeliveryUnits = probationDeliveryUnits,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.clie
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FacilitatorEntityFactory
@@ -56,15 +57,15 @@ class ProgrammeGroupMembershipServiceTest {
     )
   }
 
-  @Test
-  fun `should allocate referral to group`() {
-    // Given
-    val referralId = UUID.randomUUID()
-    val groupId = UUID.randomUUID()
-    val allocatedToGroupBy = "testAdmin"
-    val additionalDetails = "test additional details"
-    val referralEntity = ReferralEntityFactory().withPersonName("John Smith").withId(referralId)
-      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
+  /**
+   * Sets up common mocks for allocateReferralToGroup tests.
+   * Returns a Triple of (referralId, groupId, referralEntity) for use in assertions.
+   */
+  private fun setupAllocationMocks(
+    referralEntity: ReferralEntity,
+    groupId: UUID = UUID.randomUUID(),
+  ): Pair<UUID, UUID> {
+    val referralId = referralEntity.id!!
     val facilitator = FacilitatorEntityFactory().produce()
     val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
     val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
@@ -75,6 +76,18 @@ class ProgrammeGroupMembershipServiceTest {
     every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
     every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
     every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
+    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
+
+    return referralId to groupId
+  }
+
+  @Test
+  fun `should allocate referral to group`() {
+    // Given
+    val referralEntity = ReferralEntityFactory().withPersonName("John Smith").withId(UUID.randomUUID())
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
+    val (referralId, groupId) = setupAllocationMocks(referralEntity)
+
     every { referralRepository.save(referralEntity) } returns referralEntity
     every { nDeliusIntegrationApiClient.getRequirementManagerDetails(any(), any()) } returns ClientResult.Success(
       HttpStatusCode.valueOf(200),
@@ -82,111 +95,77 @@ class ProgrammeGroupMembershipServiceTest {
     )
     every { scheduleService.createNdeliusAppointmentsForSessions(any()) } returns Unit
     every { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) } returns Unit
-    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
 
     // When
-    val result = service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+    val result = service.allocateReferralToGroup(referralId, groupId, "testAdmin", "test additional details")
 
     // Then
     assertThat(result).isNotNull()
     assertThat(result).isEqualTo(referralEntity)
-    verify { referralRepository.findByIdOrNull(referralId) }
-    verify { programmeGroupRepository.findByIdOrNull(groupId) }
-    verify { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) }
-    verify { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) }
-    verify { referralStatusDescriptionRepository.getScheduledStatusDescription() }
     verify { nDeliusIntegrationApiClient.getRequirementManagerDetails(referralEntity.crn, referralEntity.eventId!!) }
     verify { referralRepository.save(referralEntity) }
     verify { scheduleService.createNdeliusAppointmentsForSessions(any()) }
     verify { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) }
-    verify { telemetryClient.logToAppInsights(any(), any()) }
   }
 
   @Test
   fun `should throw BusinessException when referral licence condition does not exist in nDelius`() {
     // Given
-    val referralId = UUID.randomUUID()
-    val groupId = UUID.randomUUID()
-    val allocatedToGroupBy = "testAdmin"
-    val additionalDetails = "test additional details"
     val referralEntity = ReferralEntityFactory()
       .withPersonName("John Smith")
-      .withId(referralId)
+      .withId(UUID.randomUUID())
       .withSourcedFrom(ReferralEntitySourcedFrom.LICENCE_CONDITION)
       .withEventId("1503834986")
       .produce()
-    val facilitator = FacilitatorEntityFactory().produce()
-    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
-    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
-    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
+    val (referralId, groupId) = setupAllocationMocks(referralEntity)
 
-    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
-    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
-    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
-    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
-    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
     every { nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(any(), any()) } returns ClientResult.Failure.StatusCode(
       method = HttpMethod.GET,
       path = "/case/${referralEntity.crn}/licence-conditions/1503834986",
       status = HttpStatusCode.valueOf(404),
       body = "Licence condition not found",
     )
-    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
 
     // When / Then
     assertThatThrownBy {
-      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+      service.allocateReferralToGroup(referralId, groupId, "testAdmin", "test additional details")
     }
       .isInstanceOf(BusinessException::class.java)
       .hasMessageContaining("no longer exists in nDelius")
       .hasMessageContaining("licence condition")
+      .hasMessageContaining("Please contact your admin")
 
-    // nDelius appointments should NOT have been attempted
     verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
-    // Referral should NOT have been saved
     verify(exactly = 0) { referralRepository.save(any()) }
-    // Telemetry for validation failure should have been emitted
     verify { telemetryClient.logToAppInsights("Referral.allocate-to-group.ndelius-validation-failure", any()) }
   }
 
   @Test
   fun `should throw BusinessException when referral requirement does not exist in nDelius`() {
     // Given
-    val referralId = UUID.randomUUID()
-    val groupId = UUID.randomUUID()
-    val allocatedToGroupBy = "testAdmin"
-    val additionalDetails = "test additional details"
     val referralEntity = ReferralEntityFactory()
       .withPersonName("John Smith")
-      .withId(referralId)
+      .withId(UUID.randomUUID())
       .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT)
       .withEventId("1503604735")
       .produce()
-    val facilitator = FacilitatorEntityFactory().produce()
-    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
-    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
-    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
+    val (referralId, groupId) = setupAllocationMocks(referralEntity)
 
-    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
-    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
-    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
-    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
-    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
     every { nDeliusIntegrationApiClient.getRequirementManagerDetails(any(), any()) } returns ClientResult.Failure.StatusCode(
       method = HttpMethod.GET,
       path = "/case/${referralEntity.crn}/requirement/1503604735",
       status = HttpStatusCode.valueOf(404),
       body = "Requirement not found",
     )
-    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
 
     // When / Then
     assertThatThrownBy {
-      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+      service.allocateReferralToGroup(referralId, groupId, "testAdmin", "test additional details")
     }
       .isInstanceOf(BusinessException::class.java)
       .hasMessageContaining("no longer exists in nDelius")
       .hasMessageContaining("requirement")
+      .hasMessageContaining("Please contact your admin")
 
     verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
     verify(exactly = 0) { referralRepository.save(any()) }
@@ -196,29 +175,16 @@ class ProgrammeGroupMembershipServiceTest {
   @Test
   fun `should throw BusinessException when referral has null sourcedFrom`() {
     // Given
-    val referralId = UUID.randomUUID()
-    val groupId = UUID.randomUUID()
-    val allocatedToGroupBy = "testAdmin"
-    val additionalDetails = "test additional details"
     val referralEntity = ReferralEntityFactory()
       .withPersonName("John Smith")
-      .withId(referralId)
+      .withId(UUID.randomUUID())
       .withSourcedFrom(null)
       .produce()
-    val facilitator = FacilitatorEntityFactory().produce()
-    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
-    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
-    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
-
-    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
-    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
-    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
-    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
-    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
+    val (referralId, groupId) = setupAllocationMocks(referralEntity)
 
     // When / Then
     assertThatThrownBy {
-      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+      service.allocateReferralToGroup(referralId, groupId, "testAdmin", "test additional details")
     }
       .isInstanceOf(BusinessException::class.java)
       .hasMessageContaining("sentence source type is not set")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
@@ -5,11 +5,19 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatusCode
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.NDeliusIntegrationApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.config.logToAppInsights
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntitySourcedFrom
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralStatusUpdateEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FacilitatorEntityFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.ReferralEntityFactory
@@ -29,6 +37,7 @@ class ProgrammeGroupMembershipServiceTest {
   private val referralStatusDescriptionRepository = mockk<ReferralStatusDescriptionRepository>()
   private val programmeGroupMembershipRepository = mockk<ProgrammeGroupMembershipRepository>()
   private val scheduleService = mockk<ScheduleService>()
+  private val nDeliusIntegrationApiClient = mockk<NDeliusIntegrationApiClient>()
   private val telemetryClient = mockk<TelemetryClient>()
   private val applicationEventPublisher = mockk<ApplicationEventPublisher>()
   private lateinit var service: ProgrammeGroupMembershipService
@@ -41,6 +50,7 @@ class ProgrammeGroupMembershipServiceTest {
       referralStatusDescriptionRepository = referralStatusDescriptionRepository,
       programmeGroupMembershipRepository = programmeGroupMembershipRepository,
       scheduleService = scheduleService,
+      nDeliusIntegrationApiClient = nDeliusIntegrationApiClient,
       telemetryClient = telemetryClient,
       applicationEventPublisher = applicationEventPublisher,
     )
@@ -53,7 +63,8 @@ class ProgrammeGroupMembershipServiceTest {
     val groupId = UUID.randomUUID()
     val allocatedToGroupBy = "testAdmin"
     val additionalDetails = "test additional details"
-    val referralEntity = ReferralEntityFactory().withPersonName("John Smith").withId(referralId).produce()
+    val referralEntity = ReferralEntityFactory().withPersonName("John Smith").withId(referralId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT).produce()
     val facilitator = FacilitatorEntityFactory().produce()
     val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
     val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
@@ -65,6 +76,10 @@ class ProgrammeGroupMembershipServiceTest {
     every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
     every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
     every { referralRepository.save(referralEntity) } returns referralEntity
+    every { nDeliusIntegrationApiClient.getRequirementManagerDetails(any(), any()) } returns ClientResult.Success(
+      HttpStatusCode.valueOf(200),
+      mockk<NDeliusCaseRequirementOrLicenceConditionResponse>(),
+    )
     every { scheduleService.createNdeliusAppointmentsForSessions(any()) } returns Unit
     every { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) } returns Unit
     every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
@@ -80,10 +95,138 @@ class ProgrammeGroupMembershipServiceTest {
     verify { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) }
     verify { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) }
     verify { referralStatusDescriptionRepository.getScheduledStatusDescription() }
+    verify { nDeliusIntegrationApiClient.getRequirementManagerDetails(referralEntity.crn, referralEntity.eventId!!) }
     verify { referralRepository.save(referralEntity) }
     verify { scheduleService.createNdeliusAppointmentsForSessions(any()) }
     verify { applicationEventPublisher.publishEvent(ReferralStatusUpdateEvent(referralId)) }
     verify { telemetryClient.logToAppInsights(any(), any()) }
+  }
+
+  @Test
+  fun `should throw BusinessException when referral licence condition does not exist in nDelius`() {
+    // Given
+    val referralId = UUID.randomUUID()
+    val groupId = UUID.randomUUID()
+    val allocatedToGroupBy = "testAdmin"
+    val additionalDetails = "test additional details"
+    val referralEntity = ReferralEntityFactory()
+      .withPersonName("John Smith")
+      .withId(referralId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.LICENCE_CONDITION)
+      .withEventId("1503834986")
+      .produce()
+    val facilitator = FacilitatorEntityFactory().produce()
+    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
+    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
+    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
+
+    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
+    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
+    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
+    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
+    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
+    every { nDeliusIntegrationApiClient.getLicenceConditionManagerDetails(any(), any()) } returns ClientResult.Failure.StatusCode(
+      method = HttpMethod.GET,
+      path = "/case/${referralEntity.crn}/licence-conditions/1503834986",
+      status = HttpStatusCode.valueOf(404),
+      body = "Licence condition not found",
+    )
+    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
+
+    // When / Then
+    assertThatThrownBy {
+      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+    }
+      .isInstanceOf(BusinessException::class.java)
+      .hasMessageContaining("no longer exists in nDelius")
+      .hasMessageContaining("licence condition")
+      .hasMessageContaining("1503834986")
+
+    // nDelius appointments should NOT have been attempted
+    verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
+    // Referral should NOT have been saved
+    verify(exactly = 0) { referralRepository.save(any()) }
+    // Telemetry for validation failure should have been emitted
+    verify { telemetryClient.logToAppInsights("Referral.allocate-to-group.ndelius-validation-failure", any()) }
+  }
+
+  @Test
+  fun `should throw BusinessException when referral requirement does not exist in nDelius`() {
+    // Given
+    val referralId = UUID.randomUUID()
+    val groupId = UUID.randomUUID()
+    val allocatedToGroupBy = "testAdmin"
+    val additionalDetails = "test additional details"
+    val referralEntity = ReferralEntityFactory()
+      .withPersonName("John Smith")
+      .withId(referralId)
+      .withSourcedFrom(ReferralEntitySourcedFrom.REQUIREMENT)
+      .withEventId("1503604735")
+      .produce()
+    val facilitator = FacilitatorEntityFactory().produce()
+    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
+    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
+    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
+
+    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
+    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
+    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
+    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
+    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
+    every { nDeliusIntegrationApiClient.getRequirementManagerDetails(any(), any()) } returns ClientResult.Failure.StatusCode(
+      method = HttpMethod.GET,
+      path = "/case/${referralEntity.crn}/requirement/1503604735",
+      status = HttpStatusCode.valueOf(404),
+      body = "Requirement not found",
+    )
+    every { telemetryClient.logToAppInsights(any(), any()) } returns Unit
+
+    // When / Then
+    assertThatThrownBy {
+      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+    }
+      .isInstanceOf(BusinessException::class.java)
+      .hasMessageContaining("no longer exists in nDelius")
+      .hasMessageContaining("requirement")
+      .hasMessageContaining("1503604735")
+
+    verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
+    verify(exactly = 0) { referralRepository.save(any()) }
+    verify { telemetryClient.logToAppInsights("Referral.allocate-to-group.ndelius-validation-failure", any()) }
+  }
+
+  @Test
+  fun `should throw BusinessException when referral has null sourcedFrom`() {
+    // Given
+    val referralId = UUID.randomUUID()
+    val groupId = UUID.randomUUID()
+    val allocatedToGroupBy = "testAdmin"
+    val additionalDetails = "test additional details"
+    val referralEntity = ReferralEntityFactory()
+      .withPersonName("John Smith")
+      .withId(referralId)
+      .withSourcedFrom(null)
+      .produce()
+    val facilitator = FacilitatorEntityFactory().produce()
+    val programmeGroupEntity = ProgrammeGroupFactory().withTreatmentManager(facilitator).produce()
+    val referralStatusDescriptionEntity = ReferralStatusDescriptionEntityFactory().produce()
+    val programmeGroupMembershipEntity = ProgrammeGroupMembershipFactory().produce()
+
+    every { referralRepository.findByIdOrNull(referralId) } returns referralEntity
+    every { programmeGroupRepository.findByIdOrNull(groupId) } returns programmeGroupEntity
+    every { referralStatusDescriptionRepository.findMostRecentStatusByReferralId(referralId) } returns referralStatusDescriptionEntity
+    every { programmeGroupMembershipRepository.findCurrentGroupByReferralId(referralId) } returns null andThen programmeGroupMembershipEntity
+    every { referralStatusDescriptionRepository.getScheduledStatusDescription() } returns referralStatusDescriptionEntity
+
+    // When / Then
+    assertThatThrownBy {
+      service.allocateReferralToGroup(referralId, groupId, allocatedToGroupBy, additionalDetails)
+    }
+      .isInstanceOf(BusinessException::class.java)
+      .hasMessageContaining("sentence source type is not set")
+
+    verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
+    verify(exactly = 0) { referralRepository.save(any()) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupMembershipServiceTest.kt
@@ -140,7 +140,6 @@ class ProgrammeGroupMembershipServiceTest {
       .isInstanceOf(BusinessException::class.java)
       .hasMessageContaining("no longer exists in nDelius")
       .hasMessageContaining("licence condition")
-      .hasMessageContaining("1503834986")
 
     // nDelius appointments should NOT have been attempted
     verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
@@ -188,7 +187,6 @@ class ProgrammeGroupMembershipServiceTest {
       .isInstanceOf(BusinessException::class.java)
       .hasMessageContaining("no longer exists in nDelius")
       .hasMessageContaining("requirement")
-      .hasMessageContaining("1503604735")
 
     verify(exactly = 0) { scheduleService.createNdeliusAppointmentsForSessions(any()) }
     verify(exactly = 0) { referralRepository.save(any()) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -8,6 +8,11 @@ import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnit
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementStaff
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.toFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Osp
@@ -179,6 +184,30 @@ class TestReferralHelper {
         .apply { regionName?.let { withRegionStrings(description = it) } }
         .produce(),
     )
+
+    // Stub requirement/licence condition validation for nDelius appointment creation
+    val validationResponse = NDeliusCaseRequirementOrLicenceConditionResponse(
+      eventNumber = findAndReferReferralDetails.eventNumber,
+      manager = RequirementOrLicenceConditionManager(
+        staff = RequirementStaff(code = "STAFF001", name = FullName(forename = "Test", middleNames = null, surname = "Staff")),
+        team = CodeDescription("TEAM001", "Test Team"),
+        probationDeliveryUnit = NDeliusApiProbationDeliveryUnit("PDU001", "Test PDU"),
+        officeLocations = emptyList(),
+      ),
+      probationDeliveryUnits = emptyList(),
+    )
+    when (sourcedFrom) {
+      ReferralEntitySourcedFrom.LICENCE_CONDITION -> nDeliusApiStubs.stubSuccessfulLicenceConditionManagerResponse(
+        crn = crn,
+        licenceConditionId = findAndReferReferralDetails.sourcedFromReference,
+        licenceConditionResponse = validationResponse,
+      )
+      ReferralEntitySourcedFrom.REQUIREMENT -> nDeliusApiStubs.stubSuccessfulRequirementManagerResponse(
+        crn = crn,
+        requirementId = findAndReferReferralDetails.sourcedFromReference,
+        requirementResponse = validationResponse,
+      )
+    }
 
     // Stub auth token
     hmppsAuth.stubGrantToken()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -8,11 +8,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.OffenceCohort
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.CodeDescription
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.FullName
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusApiProbationDeliveryUnit
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.NDeliusCaseRequirementOrLicenceConditionResponse
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementOrLicenceConditionManager
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.RequirementStaff
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.getNameAsString
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.nDeliusIntegrationApi.model.toFullName
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.oasysApi.model.Osp
@@ -26,6 +21,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.enti
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.InterventionType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.PersonReferenceType
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FindAndReferReferralDetailsFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusCaseRequirementOrLicenceConditionResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusPersonalDetailsFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.NDeliusSentenceResponseFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.PniAssessmentFactory
@@ -186,16 +182,9 @@ class TestReferralHelper {
     )
 
     // Stub requirement/licence condition validation for nDelius appointment creation
-    val validationResponse = NDeliusCaseRequirementOrLicenceConditionResponse(
-      eventNumber = findAndReferReferralDetails.eventNumber,
-      manager = RequirementOrLicenceConditionManager(
-        staff = RequirementStaff(code = "STAFF001", name = FullName(forename = "Test", middleNames = null, surname = "Staff")),
-        team = CodeDescription("TEAM001", "Test Team"),
-        probationDeliveryUnit = NDeliusApiProbationDeliveryUnit("PDU001", "Test PDU"),
-        officeLocations = emptyList(),
-      ),
-      probationDeliveryUnits = emptyList(),
-    )
+    val validationResponse = NDeliusCaseRequirementOrLicenceConditionResponseFactory()
+      .withEventNumber(findAndReferReferralDetails.eventNumber)
+      .produce()
     when (sourcedFrom) {
       ReferralEntitySourcedFrom.LICENCE_CONDITION -> nDeliusApiStubs.stubSuccessfulLicenceConditionManagerResponse(
         crn = crn,


### PR DESCRIPTION
APG-2332: Pre-validate nDelius requirement/licence condition before group allocation

**What**
Adds a pre-validation step when allocating a referral to a programme group. Before mutating any state, we now call nDelius to verify that the referral's linked requirement or licence condition still exists.

**Why**
Previously, if a referral's sentence data was stale (e.g. after a transfer or sentence termination), the allocation would partially succeed but then fail with a cryptic 400 error when attempting to create appointments in nDelius. This made it difficult for users to understand what went wrong and left the system in a partially mutated state.
By validating upfront, we fail fast with a clear, user-friendly error message before any state changes occur.

**Changes**
`ProgrammeGroupMembershipService` — Added `validateReferralSentenceDataExistsInNDelius()` which calls the appropriate nDelius endpoint (`getRequirementManagerDetails` or `getLicenceConditionManagerDetails`) based on the referral's `sourcedFrom` type. Throws a `BusinessException` with a descriptive message on failure.

`NDeliusCaseRequirementOrLicenceConditionResponseFactory` — New test factory for building nDelius response objects.

`ProgrammeGroupMembershipServiceTest` — Added tests covering the validation logic (success, 404/status failures, network failures, null `eventId`/`sourcedFrom`).

`TestReferralHelper` — Extracted common test setup into a reusable helper method.

**Notes**
The extra GET call on every allocation is intentional — it's a lightweight read that prevents expensive failure recovery later.
Internal IDs are not exposed in user-facing error messages.
Success log demoted to debug level to reduce noise.