### PR TITLE
APG-2530 ServletRequestResponseNonNullFilterFunction to WebClient configuration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/config/WebClientConfiguration.kt
@@ -16,6 +16,7 @@ import org.springframework.security.oauth2.client.web.reactive.function.client.S
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
+import uk.gov.justice.hmpps.kotlin.auth.ServletRequestResponseNonNullFilterFunction
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
 
@@ -126,6 +127,7 @@ class WebClientConfiguration(
         it.defaultCodecs().maxInMemorySize(maxResponseInMemorySizeBytes)
       }.build(),
     )
+    .filter(ServletRequestResponseNonNullFilterFunction())
     .filter(oauth2Client)
     .build()
 }


### PR DESCRIPTION

The latest spring boot release pulls in a spring security bug (https://github.com/spring-projects/spring-security/issues/19324). 

This release includes an additional `ServletRequestResponseNonNullFilterFunction` filter function to workaround the issue.