### PR TITLE
Add `preprod` profile to AdminController annotations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminController.kt
@@ -39,7 +39,7 @@ data class PopulatePersonalDetailsResponse(val ids: List<String>)
  */
 @RestController
 @PreAuthorize("hasAnyRole('ROLE_ACCREDITED_PROGRAMMES_MANAGE_AND_DELIVER_API__ACPMAD_UI_WR')")
-@Profile(value = ["dev", "local", "test"])
+@Profile(value = ["dev", "local", "test", "preprod"])
 class AdminController(
   private val adminService: AdminService,
   private val dispatcher: CoroutineDispatcher = Dispatchers.IO,


### PR DESCRIPTION

Allow for the invoking of admin API endpoints in the pre-prod environment.