### PR TITLE
APG-2478: normalise status filter for caselist otherTabCount query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralCaseListItemService.kt
@@ -45,6 +45,10 @@ class ReferralCaseListItemService(
 
     val userRegionNames = userService.getUserRegionNames(username)
 
+    // Normalise the status filter once so both the main query and the otherTabCount query
+    // receive the same DB-compatible value (e.g. "Breach" -> "Breach (non-attendance)").
+    val normalisedStatus = ReferralStatusUtils.unformatStatus(status)
+
     val referralsToReturn = getReferralCaseList(
       pageable = pageable,
       openOrClosed = openOrClosed,
@@ -52,7 +56,7 @@ class ReferralCaseListItemService(
       crnOrPersonName = crnOrPersonName,
       offenceCohort = offenceType,
       hasLdc = hasLdc,
-      status = ReferralStatusUtils.unformatStatus(status),
+      status = normalisedStatus,
       pdus = pdus,
       reportingTeams = reportingTeams,
     ).map { it.toApi() }
@@ -64,7 +68,7 @@ class ReferralCaseListItemService(
       crnOrPersonName = crnOrPersonName,
       offenceCohort = offenceType,
       hasLdc = hasLdc,
-      status = status,
+      status = normalisedStatus,
       pdus = pdus,
       reportingTeams = reportingTeams,
     ).totalElements

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/CaseListControllerIntegrationTest.kt
@@ -817,6 +817,92 @@ class CaseListControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `getCaseListItems for OPEN tab filtered by Breach returns matching referral and correct otherTabTotal`() {
+      // Given a Breach (non-attendance) referral seeded in addition to the standard fixtures
+      seedBreachReferral()
+
+      // When: filter the OPEN tab by the UI-facing label "Breach"
+      val response = performRequestAndExpectOk(
+        HttpMethod.GET,
+        "/pages/caselist/open?status=Breach",
+        object : ParameterizedTypeReference<PagedCaseListReferrals<ReferralCaseListItem>>() {},
+      )
+
+      // Then the main query normalises "Breach" -> "Breach (non-attendance)" for the DB lookup
+      // and returns the seeded referral. The API-level label is formatted back to "Breach".
+      assertThat(response.pagedReferrals.totalElements).isEqualTo(1)
+      assertThat(response.pagedReferrals.content)
+        .allSatisfy { item ->
+          assertThat(item.crn).isEqualTo("CRN-BREACH1")
+          assertThat(item.referralStatus).isEqualTo("Breach")
+        }
+      // And Breach is an open-only status, so the CLOSED tab count is 0
+      assertThat(response.otherTabTotal).isEqualTo(0)
+    }
+
+    @Test
+    fun `getCaseListItems for CLOSED tab filtered by Breach normalises status for otherTabCount`() {
+      // Given a Breach (non-attendance) referral (OPEN) seeded in addition to the standard fixtures.
+      // Previously the otherTabCount query received the raw "Breach" string which never matched
+      // the DB value "Breach (non-attendance)", so otherTabTotal was always 0.
+      seedBreachReferral()
+
+      // When: user is on the CLOSED tab filtering by Breach
+      val response = performRequestAndExpectOk(
+        HttpMethod.GET,
+        "/pages/caselist/closed?status=Breach",
+        object : ParameterizedTypeReference<PagedCaseListReferrals<ReferralCaseListItem>>() {},
+      )
+
+      // Then the CLOSED tab has no Breach referrals
+      assertThat(response.pagedReferrals.totalElements).isEqualTo(0)
+      // And the OPEN tab count (otherTabTotal) correctly reflects the seeded Breach referral
+      assertThat(response.otherTabTotal).isEqualTo(1)
+    }
+
+    private fun seedBreachReferral() {
+      val breachStatusDescription = referralStatusDescriptionRepository.getBreachNonAttendanceStatusDescription()
+
+      // Re-stub access check to include the additional CRN alongside the ones set up in @BeforeEach
+      nDeliusApiStubs.stubAccessCheck(
+        true,
+        "X7182552",
+        "CRN-999999",
+        "CRN-888888",
+        "CRN-777777",
+        "CRN-66666",
+        "CRN-555555",
+        "CRN-111111",
+        "CRN-BREACH1",
+      )
+
+      val breachReferral = ReferralEntityFactory()
+        .withPersonName("Barry Reach")
+        .withCrn("CRN-BREACH1")
+        .withInterventionName("Building Choices")
+        .produce()
+      val breachReportingLocation = ReferralReportingLocationFactory(breachReferral)
+        .withPduName(pduWithComma)
+        .withReportingTeam("reportingTeam1")
+        .withRegionName("WIREMOCKED REGION")
+        .produce()
+      val breachStatusHistory = ReferralStatusHistoryEntityFactory()
+        .withCreatedAt(LocalDateTime.now())
+        .withCreatedBy("USER_ID_12345")
+        .withStartDate(LocalDateTime.now())
+        .produce(breachReferral, breachStatusDescription)
+      val breachCohortHistory = ReferralCohortHistoryFactory().withReferral(breachReferral).produce()
+
+      breachReferral.referralReportingLocation = breachReportingLocation
+      breachReferral.referralCohortHistories = mutableSetOf(breachCohortHistory)
+
+      testDataGenerator.createReferralWithFields(
+        breachReferral,
+        listOf(breachStatusHistory, breachStatusHistory, breachCohortHistory, breachReportingLocation),
+      )
+    }
+
+    @Test
     fun `getCaseListItems for OPEN referrals with reporting location should default to 'UNKNOWN' values and return 200 and paged list of referral case list items`() {
       val response = performRequestAndExpectOk(
         HttpMethod.GET,


### PR DESCRIPTION
The otherTabCount query in ReferralCaseListItemService was passing the raw (UI-formatted) status string, while the main query was passing the value through ReferralStatusUtils.unformatStatus. This meant that when a user filtered by 'Breach', the DB lookup for the opposite tab's count never matched the stored value 'Breach (non-attendance)' and always returned 0.

Compute the unformatted status once and use it for both queries, so they can never drift again. Adds two integration tests that seed a Breach (non-attendance) referral and exercise both the OPEN tab main query and the CLOSED tab otherTabTotal - the latter fails against the previous implementation.