### PR TITLE
Set `JAVA_OPTS` for increased memory allocation in production

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,6 +16,7 @@ generic-service:
     SERVICES_GOVUK-API_BASE-URL: "https://www.gov.uk"
     CACHE_EVICT_BANK_HOLIDAYS_CRON: "0 0 0 */1 * ?" #every day on PROD
     SENTRY_ENVIRONMENT: prod
+    JAVA_OPTS: "-Xmx2048m"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
```
### Description
This pull request adds a `JAVA_OPTS` configuration to allocate additional memory for the production deployment, increasing the max heap size to 2GB. This change aims to improve application performance and stability under high load conditions.

