### PR TITLE
APG-2401 Update cron job to use `postgres:17` for production-to-preprod data refresh.

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-manage-and-deliver-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
@@ -71,7 +71,7 @@ spec:
             runAsUser: 999
           containers:
             - name: dbrefresh
-              image: "postgres:16"
+              image: "postgres:17"
               command:
                 - /bin/entrypoint.sh
               volumeMounts:


### PR DESCRIPTION

Upgrading docker image version due to job failure with the following errror message in the logs: 

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.9; pg_dump version: 16.14 (Debian 16.14-1.pgdg13+1)
```