### PR TITLE
APG-2458 Prevent duplicate referrals through validation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/repository/ReferralRepository.kt
@@ -31,6 +31,12 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     sourcedFrom: ReferralEntitySourcedFrom,
   ): ReferralEntity?
 
+  fun existsByCrnAndEventIdAndSourcedFrom(
+    crn: String,
+    eventId: String,
+    sourcedFrom: ReferralEntitySourcedFrom,
+  ): Boolean
+
   fun findAllByCreatedAtBefore(createdAtBefore: LocalDateTime): MutableList<ReferralEntity>
 
   fun findAllByUpdatedAtBefore(updatedAtBefore: LocalDateTime, pageable: Pageable): Page<ReferralEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -73,6 +73,10 @@ class ReferralEventNumberResolverService(
       it.subCategory?.code == LICENCE_CONDITION_BUILDING_CHOICES_SUBCATEGORY_CODE &&
         it.subCategory.description == BUILDING_CHOICES_SUBCATEGORY_DESCRIPTION
     }?.let {
+      if (duplicateReferralDetailsExists(referral, it.id.toString())) {
+        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: $it.id.toString(), sourced_from: ${referral.sourcedFrom}")
+        return false
+      }
       referral.eventNumber = it.eventNumber.toInt()
       referral.eventId = it.id.toString()
       referralRepository.save(referral)
@@ -90,6 +94,10 @@ class ReferralEventNumberResolverService(
         it.subCategory.description == BUILDING_CHOICES_SUBCATEGORY_DESCRIPTION
     }
     buildingChoicesRequirement?.let {
+      if (duplicateReferralDetailsExists(referral, it.id.toString())) {
+        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: $it.id.toString(), sourced_from: ${referral.sourcedFrom}")
+        return false
+      }
       referral.eventNumber = it.eventNumber.toInt()
       referral.eventId = it.id.toString()
       referralRepository.save(referral)
@@ -98,6 +106,16 @@ class ReferralEventNumberResolverService(
     } ?: logFailureEvent(referral)
     return false
   }
+
+  // A unique key on the referral table exists to prevent duplicate referrals being created for a given crn, event_id and sourced_from
+  fun duplicateReferralDetailsExists(
+    referral: ReferralEntity,
+    newEventId: String,
+  ): Boolean = referralRepository.existsByCrnAndEventIdAndSourcedFrom(
+    referral.crn,
+    newEventId,
+    referral.sourcedFrom!!,
+  )
 
   /**
    * When Referrals are populated by the data-importer-service, they have the eventNumber of 0, we know that this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ReferralEventNumberResolverService.kt
@@ -74,7 +74,7 @@ class ReferralEventNumberResolverService(
         it.subCategory.description == BUILDING_CHOICES_SUBCATEGORY_DESCRIPTION
     }?.let {
       if (duplicateReferralDetailsExists(referral, it.id.toString())) {
-        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: $it.id.toString(), sourced_from: ${referral.sourcedFrom}")
+        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: ${it.id}, sourced_from: ${referral.sourcedFrom}")
         return false
       }
       referral.eventNumber = it.eventNumber.toInt()
@@ -95,7 +95,7 @@ class ReferralEventNumberResolverService(
     }
     buildingChoicesRequirement?.let {
       if (duplicateReferralDetailsExists(referral, it.id.toString())) {
-        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: $it.id.toString(), sourced_from: ${referral.sourcedFrom}")
+        log.warn("Existing referral details found for crn: ${referral.crn}, event_id: ${it.id}, sourced_from: ${referral.sourcedFrom}")
         return false
       }
       referral.eventNumber = it.eventNumber.toInt()
@@ -108,7 +108,7 @@ class ReferralEventNumberResolverService(
   }
 
   // A unique key on the referral table exists to prevent duplicate referrals being created for a given crn, event_id and sourced_from
-  fun duplicateReferralDetailsExists(
+  private fun duplicateReferralDetailsExists(
     referral: ReferralEntity,
     newEventId: String,
   ): Boolean = referralRepository.existsByCrnAndEventIdAndSourcedFrom(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/AdminControllerIntegrationTest.kt
@@ -461,4 +461,52 @@ class AdminControllerIntegrationTest : IntegrationTestBase() {
     assertThat(updatedReferral3?.eventNumber).isEqualTo(5)
     assertThat(updatedReferral3?.eventId).isEqualTo("2500910296")
   }
+
+  @Test
+  fun `should not update referral event number if a duplicate referral already exists`() {
+    // Given
+    val crn = "X123456"
+    val duplicateEventId = "2500949965"
+
+    // 1. Existing referral with the target eventId
+    testReferralHelper.createReferral(
+      crn = crn,
+      sourcedFrom = ReferralEntitySourcedFrom.REQUIREMENT,
+      sourcedFromReference = duplicateEventId,
+      eventNumber = 3,
+    )
+
+    // 2. Referral with invalid event number that would resolve to the same eventId
+    val referralToResolve = testReferralHelper.createReferral(
+      crn = crn,
+      sourcedFrom = ReferralEntitySourcedFrom.REQUIREMENT,
+      eventNumber = 0,
+    )
+
+    // Stub nDelius to return the same requirement (eventId) for the CRN
+    nDeliusApiStubs.stubSuccessfulRequirementsResponse(
+      crn,
+      Requirements(
+        content = listOf(
+          RequirementFactory()
+            .withId(duplicateEventId.toLong())
+            .withSubCategory(CodeDescription("734", "Building Choices"))
+            .withEventNumber("3")
+            .produce(),
+        ),
+      ),
+    )
+
+    // When
+    performRequestAndExpectStatusNoBody(
+      HttpMethod.PUT,
+      "/admin/resolve-referral-event-numbers",
+      expectedResponseStatus = HttpStatus.OK.value(),
+    )
+
+    // Then
+    val unresolvedReferral = referralRepository.findByIdOrNull(referralToResolve.id!!)
+    assertThat(unresolvedReferral?.eventNumber).isEqualTo(0)
+    assertThat(unresolvedReferral?.eventId).isNotEqualTo(duplicateEventId)
+  }
 }


### PR DESCRIPTION

### Description

- The pull request introduces validation logic in `resolveReferralEventNumbers` to ensure duplicate referrals are prevented, which have occurred in testing due to the unique constraint : `uq_referral_crn_event_id_sourced_from`.  

- The licence/requirement data coming back from nDelius may inadvertently attempt to update referral data to a combination that already exists. 


### Changes Made

- Added a validation mechanism to check and avoid duplicate referrals in `resolveReferralEventNumbers` by performing an upfront test to verify that an existing referral with the "new" details doesn't already exist.
- Added an integration test to verify this scenario

