### PR TITLE
fix: Find the Users for the Waitlist by the *group's* region, not the currently logged-in user's region

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetGroupWaitlistItemSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/specification/GetGroupWaitlistItemSpecification.kt
@@ -15,7 +15,7 @@ fun getGroupWaitlistItemSpecification(
   nameOrCRN: String?,
   pdu: String?,
   reportingTeams: List<String>?,
-  userRegionName: String,
+  regionName: String,
 ): Specification<GroupWaitlistItemViewEntity> = Specification { root, _, criteriaBuilder ->
   val predicates = mutableListOf<Predicate>()
 
@@ -25,8 +25,9 @@ fun getGroupWaitlistItemSpecification(
    */
   when (selectedTab) {
     GroupPageTab.ALLOCATED -> predicates.add(criteriaBuilder.equal(root.get<UUID>("activeProgrammeGroupId"), groupId))
+
     GroupPageTab.WAITLIST -> {
-      predicates.add(criteriaBuilder.equal(root.get<String>("regionName"), userRegionName))
+      predicates.add(criteriaBuilder.equal(root.get<String>("regionName"), regionName))
       predicates.add(criteriaBuilder.equal(root.get<String>("status"), "Awaiting allocation"))
       predicates.add(criteriaBuilder.isNull(root.get<UUID>("activeProgrammeGroupId")))
       sex?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -351,9 +351,7 @@ class ProgrammeGroupService(
     // Verify the group exists first
     val group = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Programme group with id $groupId not found")
-    val userRegion = userService.getUserRegions(username).firstOrNull()
-      ?: throw NotFoundException("Region for username $username not found")
-    val userRegionName = userRegion.description
+    val groupRegionName = group.regionName
 
     val otherTab = if (selectedTab === GroupPageTab.WAITLIST) GroupPageTab.ALLOCATED else GroupPageTab.WAITLIST
 
@@ -366,11 +364,11 @@ class ProgrammeGroupService(
         nameOrCRN,
         pdu,
         reportingTeams,
-        userRegionName,
+        groupRegionName,
       )
 
     val nonActiveSpecification =
-      getGroupWaitlistItemSpecification(otherTab, groupId, sex, cohort, nameOrCRN, pdu, reportingTeams, userRegionName)
+      getGroupWaitlistItemSpecification(otherTab, groupId, sex, cohort, nameOrCRN, pdu, reportingTeams, groupRegionName)
 
     val groupListDataToReturn: Page<GroupItem> =
       groupWaitlistItemViewRepository.findAll(activeSpecification, pageable).map { it.toApi() }
@@ -383,7 +381,7 @@ class ProgrammeGroupService(
         code = group.code,
         regionName = group.regionName,
       ),
-      filters = getGroupAllocationsFilters(userRegionName),
+      filters = getGroupAllocationsFilters(groupRegionName),
       pagedGroupData = groupListDataToReturn,
       otherTabTotal = otherTabCount,
     )
@@ -417,9 +415,9 @@ class ProgrammeGroupService(
     return GroupDetailsResponse.from(programmeGroup, daysAndTimes, earliestPreGroupSessionDate)
   }
 
-  fun getGroupAllocationsFilters(userRegionName: String): ProgrammeGroupAllocations.ProgrammeGroupAllocationsFilters {
+  fun getGroupAllocationsFilters(regionName: String): ProgrammeGroupAllocations.ProgrammeGroupAllocationsFilters {
     val referralReportingLocations =
-      referralReportingLocationRepository.getPdusAndReportingTeamsByRegions(listOf(userRegionName))
+      referralReportingLocationRepository.getPdusAndReportingTeamsByRegions(listOf(regionName))
     val pdusWithReportingTeams = referralReportingLocations.groupBy { it.pduName }
       .map { (pduName, reportingTeams) ->
         LocationFilterValues(pduName = pduName, reportingTeams = reportingTeams.map { it.reportingTeam }.distinct())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -315,7 +315,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       initialiseReferrals()
       stubAuthTokenEndpoint()
-      val group = ProgrammeGroupFactory().withCode("TEST001").withRegionName("TEST REGION").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST001").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When
@@ -327,7 +327,6 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Then
       assertThat(response).isNotNull
       assertThat(response.group.code).isEqualTo("TEST001")
-      assertThat(response.group.regionName).isEqualTo("TEST REGION")
       assertThat(response.pagedGroupData.content.size).isEqualTo(6)
       assertThat(response.filters).isNotNull
       assertThat(response.filters.sex).containsExactly("Male", "Female")
@@ -377,7 +376,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       initialiseReferrals()
       stubAuthTokenEndpoint()
-      val group = ProgrammeGroupFactory().withCode("TEST006").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST006").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When - Get first page
@@ -437,7 +436,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       initialiseReferrals()
       stubAuthTokenEndpoint()
-      val group = ProgrammeGroupFactory().withCode("TEST006").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST006").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When
@@ -462,7 +461,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       initialiseReferrals()
       stubAuthTokenEndpoint()
-      val group = ProgrammeGroupFactory().withCode("TEST006").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST006").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When
@@ -487,7 +486,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       // Given
       initialiseReferrals()
       stubAuthTokenEndpoint()
-      val group = ProgrammeGroupFactory().withCode("TEST006B").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST006B").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When
@@ -511,7 +510,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     fun `getGroupAllocations returns 200 for ALLOCATED tab with all data when no filters are provided`() {
       // Given
       initialiseReferrals()
-      val group = testGroupHelper.createGroup(groupCode = "TEST008")
+      val group = testGroupHelper.createGroup(groupCode = "TEST008", region = CodeDescription("REGION", "WIREMOCKED REGION"))
       stubAuthTokenEndpoint()
       nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
 
@@ -549,7 +548,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     @Test
     fun `getGroupAllocations returns 401 when not authorized`() {
       // Given
-      val group = ProgrammeGroupFactory().withCode("TEST009").produce()
+      val group = ProgrammeGroupFactory().withCode("TEST009").withRegionName("WIREMOCKED REGION").produce()
       testDataGenerator.createGroup(group)
 
       // When & Then
@@ -566,7 +565,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `getGroupAllocations WAITLIST only returns referrals from the user's own region`() {
+    fun `getGroupAllocations WAITLIST only returns referrals from the group's own region`() {
       // Given
       // The beforeEach stubs AUTH_ADM user as belonging to "WIREMOCKED REGION"
       stubAuthTokenEndpoint()
@@ -610,7 +609,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         referralService.updateStatus(it, status.id, createdBy = "AUTH_USER")
       }
 
-      val group = testGroupHelper.createGroup(groupCode = "TEST_REGION_01")
+      val group = testGroupHelper.createGroup(groupCode = "TEST_REGION_01", region = CodeDescription("TEST_REGION_1", "WIREMOCKED REGION"))
 
       // When
       val response = performRequestAndExpectOk(
@@ -626,7 +625,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `getGroupAllocations WAITLIST filters only show PDUs from the user's own region`() {
+    fun `getGroupAllocations WAITLIST filters only show PDUs from the group's own region`() {
       // Given
       // The beforeEach stubs AUTH_ADM user as belonging to "WIREMOCKED REGION"
       stubAuthTokenEndpoint()
@@ -651,7 +650,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
         referralService.updateStatus(it, status.id, createdBy = "AUTH_USER")
       }
 
-      val group = testGroupHelper.createGroup(groupCode = "TEST_REGION_02")
+      val group = testGroupHelper.createGroup(groupCode = "TEST_REGION_02", region = CodeDescription("CODE", "WIREMOCKED REGION"))
 
       // When
       val response = performRequestAndExpectOk(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceTest.kt
@@ -7,12 +7,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.type.GroupPageTab
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.CreateGroupRequestFactory
-import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.factory.programmeGroup.ProgrammeGroupFactory
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.AccreditedProgrammeTemplateRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.GroupWaitlistItemViewRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ModuleSessionTemplateRepository
@@ -20,7 +16,6 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralReportingLocationRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.utils.SessionNameFormatter
-import java.util.UUID
 
 class ProgrammeGroupServiceTest {
   private val programmeGroupRepository = mockk<ProgrammeGroupRepository>()
@@ -51,33 +46,6 @@ class ProgrammeGroupServiceTest {
       sessionService,
       moduleSessionTemplateRepository,
     )
-  }
-
-  @Test
-  fun shouldThrowExceptionWhenUsernameIsWithoutRegionOnGetGroupWaitlistDataByCriteria() {
-    // Given
-    val groupId = UUID.randomUUID()
-    val username = "user1"
-    val pageRequest = PageRequest.of(0, 10)
-    val groupEntity = ProgrammeGroupFactory().produce()
-    every { programmeGroupRepository.findByIdOrNull(groupId) } returns groupEntity
-    every { userService.getUserRegions(username) } returns emptyList()
-
-    // When
-    val exception = assertThrows<NotFoundException> {
-      service.getGroupWaitlistDataByCriteria(
-        pageRequest,
-        GroupPageTab.ALLOCATED, groupId, null, null, null, null, null, username,
-      )
-    }
-
-    // Then
-    assertTrue(
-      exception.message!!
-        .contains("Region for username $username not found"),
-    )
-    verify { programmeGroupRepository.findByIdOrNull(groupId) }
-    verify { userService.getUserRegions(username) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestGroupHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/utils/TestGroupHelper.kt
@@ -115,6 +115,7 @@ class TestGroupHelper {
         teamMemberType = CreateGroupTeamMemberType.REGULAR_FACILITATOR,
       ),
     ),
+    region: CodeDescription = CodeDescription("REGION001", "WIREMOCKED REGION"),
   ): ProgrammeGroupEntity {
     hmppsAuth.stubGrantToken()
     govUkApiStubs.stubBankHolidaysResponse()
@@ -126,7 +127,7 @@ class TestGroupHelper {
             code = "TEAM001",
             description = "Test Team 1",
             pdu = CodeDescription("PDU001", "Test PDU 1"),
-            region = CodeDescription("REGION001", "WIREMOCKED REGION"),
+            region = region,
           ),
         ),
       ),


### PR DESCRIPTION
**WHAT**

This commit changes the way that the Waitlist on a Programme Group finds Referrals - we now use the Group's region rather than one from the currently-logged in user.
