### PR TITLE
fix: add missing automaticallyRescheduleOtherSessions flag in update …

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -3794,6 +3794,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         sex = ProgrammeGroupSexEnum.FEMALE,
         cohort = ProgrammeGroupCohort.SEXUAL_LDC,
         earliestStartDate = LocalDate.of(2026, 12, 25),
+        automaticallyRescheduleOtherSessions = false,
         pduName = "Updated PDU",
         pduCode = "UPD_PDU",
         deliveryLocationName = "Updated Location",


### PR DESCRIPTION
…group test

The 'should return 200 when updating multiple fields at once' test was failing with a 400 because earliestStartDate was provided without automaticallyRescheduleOtherSessions. This caused the service to attempt rescheduling the pre-group one-to-one placeholder session, which failed validation. Set the flag to false to match the test's intent of updating fields without triggering a reschedule.