### PR TITLE
feat(APG-2356): set updatedAt on ReferralReportingLocation during ref…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralReportingLocationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/entity/ReferralReportingLocationEntity.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.ent
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -10,10 +11,14 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.ColumnDefault
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
 @Table(name = "referral_reporting_location")
+@EntityListeners(AuditingEntityListener::class)
 open class ReferralReportingLocationEntity(
   @Id
   @GeneratedValue
@@ -39,4 +44,9 @@ open class ReferralReportingLocationEntity(
   @ColumnDefault("UNKNOWN_REPORTING_TEAM")
   @Column(name = "reporting_team")
   open var reportingTeam: String,
+
+  @NotNull
+  @Column(name = "updated_at")
+  @LastModifiedDate
+  open var updatedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralServiceIntegrationTest.kt
@@ -52,6 +52,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.Duration.ofMillis
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 class ReferralServiceIntegrationTest : IntegrationTestBase() {
@@ -886,6 +887,36 @@ class ReferralServiceIntegrationTest : IntegrationTestBase() {
       assertThat(referralDetails.interventionName).isEqualTo(referral.interventionName)
       assertThat(referralDetails.createdAt).isEqualTo(referral.createdAt.toLocalDate())
       assertThat(referralDetails.dateOfBirth).isEqualTo(dateOfBirth)
+    }
+
+    @Test
+    fun `refreshPersonalDetailsForReferral updates updatedAt on referral reporting location`() = runTest {
+      val referral = ReferralEntityFactory().produce()
+      val name = randomFullName()
+      val dateOfBirth = randomDateOfBirth()
+      testDataGenerator.createReferralWithStatusHistory(referral)
+      oasysApiStubs.stubSuccessfulPniResponse(referral.crn)
+      nDeliusApiStubs.stubPersonalDetailsResponse(
+        NDeliusPersonalDetailsFactory()
+          .withName(name)
+          .withDateOfBirth(dateOfBirth)
+          .produce(),
+      )
+      nDeliusApiStubs.stubSuccessfulSentenceInformationResponse(
+        referral.crn,
+        referral.eventNumber,
+        NDeliusSentenceResponseFactory().withExpectedEndDate(LocalDate.parse("2027-11-02")).produce(),
+      )
+      nDeliusApiStubs.stubAccessCheck(granted = true, referral.crn)
+
+      val beforeRefresh = LocalDateTime.now().minusSeconds(1)
+
+      // Refresh — creates/updates the reporting location
+      referralService.refreshPersonalDetailsForReferral(referral.id!!)
+      val reportingLocation = reportingLocationRepository.findByReferralId(referral.id)!!
+
+      assertThat(reportingLocation.updatedAt).isAfter(beforeRefresh)
+      assertThat(reportingLocation.updatedAt).isBefore(LocalDateTime.now().plusSeconds(1))
     }
 
     @Test

--- a/src/test/resources/sar/entity-schema-snapshot.json
+++ b/src/test/resources/sar/entity-schema-snapshot.json
@@ -240,7 +240,8 @@
     "pduName": "String",
     "referral": "ReferralEntity",
     "regionName": "String",
-    "reportingTeam": "String"
+    "reportingTeam": "String",
+    "updatedAt": "LocalDateTime"
   },
   "ReferralStatusDescriptionEntity": {
     "createdAt": "LocalDateTime",


### PR DESCRIPTION
…resh

Add @LastModifiedDate to ReferralReportingLocationEntity so that updated_at is automatically set to now() whenever the row is saved. This ensures the timestamp reflects when the reporting location was last refreshed via the Refresh Personal Details flow.
- Map existing updated_at column in entity with @LastModifiedDate
- Add @EntityListeners(AuditingEntityListener) to enable JPA auditing
- Update SAR entity schema snapshot to include updatedAt
- Add integration test verifying updatedAt is set on refresh