### PR TITLE
fix: use expectedEndDate for LICENCE_CONDITION sentence end date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SentenceService.kt
@@ -64,8 +64,9 @@ class SentenceService(
   fun getSentenceEndDate(crn: String, eventNumber: Int?, sentenceType: ReferralEntitySourcedFrom?): LocalDate? {
     val sentenceInfo = getSentenceInformationByIdentifier(crn, eventNumber)
     return when (sentenceType) {
-      ReferralEntitySourcedFrom.REQUIREMENT -> sentenceInfo?.expectedEndDate
-      ReferralEntitySourcedFrom.LICENCE_CONDITION -> sentenceInfo?.licenceExpiryDate
+      ReferralEntitySourcedFrom.REQUIREMENT,
+      ReferralEntitySourcedFrom.LICENCE_CONDITION,
+      -> sentenceInfo?.expectedEndDate
       else -> null
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/DomainEventsListenerIntegrationTest.kt
@@ -113,7 +113,7 @@ class DomainEventsListenerIntegrationTest : IntegrationTestBase() {
       .produce()
     nDeliusApiStubs.stubPersonalDetailsResponse(personalDetails)
     val sentenceInformation =
-      NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2025-10-01")).produce()
+      NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2025-10-01")).produce()
     nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(crn, eventNumber, sentenceInformation)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/EntityFactoriesTest.kt
@@ -218,7 +218,7 @@ class EntityFactoriesTest {
 
     assertThat(sentenceResponse.description).isNotNull()
     assertThat(sentenceResponse.startDate).isNotNull()
-    assertThat(sentenceResponse.expectedEndDate).isNull()
+    assertThat(sentenceResponse.expectedEndDate).isNotNull()
     assertThat(sentenceResponse.licenceExpiryDate).isNotNull()
     assertThat(sentenceResponse.postSentenceSupervisionEndDate).isNotNull()
     assertThat(sentenceResponse.twoThirdsSupervisionDate).isNotNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/factory/NDeliusSentenceResponseFactory.kt
@@ -11,13 +11,11 @@ import java.time.LocalDate
 class NDeliusSentenceResponseFactory(sourcedFrom: ReferralEntitySourcedFrom? = null) {
   private var description: String? = randomSentence(wordRange = 2..5)
   private var startDate: LocalDate = LocalDate.now().minusYears(1)
-  private var expectedEndDate: LocalDate? =
-    if (sourcedFrom === ReferralEntitySourcedFrom.REQUIREMENT || sourcedFrom == null) {
-      LocalDate.now()
-        .plusYears(2)
-    } else {
-      null
-    }
+  private var expectedEndDate: LocalDate? = LocalDate.now().plusYears(2)
+
+  // licenceExpiryDate is still controlled by sourcedFrom because the SentenceInformation display model
+  // uses it to calculate postSentenceSupervisionStartDate (licenceExpiryDate + 1 day).
+  // It is NOT used for sentence end date — both REQUIREMENT and LICENCE_CONDITION use expectedEndDate.
   private var licenceExpiryDate: LocalDate? =
     if (sourcedFrom === ReferralEntitySourcedFrom.LICENCE_CONDITION) LocalDate.now().plusYears(2) else null
   private var postSentenceSupervisionEndDate: LocalDate? = LocalDate.now().plusYears(3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -631,7 +631,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         "CRN-12345",
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       //    When
@@ -674,7 +674,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referralDetails.personReference,
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       // When
@@ -709,7 +709,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referralDetails.personReference,
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       // When
@@ -741,7 +741,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referralDetails.personReference,
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       // When
@@ -770,7 +770,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referralDetails.personReference,
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       // When
@@ -796,7 +796,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referralDetails.personReference,
         1,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
 
       // When
@@ -874,7 +874,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referral.crn,
         referral.eventNumber,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
       nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
 
@@ -904,7 +904,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referral.crn,
         referral.eventNumber,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
       nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
 
@@ -926,7 +926,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referral.crn,
         referral.eventNumber,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
       nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
 
@@ -1102,7 +1102,7 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
         referral.crn,
         referral.eventNumber,
-        NDeliusSentenceResponseFactory().withLicenceExpiryDate(LocalDate.parse("2027-11-02")).produce(),
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
       )
       nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestReferralHelper.kt
@@ -154,11 +154,7 @@ class TestReferralHelper {
     val sentenceResponse = NDeliusSentenceResponseFactory(sourcedFrom)
       .apply {
         sentenceEndDate?.let {
-          if (sourcedFrom == ReferralEntitySourcedFrom.LICENCE_CONDITION) {
-            withLicenceExpiryDate(it)
-          } else {
-            withExpectedEndDate(it)
-          }
+          withExpectedEndDate(it)
         }
       }
       .produce()


### PR DESCRIPTION
Fix: Use expectedEndDate for LICENCE_CONDITION sentence end date

**What**
Previously, LICENCE_CONDITION referrals incorrectly used licenceExpiryDate as the sentence end date, while REQUIREMENT referrals correctly used expectedEndDate. Both referral types should use expectedEndDate.

**Why**
licenceExpiryDate serves a different purpose — it is used to calculate postSentenceSupervisionStartDate (licence expiry date + 1 day). It should not be used as the sentence end date for licence condition referrals.

**Changes**
SentenceService.kt — Updated getSentenceEndDate() so both REQUIREMENT and LICENCE_CONDITION return expectedEndDate
NDeliusSentenceResponseFactory.kt — Simplified factory: expectedEndDate is now always populated regardless of sourcedFrom. licenceExpiryDate remains conditional (only set for LICENCE_CONDITION) as it's used for other calculations
TestReferralHelper.kt — Removed branching logic that set licenceExpiryDate vs expectedEndDate based on sourcedFrom; now always sets expectedEndDate

Integration tests — Updated all test stubs that were using withLicenceExpiryDate() to use withExpectedEndDate() for sentence end date assertions

**Testing**
Updated unit and integration tests to reflect the corrected behaviour
All existing tests pass with the updated logic