### PR TITLE
APG-2390 Fix Rescheduling algorithm

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleService.kt
@@ -181,6 +181,7 @@ class ScheduleService(
     programmeGroupId: UUID,
     mostRecentSession: SessionEntity? = null,
     skipPreGroupOneToOnePlaceholder: Boolean = false,
+    coveredTemplateIds: Set<UUID> = emptySet(),
   ): MutableSet<SessionEntity> {
     val group = programmeGroupRepository.findByIdOrNull(programmeGroupId)
       ?: throw NotFoundException("Group with id: $programmeGroupId could not be found")
@@ -198,18 +199,13 @@ class ScheduleService(
         moduleEntity.sessionTemplates.sortedBy { it.sessionNumber }
       }
 
-    // If rescheduling, only include sessions after the most recent held session
-    if (mostRecentSession != null) {
-      allSessionTemplates = allSessionTemplates.filter { template ->
-        template.module.moduleNumber > mostRecentSession.moduleNumber ||
-          (
-            template.module.moduleNumber == mostRecentSession.moduleNumber &&
-              template.sessionNumber > mostRecentSession.sessionNumber
-            )
-      }
+    // If rescheduling, only regenerate templates that are not already covered by a session we are
+    // keeping (i.e. a past session, or a retained future placeholder). This ensures we do not drop future sessions
+    // that are sit earlier in the template order than the most recent past session
+    if (coveredTemplateIds.isNotEmpty()) {
+      allSessionTemplates = allSessionTemplates.filter { template -> template.id !in coveredTemplateIds }
     }
 
-    // If skipping pre-group one-to-one placeholder, exclude that template
     if (skipPreGroupOneToOnePlaceholder) {
       allSessionTemplates = allSessionTemplates.filter { template ->
         !(template.sessionType == ONE_TO_ONE && template.module.name == "Pre-group one-to-ones")
@@ -219,10 +215,25 @@ class ScheduleService(
     val groupSlots = group.programmeGroupSessionSlots
     require(groupSlots.isNotEmpty()) { "Programme group slots must not be empty" }
 
+    // When rescheduling after past sessions, start from the later of:
+    // - the day after the most recent past session (so future sessions are never placed before it),
+    // - the group's configured earliest start date (honoured when e.g. a future restart date was set), or
+    // - today (so regenerated sessions are never placed in the past, even when the most recent past
+    //   session ran several days ago and the new slot day falls between then and now)
+    val startFrom = if (mostRecentSession != null) {
+      maxOf(
+        mostRecentSession.startsAt.toLocalDate().plusDays(1),
+        group.earliestPossibleStartDate,
+        LocalDate.now(clock),
+      )
+    } else {
+      group.earliestPossibleStartDate
+    }
+
     var slotQueue = buildSlotQueue(
       bankHolidays = bankHolidays,
       groupSlots = groupSlots,
-      startFrom = group.earliestPossibleStartDate,
+      startFrom = startFrom,
     )
 
     var firstSessionScheduledAndGapApplied = false
@@ -241,7 +252,7 @@ class ScheduleService(
           startsAt = startsAt,
           endsAt = endsAt,
           locationName = group.deliveryLocationName,
-          // If we are scheduling One-to-One here it is a placeholder session
+          // If we are scheduling One-to-One here, it is a placeholder session
           isPlaceholder = template.sessionType == ONE_TO_ONE,
         )
         session.sessionFacilitators = group.groupFacilitators.map {
@@ -313,7 +324,7 @@ class ScheduleService(
       }
     }
 
-    // Save the group here so the parent entity is updated and updates the corresponding sessions
+    // Save the group here so the parent entity is updated and updates the corresponding sessions,
     // otherwise JPA does not always update the inverse side of the relationship.
     group.sessions.addAll(generatedSessions)
     programmeGroupRepository.save(group)
@@ -354,6 +365,14 @@ class ScheduleService(
     val futureNDeliusAppointmentsToRemove = futureSessions.flatMap { session -> session.ndeliusAppointments }
     val mostRecentSession = group.sessions.filter { it.startsAt <= now }.maxByOrNull { it.startsAt }
 
+    // Templates already covered by a session we are keeping (past sessions, plus any retained future
+    // placeholder) must not be regenerated. Catch-ups are excluded.
+    val retainedSessions = group.sessions.filterNot { it in futureSessions }
+    val coveredTemplateIds = retainedSessions
+      .filterNot { it.isCatchup }
+      .mapNotNull { it.moduleSessionTemplate.id }
+      .toSet()
+
     if (futureSessions.isNotEmpty()) {
       removeNDeliusAppointments(futureNDeliusAppointmentsToRemove, futureSessions.toList())
       group.sessions.removeAll(futureSessions)
@@ -361,7 +380,12 @@ class ScheduleService(
     }
 
     // If there is no prior session, just schedule from start
-    val sessions = scheduleSessionsForGroup(programmeGroupId, mostRecentSession, skipPreGroupOneToOnePlaceholder)
+    val sessions = scheduleSessionsForGroup(
+      programmeGroupId,
+      mostRecentSession,
+      skipPreGroupOneToOnePlaceholder,
+      coveredTemplateIds,
+    )
     val attendees = sessions.flatMap { it.attendees }.toList()
     createNdeliusAppointmentsForSessions(attendees)
 
@@ -484,12 +508,14 @@ class ScheduleService(
     bankHolidays: Set<LocalDate>,
     durationMinutes: Int,
   ): List<Pair<LocalDateTime, LocalDateTime>> {
-    val slotQueue = buildSlotQueue(bankHolidays, programmeGroupSlots, initialStartDate)
+    // Start from the day after the rescheduled session so that subsequent sessions
+    // are placed on the next available slots.  Building from the initialStartDate + 1 day
+    // works whether the rescheduled session falls on a slot day or not: when it IS a
+    // slot day, the slot is naturally skipped; when it is NOT a slot day, the first
+    // available slot (which belongs to the next session) is no longer incorrectly
+    // consumed as if it were the rescheduled session's own slot.
+    val slotQueue = buildSlotQueue(bankHolidays, programmeGroupSlots, initialStartDate.plusDays(1))
     val schedule = mutableListOf<Pair<LocalDateTime, LocalDateTime>>()
-
-    val firstSlot = slotQueue.poll()
-    val nextDate = findNextValidDate(bankHolidays, firstSlot.nextDate.plusDays(1), firstSlot.slot)
-    slotQueue.add(firstSlot.copy(nextDate = nextDate))
 
     repeat(sessionCount) {
       val slotInstance = slotQueue.poll()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/SessionService.kt
@@ -133,8 +133,6 @@ class SessionService(
     val currentSessionDuration = Duration.between(session.startsAt, session.endsAt)
     val requestedSessionDuration = Duration.between(requestedStartTime, requestedEndTime)
 
-    val originalSessionStartsAt = session.startsAt
-
     // Past sessions (end time has passed) may not be lengthened; shortening is allowed
     if (session.endsAt.isBefore(LocalDateTime.now()) && requestedSessionDuration > currentSessionDuration) {
       log.warn("Invalid reschedule request received for past session with id: $sessionId. Requested duration $requestedSessionDuration exceeds current duration $currentSessionDuration")
@@ -149,19 +147,37 @@ class SessionService(
 
     // Reschedule later group sessions, place-holder one-to-ones, but not catch-up sessions
     if (request.rescheduleOtherSessions) {
+      val now = LocalDateTime.now(clock)
+
+      // Select and order sessions that come AFTER the rescheduled session in template order
+      // (module number then session number), not by the current scheduled date.
+      // A date-based filter would miss sessions that are later in template order but
+      // currently have an earlier date (e.g. due to a prior ordering bug).
+      // Only sessions that are still in the future may be auto-rescheduled: sessions in
+      // the past must never be moved, even when they are later in template order than the
+      // edited session (which can happen when a schedule has previously been knocked out
+      // of order).
       val subsequentGroupSessions = session.programmeGroup.sessions
         .asSequence()
         .filter { it.sessionType == SessionType.GROUP || it.isPlaceholder }
-        .filter { it.id != session.id } // filter out the original session
+        .filter { it.id != session.id }
         .filter { !it.isCatchup }
-        .filter { it.startsAt.isAfter(originalSessionStartsAt) }
-        .sortedBy { it.startsAt }
+        .filter { it.startsAt > now }
+        .filter {
+          it.moduleNumber > session.moduleNumber ||
+            (it.moduleNumber == session.moduleNumber && it.sessionNumber > session.sessionNumber)
+        }
+        .sortedWith(compareBy({ it.moduleNumber }, { it.sessionNumber }))
         .toList()
 
       if (isGroupSession && session.programmeGroup.programmeGroupSessionSlots.isNotEmpty()) {
+        // Anchor on the later of the edited session's new date and today, so later
+        // sessions are never generated into the past. This matters when the edited session
+        // is itself in the past, or when a future session is moved to before today.
+        val anchorDate = maxOf(session.startsAt.toLocalDate(), now.toLocalDate())
         val scheduleDates = scheduleService.generateScheduleDates(
           programmeGroupSlots = session.programmeGroup.programmeGroupSessionSlots,
-          initialStartDate = session.startsAt.toLocalDate(),
+          initialStartDate = anchorDate,
           sessionCount = subsequentGroupSessions.size,
           bankHolidays = scheduleService.englandAndWalesHolidayDates(),
           durationMinutes = session.moduleSessionTemplate.durationMinutes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/programmeGroup/RescheduleGroupSessionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/programmeGroup/RescheduleGroupSessionsIntegrationTest.kt
@@ -1,0 +1,437 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.programmeGroup
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.AmOrPm
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.CreateGroupSessionSlot
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.GroupScheduleOverview
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.RescheduleSessionRequest
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.SessionTime
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.UpdateGroupRequest
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.UpdateGroupResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.programmeGroup.session.EditSessionDateAndTimeResponse
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.randomAlphanumericString
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupSessionSlotEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.type.SessionType
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.FacilitatorEntityFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.ProgrammeGroupFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.SessionFactory
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.UUID
+
+class RescheduleGroupSessionsIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var sessionRepository: SessionRepository
+
+  private val now: LocalDate = LocalDate.of(2025, 11, 22)
+
+  @BeforeEach
+  fun setup() {
+    testDataCleaner.cleanAllTables()
+    whenever(clock.instant()).thenReturn(Instant.parse("2025-11-22T12:00:00Z"))
+    whenever(clock.zone).thenReturn(ZoneId.of("Europe/London"))
+
+    stubAuthTokenEndpoint()
+    govUkApiStubs.stubBankHolidaysResponse()
+    nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulDeleteAppointmentsResponse()
+  }
+
+  @Nested
+  @DisplayName("When editing a group's slots")
+  inner class WhenEditingGroupDaysAndTimes {
+
+    @Test
+    fun `does not change sessions in the past and moves future sessions onto the new slot day`() {
+      // Given a single past Monday session and three future Monday sessions
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 17),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past
+          2 to LocalDate.of(2025, 11, 24).atTime(10, 0),
+          3 to LocalDate.of(2025, 12, 1).atTime(10, 0),
+          4 to LocalDate.of(2025, 12, 8).atTime(10, 0),
+        ),
+      )
+      val pastSession = fixture.sessions[0]
+
+      // When the slots are changed to Wednesday and an automatic reschedule is requested
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${fixture.group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = UpdateGroupRequest(
+          createGroupSessionSlot = setOf(CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)),
+          automaticallyRescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.sessions).hasSize(4)
+
+      // Past session is untouched
+      assertThat(overview.dateOf(pastSession.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+
+      // The rescheduled future sessions are all on the new Wednesday slot, in the future, and ordered
+      val rescheduled = overview.sessions.filter { it.id != pastSession.id }.sortedBy { it.date }
+      assertThat(rescheduled).hasSize(3)
+      assertThat(rescheduled).allMatch { it.date.dayOfWeek == DayOfWeek.WEDNESDAY }
+      assertThat(rescheduled).allMatch { it.date.isAfter(now) }
+      assertThat(rescheduled.map { it.date }).isSorted
+    }
+
+    @Test
+    fun `keeps every rescheduled session after the most recent past session with multiple slots`() {
+      // Given two past sessions (Mon 17th, Thu 20th) and two future sessions, across two slots
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 17),
+        slots = listOf(
+          DayOfWeek.MONDAY to LocalTime.of(10, 0),
+          DayOfWeek.THURSDAY to LocalTime.of(12, 0),
+        ),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past
+          2 to LocalDate.of(2025, 11, 20).atTime(12, 0), // past (most recent)
+          3 to LocalDate.of(2025, 11, 24).atTime(10, 0),
+          4 to LocalDate.of(2025, 11, 27).atTime(12, 0),
+        ),
+      )
+      val firstPast = fixture.sessions[0]
+      val mostRecentPast = fixture.sessions[1]
+
+      // When the group is changed to a single Wednesday slot
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${fixture.group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = UpdateGroupRequest(
+          createGroupSessionSlot = setOf(CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)),
+          automaticallyRescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then both past sessions are untouched
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.sessions).hasSize(4)
+      assertThat(overview.dateOf(firstPast.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+      assertThat(overview.dateOf(mostRecentPast.id)).isEqualTo(LocalDate.of(2025, 11, 20))
+
+      // And the rescheduled sessions are strictly after the most recent past session and in the future
+      val rescheduled = overview.sessions
+        .filter { it.id != firstPast.id && it.id != mostRecentPast.id }
+        .sortedBy { it.date }
+      assertThat(rescheduled).hasSize(2)
+      assertThat(rescheduled).allMatch { it.date.dayOfWeek == DayOfWeek.WEDNESDAY }
+      assertThat(rescheduled).allMatch { it.date.isAfter(LocalDate.of(2025, 11, 20)) }
+      assertThat(rescheduled).allMatch { it.date.isAfter(now) }
+    }
+
+    @Test
+    fun `does not place regenerated sessions in the past when the last past session ran days ago`() {
+      // Given the most recent past session ran on Mon 17th, but "now" is Sat 22nd, so the new
+      // Wednesday slot has a candidate (Wed 19th) that falls between the past session and today.
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 10),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 10).atTime(10, 0), // past
+          2 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past (most recent)
+          3 to LocalDate.of(2025, 11, 24).atTime(10, 0),
+          4 to LocalDate.of(2025, 12, 1).atTime(10, 0),
+        ),
+      )
+      val pastSessions = listOf(fixture.sessions[0], fixture.sessions[1])
+
+      // When the slots change to Wednesday
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${fixture.group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = UpdateGroupRequest(
+          createGroupSessionSlot = setOf(CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)),
+          automaticallyRescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then no regenerated session is placed on the past Wednesday (19 Nov); all are today or later
+      val overview = scheduleOverview(fixture.group.id!!)
+      val rescheduled = overview.sessions.filterNot { session -> session.id in pastSessions.map { it.id } }
+      assertThat(rescheduled).hasSize(2)
+      assertThat(rescheduled).allMatch { it.date.isAfter(now) }
+      assertThat(rescheduled.minOf { it.date }).isEqualTo(LocalDate.of(2025, 11, 26))
+    }
+
+    @Test
+    fun `regenerates every uncovered template when the schedule is out of template order so no sessions are dropped`() {
+      // Session for template 2 sits in the past on an earlier date than the future template 1
+      // session, i.e. the schedule is out of template order. Regeneration must be driven by which
+      // templates still need a future session, not by a positional cut-off (which would drop the
+      // template 1 session because it is earlier in template order than the most recent past session).
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 17),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 24).atTime(10, 0), // future
+          2 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past (most recent), but earlier template
+          3 to LocalDate.of(2025, 12, 1).atTime(10, 0), // future
+          4 to LocalDate.of(2025, 12, 8).atTime(10, 0), // future
+        ),
+      )
+      val pastSession = fixture.sessions[1]
+
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${fixture.group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = UpdateGroupRequest(
+          createGroupSessionSlot = setOf(CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)),
+          automaticallyRescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then all four templates remain represented (no session dropped): 1 retained + 3 regenerated
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.sessions).hasSize(4)
+      assertThat(overview.dateOf(pastSession.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+
+      val rescheduled = overview.sessions.filter { it.id != pastSession.id }
+      assertThat(rescheduled).hasSize(3)
+      assertThat(rescheduled).allMatch { it.date.dayOfWeek == DayOfWeek.WEDNESDAY }
+      assertThat(rescheduled).allMatch { it.date.isAfter(now) }
+    }
+
+    @Test
+    fun `does not duplicate a template whose retained past session is later in template order`() {
+      // Template 3's session is in the past on an earlier date than template 1's past session. A
+      // positional cut-off (templates after the most recent past session, template 1) would re-create
+      // template 3 even though it already has a retained past session, duplicating it.
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 10),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past (most recent)
+          3 to LocalDate.of(2025, 11, 10).atTime(10, 0), // past, but later in template order
+          2 to LocalDate.of(2025, 11, 24).atTime(10, 0), // future
+        ),
+      )
+      val pastTemplate1 = fixture.sessions[0]
+      val pastTemplate3 = fixture.sessions[1]
+
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/group/${fixture.group.id}",
+        returnType = object : ParameterizedTypeReference<UpdateGroupResponse>() {},
+        body = UpdateGroupRequest(
+          createGroupSessionSlot = setOf(CreateGroupSessionSlot(DayOfWeek.WEDNESDAY, 2, 0, AmOrPm.PM)),
+          automaticallyRescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then there are exactly three sessions (no duplicate of template 3): 2 retained + 1 regenerated
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.sessions).hasSize(3)
+      assertThat(overview.dateOf(pastTemplate1.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+      assertThat(overview.dateOf(pastTemplate3.id)).isEqualTo(LocalDate.of(2025, 11, 10))
+
+      val rescheduled = overview.sessions.filterNot { it.id == pastTemplate1.id || it.id == pastTemplate3.id }
+      assertThat(rescheduled).hasSize(1)
+      assertThat(rescheduled.single().date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+      assertThat(rescheduled.single().date).isAfter(now)
+    }
+  }
+
+  @Nested
+  @DisplayName("When rescheduling a single session with auto reschedule")
+  inner class WhenReschedulingAnSingleSessionWithAutoReschedule {
+
+    @Test
+    fun `reschedules subsequent future sessions in template order leaving past sessions unchanged`() {
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 17),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past
+          2 to LocalDate.of(2025, 11, 24).atTime(10, 0),
+          3 to LocalDate.of(2025, 12, 1).atTime(10, 0),
+          4 to LocalDate.of(2025, 12, 8).atTime(10, 0),
+        ),
+      )
+      val (s1, s2, s3, s4) = fixture.sessions
+
+      // When session 2 is moved to Mon 8 Dec, cascading to subsequent sessions
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/session/${s2.id}/reschedule",
+        returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+        body = RescheduleSessionRequest(
+          sessionStartDate = LocalDate.of(2025, 12, 8),
+          sessionStartTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+          sessionEndTime = SessionTime(hour = 11, minutes = 0, amOrPm = AmOrPm.AM),
+          rescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then the past session is untouched and the subsequent sessions follow in template order
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.dateOf(s1.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+      assertThat(overview.dateOf(s2.id)).isEqualTo(LocalDate.of(2025, 12, 8))
+      assertThat(overview.dateOf(s3.id)).isEqualTo(LocalDate.of(2025, 12, 15))
+      assertThat(overview.dateOf(s4.id)).isEqualTo(LocalDate.of(2025, 12, 22))
+    }
+
+    @Test
+    fun `does not move a subsequent session that is in the past`() {
+      // Session 2 is later in template order than session 1 but, due to a previously broken
+      // schedule, currently sits in the past. It must not be moved.
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 17),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 24).atTime(10, 0), // future
+          2 to LocalDate.of(2025, 11, 17).atTime(10, 0), // past, but later in template order
+          3 to LocalDate.of(2025, 12, 1).atTime(10, 0), // future
+        ),
+      )
+      val (s1, s2, s3) = fixture.sessions
+
+      // When session 1 is rescheduled with cascade
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/session/${s1.id}/reschedule",
+        returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+        body = RescheduleSessionRequest(
+          sessionStartDate = LocalDate.of(2025, 12, 8),
+          sessionStartTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+          sessionEndTime = SessionTime(hour = 11, minutes = 0, amOrPm = AmOrPm.AM),
+          rescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then the past session 2 keeps its original date, while the future session 3 is moved
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.dateOf(s2.id)).isEqualTo(LocalDate.of(2025, 11, 17))
+      assertThat(overview.dateOf(s1.id)).isEqualTo(LocalDate.of(2025, 12, 8))
+      assertThat(overview.dateOf(s3.id)).isEqualTo(LocalDate.of(2025, 12, 15))
+    }
+
+    @Test
+    fun `keeps subsequent future sessions in the future when a session is moved to the past`() {
+      val fixture = buildGroup(
+        earliestStartDate = LocalDate.of(2025, 11, 24),
+        slots = listOf(DayOfWeek.MONDAY to LocalTime.of(10, 0)),
+        sessionSpecs = listOf(
+          1 to LocalDate.of(2025, 11, 24).atTime(10, 0), // future
+          2 to LocalDate.of(2025, 12, 1).atTime(10, 0), // future
+          3 to LocalDate.of(2025, 12, 8).atTime(10, 0), // future
+        ),
+      )
+      val (s1, s2, s3) = fixture.sessions
+
+      // When session 1 is moved back to a past Monday (10 Nov) with cascade
+      performRequestAndExpectStatusWithBody(
+        httpMethod = HttpMethod.PUT,
+        uri = "/session/${s1.id}/reschedule",
+        returnType = object : ParameterizedTypeReference<EditSessionDateAndTimeResponse>() {},
+        body = RescheduleSessionRequest(
+          sessionStartDate = LocalDate.of(2025, 11, 10),
+          sessionStartTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+          sessionEndTime = SessionTime(hour = 11, minutes = 0, amOrPm = AmOrPm.AM),
+          rescheduleOtherSessions = true,
+        ),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      // Then the subsequent sessions are re-anchored on "now" rather than the past date, so they
+      // remain in the future (and are never pushed onto a past Monday such as 17 Nov)
+      val overview = scheduleOverview(fixture.group.id!!)
+      assertThat(overview.dateOf(s1.id)).isEqualTo(LocalDate.of(2025, 11, 10))
+      assertThat(overview.dateOf(s2.id)).isEqualTo(LocalDate.of(2025, 11, 24))
+      assertThat(overview.dateOf(s3.id)).isEqualTo(LocalDate.of(2025, 12, 1))
+      assertThat(overview.dateOf(s2.id)).isAfter(now)
+      assertThat(overview.dateOf(s3.id)).isAfter(now)
+    }
+  }
+
+  private data class GroupToSessionsMap(val group: ProgrammeGroupEntity, val sessions: List<SessionEntity>)
+
+  /**
+   * Builds a programme group backed by a simple single-module template with one GROUP session
+   * template per supplied session, then persists a session for each spec at the given start time.
+   *
+   * @param sessionSpecs pairs of (template/session number, startsAt). Sessions are 60 minutes long.
+   */
+  private fun buildGroup(
+    earliestStartDate: LocalDate,
+    slots: List<Pair<DayOfWeek, LocalTime>>,
+    sessionSpecs: List<Pair<Int, LocalDateTime>>,
+  ): GroupToSessionsMap {
+    val programmeTemplate =
+      testDataGenerator.createAccreditedProgrammeTemplate("Reschedule ${randomAlphanumericString()}")
+    val module = testDataGenerator.createModule(programmeTemplate, "Module A", 1)
+
+    val group = ProgrammeGroupFactory()
+      .withAccreditedProgrammeTemplate(programmeTemplate)
+      .withTreatmentManager(testDataGenerator.createFacilitator(FacilitatorEntityFactory().produce()))
+      .withEarliestStartDate(earliestStartDate)
+      .withCode(randomAlphanumericString())
+      .produce()
+    group.programmeGroupSessionSlots = slots.map { (day, time) ->
+      ProgrammeGroupSessionSlotEntity(programmeGroup = group, dayOfWeek = day, startTime = time)
+    }.toMutableSet()
+    testDataGenerator.createGroup(group)
+
+    val sessions = sessionSpecs.map { (sessionNumber, startsAt) ->
+      val template = testDataGenerator.createModuleSessionTemplate(
+        module = module,
+        name = "Session $sessionNumber",
+        sessionNumber = sessionNumber,
+        sessionType = SessionType.GROUP,
+        durationMinutes = 60,
+      )
+      testDataGenerator.createSession(
+        SessionFactory()
+          .withProgrammeGroup(group)
+          .withModuleSessionTemplate(template)
+          .withStartsAt(startsAt)
+          .withEndsAt(startsAt.plusHours(1))
+          .produce(),
+      )
+    }
+    return GroupToSessionsMap(group, sessions)
+  }
+
+  private fun scheduleOverview(groupId: UUID): GroupScheduleOverview = performRequestAndExpectOk(
+    httpMethod = HttpMethod.GET,
+    uri = "/bff/group/$groupId/schedule-overview",
+    returnType = object : ParameterizedTypeReference<GroupScheduleOverview>() {},
+  )
+
+  private fun GroupScheduleOverview.dateOf(sessionId: UUID?): LocalDate = sessions.first { it.id == sessionId }.date
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ScheduleServiceIntegrationTest.kt
@@ -48,6 +48,10 @@ class ScheduleServiceIntegrationTest(@Autowired private val sessionRepository: S
 
     nDeliusApiStubs.clearAllStubs()
     govUkApiStubs.stubBankHolidaysResponse()
+    // Register the appointment stubs for every test so they do not depend on a stub leaking in from
+    // an earlier test (clearAllStubs only resets the request journal, not the stub mappings).
+    nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulDeleteAppointmentsResponse()
 
     stubAuthTokenEndpoint()
     nDeliusApiStubs.stubUserTeamsResponse(
@@ -303,6 +307,61 @@ class ScheduleServiceIntegrationTest(@Autowired private val sessionRepository: S
     assertThat(rescheduled).allMatch {
       it.startsAt.dayOfWeek == DayOfWeek.WEDNESDAY && it.startsAt.toLocalTime() == LocalTime.of(15, 0)
     }
+  }
+
+  @Test
+  fun `Reschedule sessions with multiple slots should schedule all future sessions after the most recent past session`() {
+    // Two slots: Monday and Thursday. Clock is 2025-11-22.
+    // Start date 2025-11-15 means multiple sessions have already run.
+    val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+    val slot2 = CreateGroupSessionSlotFactory().produce(DayOfWeek.THURSDAY, 12, 0, AmOrPm.PM)
+    val body = CreateGroupRequestFactory().produce(
+      earliestStartDate = LocalDate.now(clock).minusDays(7), // 2025-11-15
+      createGroupSessionSlot = setOf(slot1, slot2),
+    )
+    performRequestAndExpectStatus(
+      httpMethod = HttpMethod.POST,
+      uri = "/group",
+      body = body,
+      expectedResponseStatus = HttpStatus.CREATED.value(),
+    )
+
+    val group = programmeGroupRepository.findByCode(body.groupCode)!!
+    assertThat(group.sessions).hasSize(27)
+
+    // Change to a single new slot (Wednesday) to trigger a reschedule
+    group.programmeGroupSessionSlots = mutableSetOf(
+      ProgrammeGroupSessionSlotEntity(
+        programmeGroup = group,
+        dayOfWeek = DayOfWeek.WEDNESDAY,
+        startTime = LocalTime.of(10, 0),
+      ),
+    )
+    programmeGroupRepository.save(group)
+
+    scheduleService.rescheduleSessionsForGroup(group.id!!)
+
+    val updatedGroup = programmeGroupRepository.findByIdOrNull(group.id!!)!!
+    val now = LocalDateTime.now(clock)
+
+    val pastSessions = updatedGroup.sessions.filter { it.startsAt <= now }.sortedBy { it.startsAt }
+    val futureSessions = updatedGroup.sessions.filter { it.startsAt > now }.sortedBy { it.startsAt }
+
+    assertThat(pastSessions).isNotEmpty
+    val mostRecentPastSession = pastSessions.last()
+
+    // Every rescheduled session must come strictly after the most recent past session
+    assertThat(futureSessions).allMatch { it.startsAt > mostRecentPastSession.startsAt }
+
+    // All rescheduled sessions must be on the new slot day
+    assertThat(futureSessions).allMatch { it.startsAt.dayOfWeek == DayOfWeek.WEDNESDAY }
+
+    // Rescheduled sessions must follow module/session template order
+    val sessionsByDate = futureSessions.sortedBy { it.startsAt }
+    val sessionsByTemplateOrder = futureSessions.sortedWith(
+      compareBy({ it.moduleSessionTemplate.module.moduleNumber }, { it.moduleSessionTemplate.sessionNumber }),
+    )
+    assertThat(sessionsByDate.map { it.id }).isEqualTo(sessionsByTemplateOrder.map { it.id })
   }
 
   @Test


### PR DESCRIPTION
## WHAT

When rescheduling sessions in a group

via Slots change
- Ensure only future sessions are affected by the slot change

via Session Date and time change
- Ensure that future sessions being rescheduled match the module and session order rather than using the session date as the reschedule point use now instead