### PR TITLE
APG-2461 Programme completion event not being sent from finding incorrect session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralStatusService.kt
@@ -16,8 +16,11 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.api.model.toSuggestedStatus
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ProgrammeGroupMembershipEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.ReferralStatusDescriptionEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionAttendanceEntity
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.entity.SessionEntity
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.event.listener.ReferralProgrammeCompleteEvent
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ProgrammeGroupMembershipRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralRepository
@@ -26,6 +29,7 @@ import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repo
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.ReferralStatusTransitionRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.SessionAttendanceRepository
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.repository.type.ReferralStatusType
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -109,14 +113,8 @@ class ReferralStatusService(
     val currentGroupMembership = referral.programmeGroupMemberships.maxByOrNull { it.createdAt }
       ?: throw NotFoundException("No group membership found for referral $referralId")
 
-    val postProgrammeReviewSession = currentGroupMembership.programmeGroup.sessions
-      .find { it.moduleSessionTemplate.module.isPostProgrammeModule() && !it.isPlaceholder }
-      ?: throw NotFoundException("No post-programme review session found for referral $referralId")
-
-    val attendance = sessionAttendanceRepository.findFirstBySessionIdAndGroupMembershipIdOrderByRecordedAtDesc(
-      sessionId = postProgrammeReviewSession.id!!,
-      groupMembershipId = currentGroupMembership.id!!,
-    ) ?: throw NotFoundException("No attendance record found for referral $referralId in post-programme review session")
+    val (postProgrammeReviewSession, attendance) = findPostProgrammeReviewAttendance(currentGroupMembership)
+      ?: throw NotFoundException("No attendance record found for referral $referralId in post-programme review session")
 
     val attended = attendance.outcomeType.attendance == true
     val complied = attendance.outcomeType.compliant
@@ -158,18 +156,30 @@ class ReferralStatusService(
   private fun hasValidPostProgrammeReviewAttendance(referral: ReferralEntity): Boolean {
     val currentGroupMembership = referral.programmeGroupMemberships.maxByOrNull { it.createdAt } ?: return false
 
-    val postProgrammeReviewSession = currentGroupMembership.programmeGroup.sessions
-      .find { it.moduleSessionTemplate.module.isPostProgrammeModule() && !it.isPlaceholder }
-      ?: return false
-
-    val attendance = sessionAttendanceRepository.findFirstBySessionIdAndGroupMembershipIdOrderByRecordedAtDesc(
-      sessionId = postProgrammeReviewSession.id!!,
-      groupMembershipId = currentGroupMembership.id!!,
-    ) ?: return false
+    val (_, attendance) = findPostProgrammeReviewAttendance(currentGroupMembership) ?: return false
 
     val attended = attendance.outcomeType.attendance == true
     val complied = attendance.outcomeType.compliant == true
 
     return attended && complied
   }
+
+  /**
+   * A programme group can contain multiple post-programme review sessions (one per referral),
+   * so we can't just pick the first post-programme session in the group. Instead, we look at
+   * all non-placeholder post-programme sessions and keep the one that actually has an attendance
+   * recorded against this membership, taking the most recent by recorded date if there is more
+   * than one.
+   */
+  private fun findPostProgrammeReviewAttendance(
+    currentGroupMembership: ProgrammeGroupMembershipEntity,
+  ): Pair<SessionEntity, SessionAttendanceEntity>? = currentGroupMembership.programmeGroup.sessions
+    .filter { it.moduleSessionTemplate.module.isPostProgrammeModule() && !it.isPlaceholder }
+    .mapNotNull { session ->
+      sessionAttendanceRepository.findFirstBySessionIdAndGroupMembershipIdOrderByRecordedAtDesc(
+        sessionId = session.id!!,
+        groupMembershipId = currentGroupMembership.id!!,
+      )?.let { session to it }
+    }
+    .maxByOrNull { (_, attendance) -> attendance.recordedAt ?: LocalDateTime.MIN }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCompleteEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/event/ReferralCompleteEventTest.kt
@@ -125,4 +125,130 @@ class ReferralCompleteEventTest(
     assertThat(response.licReqCompletedAt).isCloseTo(postProgrammeSession.startsAt, within(1, ChronoUnit.SECONDS))
     assertThat(response.sourcedFromEntityType).isEqualTo(referral.sourcedFrom)
   }
+
+  @Test
+  fun `publish a referral completed event and retrieve details via rest endpoint when there are multiple post programme reviews in group scheduled`() {
+    nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulDeleteAppointmentsResponse()
+    nDeliusApiStubs.stubSuccessfulPutAppointmentsResponse()
+
+    // Go through referral journey update status -> assign to group
+    val awaitingAllocationStatus = referralStatusDescriptionRepository.getAwaitingAllocationStatusDescription()
+    val onProgrammeStatus = referralStatusDescriptionRepository.getOnProgrammeStatusDescription()
+    val programmeCompleteStatus = referralStatusDescriptionRepository.getProgrammeCompleteStatusDescription()
+    var referral1 = testReferralHelper.createReferral()
+    referral1 = testReferralHelper.updateReferralStatus(referral1, awaitingAllocationStatus)
+    var referral2 = testReferralHelper.createReferral()
+    referral2 = testReferralHelper.updateReferralStatus(referral2, awaitingAllocationStatus)
+
+    val programmeGroup = testGroupHelper.createGroup(earliestStartDate = LocalDate.now())
+    referral1 = testGroupHelper.allocateToGroup(programmeGroup, referral1)
+    referral2 = testGroupHelper.allocateToGroup(programmeGroup, referral2)
+    referral1 = testReferralHelper.updateReferralStatus(referral1, onProgrammeStatus)
+    referral2 = testReferralHelper.updateReferralStatus(referral2, onProgrammeStatus)
+
+    val postProgrammeReviewTemplate =
+      moduleSessionTemplateRepository.findByModuleId(UUID.fromString("ac581f6c-1d81-45a2-af1e-7e3a041ae756")).first()
+
+    // Schedule and mark attendance for referral2 Post programme review session
+    val scheduleSessionRequest2 = ScheduleSessionRequest(
+      sessionTemplateId = postProgrammeReviewTemplate.id!!,
+      referralIds = listOf(referral2.id!!),
+      facilitators = listOf(
+        CreateGroupTeamMemberFactory().withTeamMemberType(CreateGroupTeamMemberType.REGULAR_FACILITATOR).produce(),
+      ),
+      startDate = LocalDate.now().minusWeeks(2),
+      startTime = SessionTime(hour = 9, minutes = 0, amOrPm = AmOrPm.AM),
+      endTime = SessionTime(hour = 10, minutes = 30, amOrPm = AmOrPm.AM),
+    )
+    val postProgrammeSession2 = scheduleService.scheduleIndividualSession(programmeGroup.id!!, scheduleSessionRequest2)
+    postProgrammeSession2.startsAt = LocalDateTime.now().minusHours(4)
+    sessionRepository.save(postProgrammeSession2)
+    val freshSession2 = sessionRepository.findByIdOrNull(postProgrammeSession2.id!!)!!
+    freshSession2.startsAt = LocalDateTime.now().minusHours(2)
+    sessionRepository.save(freshSession2)
+    val attendee2 = freshSession2.attendees.find { it.referralId == referral2.id }!!
+
+    // Record attendance as attended and complied
+    val attendanceRequest2 = SessionAttendance(
+      attendees = listOf(
+        SessionAttendee(
+          referralId = attendee2.referralId,
+          outcomeCode = SessionAttendanceNDeliusCode.ATTC,
+          sessionNotes = "Post-programme review completed successfully",
+        ),
+      ),
+    )
+    val attendanceResult2 = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.POST,
+      uri = "/session/${freshSession2.id}/attendance",
+      body = attendanceRequest2,
+      returnType = object : ParameterizedTypeReference<SessionAttendance>() {},
+      expectedResponseStatus = HttpStatus.CREATED.value(),
+    )
+
+    val scheduleSessionRequest = ScheduleSessionRequest(
+      sessionTemplateId = postProgrammeReviewTemplate.id!!,
+      referralIds = listOf(referral1.id!!),
+      facilitators = listOf(
+        CreateGroupTeamMemberFactory().withTeamMemberType(CreateGroupTeamMemberType.REGULAR_FACILITATOR).produce(),
+      ),
+      startDate = LocalDate.now().minusWeeks(1),
+      startTime = SessionTime(hour = 10, minutes = 0, amOrPm = AmOrPm.AM),
+      endTime = SessionTime(hour = 11, minutes = 30, amOrPm = AmOrPm.AM),
+    )
+    val postProgrammeSession = scheduleService.scheduleIndividualSession(programmeGroup.id!!, scheduleSessionRequest)
+    postProgrammeSession.startsAt = LocalDateTime.now().minusHours(2)
+    sessionRepository.save(postProgrammeSession)
+    val freshSession = sessionRepository.findByIdOrNull(postProgrammeSession.id!!)!!
+    freshSession.startsAt = LocalDateTime.now().minusHours(2)
+    sessionRepository.save(freshSession)
+    val attendee = freshSession.attendees.find { it.referralId == referral1.id }!!
+
+    // Record attendance as attended and complied
+    val attendanceRequest = SessionAttendance(
+      attendees = listOf(
+        SessionAttendee(
+          referralId = attendee.referralId,
+          outcomeCode = SessionAttendanceNDeliusCode.ATTC,
+          sessionNotes = "Post-programme review completed successfully",
+        ),
+      ),
+    )
+    val attendanceResult = performRequestAndExpectStatusWithBody(
+      httpMethod = HttpMethod.POST,
+      uri = "/session/${freshSession.id}/attendance",
+      body = attendanceRequest,
+      returnType = object : ParameterizedTypeReference<SessionAttendance>() {},
+      expectedResponseStatus = HttpStatus.CREATED.value(),
+    )
+
+    assertThat(attendanceResult.attendees).isNotEmpty
+
+    domainEventsQueueConfig.purgeAllQueues()
+
+    referral1 = testReferralHelper.updateReferralStatus(referral1, programmeCompleteStatus)
+
+    // Wait for message to be processed
+    await withPollDelay ofMillis(100) untilCallTo { with(domainEventsQueueConfig) { interventionsQueue.countAllMessagesOnQueue() } } matches { it == 2 }
+    val messages = (1..2).map {
+      with(domainEventsQueueConfig) {
+        objectMapper.readValue<SQSMessage>(interventionsQueue.receiveMessageOnQueue().body())
+      }
+    }
+    val secondEvent = messages.first {
+      it.eventType.equals(HmppsDomainEventTypes.ACP_COMMUNITY_PROGRAMME_COMPLETE.value)
+    }
+    assertThat(secondEvent).isNotNull
+    val response = performRequestAndExpectOk(
+      httpMethod = HttpMethod.GET,
+      uri = "/referral/${referral1.id}/completion-data",
+      returnType = object : ParameterizedTypeReference<ReferralCompletionData>() {},
+    )
+
+    assertThat(response).isNotNull
+    assertThat(response.licReqId).isEqualTo(referral1.eventId)
+    assertThat(response.licReqCompletedAt).isCloseTo(postProgrammeSession.startsAt, within(1, ChronoUnit.SECONDS))
+    assertThat(response.sourcedFromEntityType).isEqualTo(referral1.sourcedFrom)
+  }
 }


### PR DESCRIPTION
If there were multiple schedule/attended post programme review sessions there was a chance that the wrong session could be being looked at for attendance and therefore the termination event would never publish.

This is because we previously had
```kotlin
val postProgrammeReviewSession = currentGroupMembership.programmeGroup.sessions
  .find { it.moduleSessionTemplate.module.isPostProgrammeModule() && !it.isPlaceholder } 

```
which could non-deterministically find the post programme review session for a group.