### PR TITLE
APG-2574 : Add LAO check on session details page

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,10 +10,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JAVA-IOOPENTELEMETRY-17280222:
-    - '*':
-        reason: Suppression for baggage limits issue as we use header size limits
-        expires: 2026-07-11T00:00:00.000Z
-        created: 2026-06-11T07:38:00.250Z
+ignore: {}
 patch: {}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ generic-service:
     SERVICES_PROBATION-ACCESS-CONTROL-API_BASE-URL: "https://probation-access-control-dev.hmpps.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: dev
     LAO_ACCESS_CHECK_ENABLED: "true"
+    EXCLUSION_ACCESS_CHECK_ENABLED: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ generic-service:
     SERVICES_PROBATION-ACCESS-CONTROL-API_BASE-URL: "https://probation-access-control-preprod.hmpps.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: preprod
     LAO_ACCESS_CHECK_ENABLED: "true"
+    EXCLUSION_ACCESS_CHECK_ENABLED: "true"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,6 +23,7 @@ generic-service:
     SPRINGDOC_API_DOCS_ENABLED: "false"
     REPORTING_ENABLED: "true"
     LAO_ACCESS_CHECK_ENABLED: "false"
+    EXCLUSION_ACCESS_CHECK_ENABLED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupController.kt
@@ -852,7 +852,9 @@ class ProgrammeGroupController(
   fun getGroupSessionPage(
     @PathVariable groupId: UUID,
     @PathVariable sessionId: UUID,
-  ): ResponseEntity<GroupSessionResponse> = ResponseEntity.ok(programmeGroupService.getGroupSessionPage(groupId, sessionId))
+  ): ResponseEntity<GroupSessionResponse> = ResponseEntity.ok(
+    programmeGroupService.getGroupSessionPage(groupId, sessionId, authenticationUtils.getUsername()),
+  )
 
   @Operation(
     tags = ["Programme Group controller"],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/GroupSessionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/model/programmeGroup/GroupSessionResponse.kt
@@ -16,7 +16,11 @@ data class GroupSessionResponse(
   @get:JsonProperty("code", required = true)
   val groupCode: String,
 
-  @Schema(description = "The title of the page", required = true, example = "Attendance and notes for Getting started session")
+  @Schema(
+    description = "The title of the page",
+    required = true,
+    example = "Attendance and notes for Getting started session",
+  )
   val pageTitle: String,
 
   @Schema(description = "The type of session", required = true, example = "one-to-one")
@@ -41,13 +45,21 @@ data class GroupSessionResponse(
   @Schema(description = "The time of the session", required = true, example = "11am")
   val time: String,
 
-  @Schema(description = "The time of the session with special times capitalised", required = true, example = "Midday to 1pm")
+  @Schema(
+    description = "The time of the session with special times capitalised",
+    required = true,
+    example = "Midday to 1pm",
+  )
   val timeWithCapitalisedMidday: String = "",
 
   @Schema(description = "The list of people scheduled to attend", required = true, example = "[John Smith, Jane Doe]")
   val scheduledToAttend: List<String>,
 
-  @Schema(description = "The names of the facilitators in the session", required = true, example = "[John Doe, Jane Smith]")
+  @Schema(
+    description = "The names of the facilitators in the session",
+    required = true,
+    example = "[John Doe, Jane Smith]",
+  )
   val facilitators: List<String>,
 
   @Schema(description = "The attendance and session notes for each attendee", required = true)
@@ -59,6 +71,11 @@ data class AttendanceAndSessionNotes(
   val referralId: UUID,
   val crn: String,
   val lao: Boolean,
+  @Schema(
+    description = "True when the current user is not authorised to view this Limited Access Offender.",
+    example = "false",
+  )
+  val isExcluded: Boolean = false,
   val attendance: String,
   val sessionNotes: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.probationAccessControlApi.ProbationAccessControlApiClient
+
+@Component
+class LimitedAccessResolverService(
+  private val probationAccessControlApiClient: ProbationAccessControlApiClient,
+  private val userService: UserService,
+  @Value("\${app.features.lao-badge-enabled}")
+  private val badgeEnabled: Boolean,
+  @Value("\${app.features.lao-view-restriction-enabled}")
+  private val restrictionEnabled: Boolean,
+) {
+  data class Access(
+    val lao: Boolean,
+    val isExcluded: Boolean,
+  )
+
+  fun resolve(username: String, crns: List<String>): Map<String, Access> {
+    val distinctCrns = crns.distinct()
+    if (distinctCrns.isEmpty()) return emptyMap()
+
+    val laoByCrn = if (badgeEnabled) distinctCrns.associateWith(::isLao) else emptyMap()
+    val accessibleCrns = if (badgeEnabled || restrictionEnabled) {
+      userService.getAccessibleOffenders(username, distinctCrns)
+    } else {
+      distinctCrns.toSet()
+    }
+
+    return distinctCrns.associateWith { crn ->
+      Access(
+        lao = laoByCrn[crn] ?: false,
+        isExcluded = crn !in accessibleCrns,
+      )
+    }
+  }
+
+  private fun isLao(crn: String): Boolean = when (val response = probationAccessControlApiClient.getCaseAccessByCrn(crn)) {
+    is ClientResult.Success -> response.body.excludedFrom.isNotEmpty() || response.body.restrictedTo.isNotEmpty()
+    is ClientResult.Failure -> false
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
@@ -11,7 +11,7 @@ class LimitedAccessResolverService(
   private val userService: UserService,
   @Value("\${app.features.lao-access-check-enabled:false}")
   private val laoAccessCheckEnabled: Boolean,
-  @Value("\${app.features.lao-view-restriction-enabled}")
+  @Value("\${app.features.exclusion-access-check-enabled}")
   private val restrictionEnabled: Boolean,
 ) {
   data class Access(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverService.kt
@@ -1,16 +1,16 @@
 package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.probationAccessControlApi.ProbationAccessControlApiClient
 
-@Component
+@Service
 class LimitedAccessResolverService(
   private val probationAccessControlApiClient: ProbationAccessControlApiClient,
   private val userService: UserService,
-  @Value("\${app.features.lao-badge-enabled}")
-  private val badgeEnabled: Boolean,
+  @Value("\${app.features.lao-access-check-enabled:false}")
+  private val laoAccessCheckEnabled: Boolean,
   @Value("\${app.features.lao-view-restriction-enabled}")
   private val restrictionEnabled: Boolean,
 ) {
@@ -23,8 +23,8 @@ class LimitedAccessResolverService(
     val distinctCrns = crns.distinct()
     if (distinctCrns.isEmpty()) return emptyMap()
 
-    val laoByCrn = if (badgeEnabled) distinctCrns.associateWith(::isLao) else emptyMap()
-    val accessibleCrns = if (badgeEnabled || restrictionEnabled) {
+    val laoByCrn = if (laoAccessCheckEnabled) distinctCrns.associateWith(::isLao) else emptyMap()
+    val accessibleCrns = if (laoAccessCheckEnabled || restrictionEnabled) {
       userService.getAccessibleOffenders(username, distinctCrns)
     } else {
       distinctCrns.toSet()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupService.kt
@@ -88,6 +88,7 @@ class ProgrammeGroupService(
   private val sessionService: SessionService,
   private val moduleSessionTemplateRepository: ModuleSessionTemplateRepository,
   private val probationAccessControlApiClient: ProbationAccessControlApiClient,
+  private val limitedAccessResolverService: LimitedAccessResolverService,
   @Value("\${app.features.lao-access-check-enabled}")
   private val laoAccessCheckEnabled: Boolean,
 ) {
@@ -374,7 +375,16 @@ class ProgrammeGroupService(
       )
 
     val nonActiveSpecification =
-      getGroupWaitlistItemSpecification(otherTab, groupId, sex, cohort, nameOrCRN, pdus, reportingTeams, groupRegionName)
+      getGroupWaitlistItemSpecification(
+        otherTab,
+        groupId,
+        sex,
+        cohort,
+        nameOrCRN,
+        pdus,
+        reportingTeams,
+        groupRegionName,
+      )
 
     val pagedData = groupWaitlistItemViewRepository.findAll(activeSpecification, pageable)
 
@@ -731,14 +741,15 @@ class ProgrammeGroupService(
     )
   }
 
-  fun getGroupSessionPage(groupId: UUID, sessionId: UUID): GroupSessionResponse {
+  fun getGroupSessionPage(groupId: UUID, sessionId: UUID, username: String): GroupSessionResponse {
     val programmeGroup = programmeGroupRepository.findByIdOrNull(groupId)
       ?: throw NotFoundException("Group with id $groupId not found")
 
     val session = sessionRepository.findByIdOrNull(sessionId)
       ?: throw NotFoundException("Session with $sessionId not found")
 
-    val laoByCrn = session.attendees.map { it.referral.crn }.distinct().associateWith { getLaoByCrn(it) }
+    val distinctCrns = session.attendees.map { it.referral.crn }.distinct()
+    val accessByCrn = limitedAccessResolverService.resolve(username, distinctCrns)
 
     val attendanceAndSessionNotes = session.attendees.map { attendee ->
       val attendanceRecord = session.attendances
@@ -746,11 +757,13 @@ class ProgrammeGroupService(
         .sortedWith(compareByDescending<SessionAttendanceEntity> { it.createdAt }.thenByDescending { it.id })
         .firstOrNull()
 
+      val access = accessByCrn[attendee.referral.crn]
       AttendanceAndSessionNotes(
         name = attendee.personName,
         referralId = attendee.referralId,
         crn = attendee.referral.crn,
-        lao = laoByCrn[attendee.referral.crn] ?: false,
+        lao = access?.lao ?: false,
+        isExcluded = access?.isExcluded ?: false,
         attendance = getAttendanceTextFromOutcome(attendanceRecord?.outcomeType),
         sessionNotes = attendanceRecord?.notesHistory?.maxByOrNull { it.createdAt }?.notes ?: "Not added",
       )
@@ -763,7 +776,11 @@ class ProgrammeGroupService(
       isCatchup = session.isCatchup,
       date = session.startsAt.toLocalDate(),
       time = formatTimeOfSession(session.startsAt.toLocalTime(), session.endsAt.toLocalTime()),
-      timeWithCapitalisedMidday = formatTimeOfSession(session.startsAt.toLocalTime(), session.endsAt.toLocalTime(), capitaliseMidday = true),
+      timeWithCapitalisedMidday = formatTimeOfSession(
+        session.startsAt.toLocalTime(),
+        session.endsAt.toLocalTime(),
+        capitaliseMidday = true,
+      ),
       unformattedEndDate = session.endsAt,
       scheduledToAttend = session.attendees.map { it.personName },
       facilitators = session.sessionFacilitators.sortedBy { it.facilitator.personName }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,6 @@
 app:
   features:
     lao-access-check-enabled: true
-    lao-badge-enabled: true
     lao-view-restriction-enabled: true
 
 spring:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 app:
   features:
     lao-access-check-enabled: true
-    lao-view-restriction-enabled: true
+    exclusion-access-check-enabled: true
 
 spring:
   datasource:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,3 +1,9 @@
+app:
+  features:
+    lao-access-check-enabled: true
+    lao-badge-enabled: true
+    lao-view-restriction-enabled: true
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,6 @@ sentry:
 app:
   features:
     lao-access-check-enabled: ${LAO_ACCESS_CHECK_ENABLED:false}
-    lao-badge-enabled: ${LAO_BADGE_ENABLED:false}
     lao-view-restriction-enabled: ${LAO_VIEW_RESTRICTION_ENABLED:false}
 
   scheduling:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ sentry:
 app:
   features:
     lao-access-check-enabled: ${LAO_ACCESS_CHECK_ENABLED:false}
-    lao-view-restriction-enabled: ${LAO_VIEW_RESTRICTION_ENABLED:false}
+    exclusion-access-check-enabled: ${EXCLUSION_ACCESS_CHECK_ENABLED:false}
 
   scheduling:
     referral-details-updated:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ sentry:
 app:
   features:
     lao-access-check-enabled: ${LAO_ACCESS_CHECK_ENABLED:false}
+    lao-badge-enabled: ${LAO_BADGE_ENABLED:false}
+    lao-view-restriction-enabled: ${LAO_VIEW_RESTRICTION_ENABLED:false}
 
   scheduling:
     referral-details-updated:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -4200,7 +4200,7 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `return 200 and flag an authorised LAO as lao but not excluded so the restricted access badge is shown`() {
+    fun `return 200 and flag an authorised LAO as lao but not excluded so the restricted access is true`() {
       initialiseReferrals()
       val authorisedLaoReferral = referrals[0]
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/api/controller/ProgrammeGroupControllerIntegrationTest.kt
@@ -3903,6 +3903,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       session.attendances.add(attendance)
       sessionRepository.saveAndFlush(session)
 
+      nDeliusApiStubs.stubAccessCheck(true, groupMembership.crn)
+
       // When
       val response = performRequestAndExpectOk(
         httpMethod = HttpMethod.GET,
@@ -4087,6 +4089,8 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       session.attendances.addAll(listOf(attendance1, attendance2, attendance3))
       sessionRepository.saveAndFlush(session)
 
+      nDeliusApiStubs.stubAccessCheck(true, referral1.crn, referral2.crn, referral3.crn)
+
       // When
       val response = performRequestAndExpectOk(
         httpMethod = HttpMethod.GET,
@@ -4102,16 +4106,217 @@ class ProgrammeGroupControllerIntegrationTest : IntegrationTestBase() {
       assertThat(notes1.attendance).isEqualTo("Attended - Complied")
       assertThat(notes1.sessionNotes).isEqualTo("Notes for referral 1 - latest")
       assertThat(notes1.lao).isFalse
+      assertThat(notes1.isExcluded).isFalse
 
       val notes2 = response.attendanceAndSessionNotes.find { it.crn == referral2.crn }!!
       assertThat(notes2.attendance).isEqualTo("Did not attend")
       assertThat(notes2.sessionNotes).isEqualTo("Notes for referral 2 - latest")
       assertThat(notes2.lao).isFalse
+      assertThat(notes2.isExcluded).isFalse
 
       val notes3 = response.attendanceAndSessionNotes.find { it.crn == referral3.crn }!!
       assertThat(notes3.attendance).isEqualTo("To be confirmed")
       assertThat(notes3.sessionNotes).isEqualTo("Not added")
       assertThat(notes3.lao).isFalse
+      assertThat(notes3.isExcluded).isFalse
+    }
+
+    @Test
+    fun `return 200 and flag LAO attendees the user is not authorised to view as excluded`() {
+      initialiseReferrals()
+      val accessibleReferral = referrals[0]
+      val excludedReferral = referrals[1]
+      val restrictedReferral = referrals[2]
+
+      val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+      val body = CreateGroupRequestFactory().produce(
+        createGroupSessionSlot = setOf(slot1),
+        teamMembers = listOf(
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.REGULAR_FACILITATOR),
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.TREATMENT_MANAGER),
+        ),
+      )
+      nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.POST,
+        uri = "/group",
+        body = body,
+        expectedResponseStatus = HttpStatus.CREATED.value(),
+      )
+
+      val group = programmeGroupRepository.findByCode(body.groupCode)!!
+
+      listOf(accessibleReferral, excludedReferral, restrictedReferral).forEach { referral ->
+        performRequestAndExpectStatus(
+          httpMethod = HttpMethod.POST,
+          uri = "/group/${group.id}/allocate/${referral.id}",
+          body = AllocateToGroupRequest(additionalDetails = "Test allocation"),
+          expectedResponseStatus = HttpStatus.OK.value(),
+        )
+      }
+
+      val groupWithAllocation = programmeGroupRepository.findByCode(body.groupCode)!!
+      val session = groupWithAllocation.sessions.first { !it.isPlaceholder }
+
+      // The excluded/restricted referrals are LAOs; the accessible one is not.
+      probationAccessControlApiStubs.stubCaseAccessByCrn(
+        crn = excludedReferral.crn,
+        excludedFrom = listOf(probationAccessControlApiStubs.createAllCaseAccessUsernameRange(username = "AUTH_ADM")),
+      )
+      probationAccessControlApiStubs.stubCaseAccessByCrn(
+        crn = restrictedReferral.crn,
+        restrictedTo = listOf(probationAccessControlApiStubs.createAllCaseAccessUsernameRange(username = "SOMEONE_ELSE")),
+      )
+      probationAccessControlApiStubs.stubCaseAccessByCrn(crn = accessibleReferral.crn)
+
+      // nDelius authorises only the accessible referral.
+      nDeliusApiStubs.stubAccessCheckMixed(
+        grantedCrns = listOf(accessibleReferral.crn),
+        excludedCrns = listOf(excludedReferral.crn),
+        restrictedCrns = listOf(restrictedReferral.crn),
+      )
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/bff/group/${group.id}/session/${session.id}",
+        returnType = object : ParameterizedTypeReference<GroupSessionResponse>() {},
+      )
+
+      assertThat(response.attendanceAndSessionNotes).hasSize(3)
+
+      val accessible = response.attendanceAndSessionNotes.first { it.crn == accessibleReferral.crn }
+      assertThat(accessible.lao).isFalse
+      assertThat(accessible.isExcluded).isFalse
+
+      val excluded = response.attendanceAndSessionNotes.first { it.crn == excludedReferral.crn }
+      assertThat(excluded.lao).isTrue
+      assertThat(excluded.isExcluded).isTrue
+
+      val restricted = response.attendanceAndSessionNotes.first { it.crn == restrictedReferral.crn }
+      assertThat(restricted.lao).isTrue
+      assertThat(restricted.isExcluded).isTrue
+    }
+
+    @Test
+    fun `return 200 and flag an authorised LAO as lao but not excluded so the restricted access badge is shown`() {
+      initialiseReferrals()
+      val authorisedLaoReferral = referrals[0]
+
+      val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+      val body = CreateGroupRequestFactory().produce(
+        createGroupSessionSlot = setOf(slot1),
+        teamMembers = listOf(
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.REGULAR_FACILITATOR),
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.TREATMENT_MANAGER),
+        ),
+      )
+      nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.POST,
+        uri = "/group",
+        body = body,
+        expectedResponseStatus = HttpStatus.CREATED.value(),
+      )
+
+      val group = programmeGroupRepository.findByCode(body.groupCode)!!
+
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.POST,
+        uri = "/group/${group.id}/allocate/${authorisedLaoReferral.id}",
+        body = AllocateToGroupRequest(additionalDetails = "Test allocation"),
+        expectedResponseStatus = HttpStatus.OK.value(),
+      )
+
+      val groupWithAllocation = programmeGroupRepository.findByCode(body.groupCode)!!
+      val session = groupWithAllocation.sessions.first { !it.isPlaceholder }
+
+      // The case is restricted, but restricted TO the current user, so they remain authorised.
+      probationAccessControlApiStubs.stubCaseAccessByCrn(
+        crn = authorisedLaoReferral.crn,
+        restrictedTo = listOf(probationAccessControlApiStubs.createAllCaseAccessUsernameRange(username = "AUTH_ADM")),
+      )
+      nDeliusApiStubs.stubAccessCheckMixed(grantedCrns = listOf(authorisedLaoReferral.crn))
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/bff/group/${group.id}/session/${session.id}",
+        returnType = object : ParameterizedTypeReference<GroupSessionResponse>() {},
+      )
+
+      // Then the attendee is flagged as an LAO but NOT excluded
+      val authorisedLao = response.attendanceAndSessionNotes.first { it.crn == authorisedLaoReferral.crn }
+      assertThat(authorisedLao.lao).isTrue
+      assertThat(authorisedLao.isExcluded).isFalse
+      assertThat(authorisedLao.name).isEqualTo(authorisedLaoReferral.personName)
+    }
+
+    @Test
+    fun `return 200 and mark all attendees excluded when the user is authorised to view none of them`() {
+      // Given a group catch-up where every LAO attendee is restricted for the current user.
+      initialiseReferrals()
+      val restrictedReferralOne = referrals[0]
+      val restrictedReferralTwo = referrals[1]
+
+      val slot1 = CreateGroupSessionSlotFactory().produce(DayOfWeek.MONDAY, 9, 30, AmOrPm.AM)
+      val body = CreateGroupRequestFactory().produce(
+        createGroupSessionSlot = setOf(slot1),
+        teamMembers = listOf(
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.REGULAR_FACILITATOR),
+          CreateGroupTeamMemberFactory().produceWithRandomValues(teamMemberType = CreateGroupTeamMemberType.TREATMENT_MANAGER),
+        ),
+      )
+      nDeliusApiStubs.stubSuccessfulPostAppointmentsResponse()
+
+      performRequestAndExpectStatus(
+        httpMethod = HttpMethod.POST,
+        uri = "/group",
+        body = body,
+        expectedResponseStatus = HttpStatus.CREATED.value(),
+      )
+
+      val group = programmeGroupRepository.findByCode(body.groupCode)!!
+
+      listOf(restrictedReferralOne, restrictedReferralTwo).forEach { referral ->
+        performRequestAndExpectStatus(
+          httpMethod = HttpMethod.POST,
+          uri = "/group/${group.id}/allocate/${referral.id}",
+          body = AllocateToGroupRequest(additionalDetails = "Test allocation"),
+          expectedResponseStatus = HttpStatus.OK.value(),
+        )
+      }
+
+      val groupWithAllocation = programmeGroupRepository.findByCode(body.groupCode)!!
+      val session = groupWithAllocation.sessions.first { !it.isPlaceholder }
+
+      probationAccessControlApiStubs.stubCaseAccessByCrn(
+        crn = restrictedReferralOne.crn,
+        excludedFrom = listOf(probationAccessControlApiStubs.createAllCaseAccessUsernameRange(username = "AUTH_ADM")),
+      )
+      probationAccessControlApiStubs.stubCaseAccessByCrn(
+        crn = restrictedReferralTwo.crn,
+        excludedFrom = listOf(probationAccessControlApiStubs.createAllCaseAccessUsernameRange(username = "AUTH_ADM")),
+      )
+      nDeliusApiStubs.stubAccessCheckMixed(
+        excludedCrns = listOf(restrictedReferralOne.crn, restrictedReferralTwo.crn),
+      )
+
+      // When
+      val response = performRequestAndExpectOk(
+        httpMethod = HttpMethod.GET,
+        uri = "/bff/group/${group.id}/session/${session.id}",
+        returnType = object : ParameterizedTypeReference<GroupSessionResponse>() {},
+      )
+
+      assertThat(response.facilitators).isNotEmpty
+      assertThat(response.attendanceAndSessionNotes).hasSize(2)
+      assertThat(response.attendanceAndSessionNotes).allSatisfy {
+        assertThat(it.lao).isTrue
+        assertThat(it.isExcluded).isTrue
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/integration/wiremock/stubs/NDeliusApiStubs.kt
@@ -80,6 +80,33 @@ class NDeliusApiStubs {
     )
   }
 
+  fun stubAccessCheckMixed(
+    grantedCrns: List<String> = emptyList(),
+    excludedCrns: List<String> = emptyList(),
+    restrictedCrns: List<String> = emptyList(),
+  ) {
+    val response = LimitedAccessOffenderCheckResponse(
+      grantedCrns.map {
+        LimitedAccessOffenderCheck(crn = it, userExcluded = false, userRestricted = false, exclusionMessage = null, restrictionMessage = null)
+      } + excludedCrns.map {
+        LimitedAccessOffenderCheck(crn = it, userExcluded = true, userRestricted = false, exclusionMessage = "Excluded", restrictionMessage = null)
+      } + restrictedCrns.map {
+        LimitedAccessOffenderCheck(crn = it, userExcluded = false, userRestricted = true, exclusionMessage = null, restrictionMessage = "Restricted")
+      },
+    )
+
+    wiremock.stubFor(
+      post(urlPathTemplate("/user/{username}/access"))
+        .withRequestBody(matchingJsonPath("$"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(response)),
+        ),
+    )
+  }
+
   fun stubPersonalDetailsResponse(
     nDeliusPersonalDetails: NDeliusPersonalDetails? = NDeliusPersonalDetailsFactory().produce(),
   ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverServiceTest.kt
@@ -22,10 +22,10 @@ class LimitedAccessResolverServiceTest {
   private val laoAuthorisedCrn = "CRN-LAO-AUTHORISED"
   private val laoRestrictedCrn = "CRN-LAO-RESTRICTED"
 
-  private fun resolver(badgeEnabled: Boolean, restrictionEnabled: Boolean) = LimitedAccessResolverService(
+  private fun resolver(accessCheckEnabled: Boolean, restrictionEnabled: Boolean) = LimitedAccessResolverService(
     probationAccessControlApiClient = probationAccessControlApiClient,
     userService = userService,
-    badgeEnabled = badgeEnabled,
+    laoAccessCheckEnabled = accessCheckEnabled,
     restrictionEnabled = restrictionEnabled,
   )
 
@@ -48,7 +48,7 @@ class LimitedAccessResolverServiceTest {
 
   @Test
   fun `both feature flags off should not make any calls to getCaseAccessByCrn and no LAO's`() {
-    val result = resolver(badgeEnabled = false, restrictionEnabled = false)
+    val result = resolver(accessCheckEnabled = false, restrictionEnabled = false)
       .resolve(username, listOf(ordinaryCrn, laoRestrictedCrn))
 
     assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
@@ -59,14 +59,14 @@ class LimitedAccessResolverServiceTest {
   }
 
   @Test
-  fun `badge only feature flag LAOs are flagged`() {
+  fun `access check enabled feature flag shows authorised LAO's`() {
     stubCaseAccess(ordinaryCrn)
     stubCaseAccess(laoAuthorisedCrn, restrictedTo = listOf(username))
     stubCaseAccess(laoRestrictedCrn, excludedFrom = listOf(username))
     // Only the ordinary and authorised-LAO CRNs are accessible to this user.
     every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
 
-    val result = resolver(badgeEnabled = true, restrictionEnabled = false)
+    val result = resolver(accessCheckEnabled = true, restrictionEnabled = false)
       .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
 
     assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
@@ -80,7 +80,7 @@ class LimitedAccessResolverServiceTest {
   fun `restriction flag enabled unauthorised participants are excluded`() {
     every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
 
-    val result = resolver(badgeEnabled = false, restrictionEnabled = true)
+    val result = resolver(accessCheckEnabled = false, restrictionEnabled = true)
       .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
 
     assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
@@ -92,13 +92,13 @@ class LimitedAccessResolverServiceTest {
   }
 
   @Test
-  fun `both feature flags enabled - LAOs are badged and unauthorised LAOs are excluded`() {
+  fun `both feature flags enabled - LAOs are access checked and unauthorised LAOs are excluded`() {
     stubCaseAccess(ordinaryCrn)
     stubCaseAccess(laoAuthorisedCrn, restrictedTo = listOf(username))
     stubCaseAccess(laoRestrictedCrn, excludedFrom = listOf(username))
     every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
 
-    val result = resolver(badgeEnabled = true, restrictionEnabled = true)
+    val result = resolver(accessCheckEnabled = true, restrictionEnabled = true)
       .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
 
     assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
@@ -108,7 +108,7 @@ class LimitedAccessResolverServiceTest {
 
   @Test
   fun `empty crns - returns an empty map and makes no external calls`() {
-    val result = resolver(badgeEnabled = true, restrictionEnabled = true).resolve(username, emptyList())
+    val result = resolver(accessCheckEnabled = true, restrictionEnabled = true).resolve(username, emptyList())
 
     assertThat(result).isEmpty()
     verify(exactly = 0) { probationAccessControlApiClient.getCaseAccessByCrn(any()) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/LimitedAccessResolverServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.probationAccessControlApi.ProbationAccessControlApiClient
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.probationAccessControlApi.model.AllCaseAccess
+import uk.gov.justice.digital.hmpps.accreditedprogrammesmanageanddeliverapi.client.probationAccessControlApi.model.AllCaseAccessUsernameRange
+import java.time.OffsetDateTime
+
+class LimitedAccessResolverServiceTest {
+
+  private val probationAccessControlApiClient: ProbationAccessControlApiClient = mockk()
+  private val userService: UserService = mockk()
+
+  private val username = "AUTH_ADM"
+  private val ordinaryCrn = "CRN-ORDINARY"
+  private val laoAuthorisedCrn = "CRN-LAO-AUTHORISED"
+  private val laoRestrictedCrn = "CRN-LAO-RESTRICTED"
+
+  private fun resolver(badgeEnabled: Boolean, restrictionEnabled: Boolean) = LimitedAccessResolverService(
+    probationAccessControlApiClient = probationAccessControlApiClient,
+    userService = userService,
+    badgeEnabled = badgeEnabled,
+    restrictionEnabled = restrictionEnabled,
+  )
+
+  private fun stubCaseAccess(
+    crn: String,
+    excludedFrom: List<String> = emptyList(),
+    restrictedTo: List<String> = emptyList(),
+  ) {
+    every { probationAccessControlApiClient.getCaseAccessByCrn(crn) } returns ClientResult.Success(
+      HttpStatus.OK,
+      AllCaseAccess(
+        crn = crn,
+        excludedFrom = excludedFrom.map { usernameRange(it) },
+        restrictedTo = restrictedTo.map { usernameRange(it) },
+      ),
+    )
+  }
+
+  private fun usernameRange(name: String) = AllCaseAccessUsernameRange(username = name, since = OffsetDateTime.now().minusDays(1), until = null)
+
+  @Test
+  fun `both feature flags off should not make any calls to getCaseAccessByCrn and no LAO's`() {
+    val result = resolver(badgeEnabled = false, restrictionEnabled = false)
+      .resolve(username, listOf(ordinaryCrn, laoRestrictedCrn))
+
+    assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+    assertThat(result[laoRestrictedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+
+    verify(exactly = 0) { probationAccessControlApiClient.getCaseAccessByCrn(any()) }
+    verify(exactly = 0) { userService.getAccessibleOffenders(any(), any()) }
+  }
+
+  @Test
+  fun `badge only feature flag LAOs are flagged`() {
+    stubCaseAccess(ordinaryCrn)
+    stubCaseAccess(laoAuthorisedCrn, restrictedTo = listOf(username))
+    stubCaseAccess(laoRestrictedCrn, excludedFrom = listOf(username))
+    // Only the ordinary and authorised-LAO CRNs are accessible to this user.
+    every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
+
+    val result = resolver(badgeEnabled = true, restrictionEnabled = false)
+      .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
+
+    assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+    assertThat(result[laoAuthorisedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = true, isExcluded = false))
+    assertThat(result[laoRestrictedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = true, isExcluded = true))
+
+    verify(exactly = 1) { userService.getAccessibleOffenders(username, any()) }
+  }
+
+  @Test
+  fun `restriction flag enabled unauthorised participants are excluded`() {
+    every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
+
+    val result = resolver(badgeEnabled = false, restrictionEnabled = true)
+      .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
+
+    assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+    assertThat(result[laoAuthorisedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+    assertThat(result[laoRestrictedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = true))
+
+    verify(exactly = 0) { probationAccessControlApiClient.getCaseAccessByCrn(any()) }
+    verify(exactly = 1) { userService.getAccessibleOffenders(username, any()) }
+  }
+
+  @Test
+  fun `both feature flags enabled - LAOs are badged and unauthorised LAOs are excluded`() {
+    stubCaseAccess(ordinaryCrn)
+    stubCaseAccess(laoAuthorisedCrn, restrictedTo = listOf(username))
+    stubCaseAccess(laoRestrictedCrn, excludedFrom = listOf(username))
+    every { userService.getAccessibleOffenders(username, any()) } returns setOf(ordinaryCrn, laoAuthorisedCrn)
+
+    val result = resolver(badgeEnabled = true, restrictionEnabled = true)
+      .resolve(username, listOf(ordinaryCrn, laoAuthorisedCrn, laoRestrictedCrn))
+
+    assertThat(result[ordinaryCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = false, isExcluded = false))
+    assertThat(result[laoAuthorisedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = true, isExcluded = false))
+    assertThat(result[laoRestrictedCrn]).isEqualTo(LimitedAccessResolverService.Access(lao = true, isExcluded = true))
+  }
+
+  @Test
+  fun `empty crns - returns an empty map and makes no external calls`() {
+    val result = resolver(badgeEnabled = true, restrictionEnabled = true).resolve(username, emptyList())
+
+    assertThat(result).isEmpty()
+    verify(exactly = 0) { probationAccessControlApiClient.getCaseAccessByCrn(any()) }
+    verify(exactly = 0) { userService.getAccessibleOffenders(any(), any()) }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/accreditedprogrammesmanageanddeliverapi/service/ProgrammeGroupServiceTest.kt
@@ -31,6 +31,7 @@ class ProgrammeGroupServiceTest {
   private val sessionService = mockk<SessionService>()
   private val moduleSessionTemplateRepository = mockk<ModuleSessionTemplateRepository>()
   private val probationAccessControlApiClient = mockk<ProbationAccessControlApiClient>()
+  private val limitedAccessResolverService = mockk<LimitedAccessResolverService>()
   private lateinit var service: ProgrammeGroupService
 
   @BeforeEach
@@ -48,6 +49,7 @@ class ProgrammeGroupServiceTest {
       sessionService,
       moduleSessionTemplateRepository,
       probationAccessControlApiClient,
+      limitedAccessResolverService,
       true,
     )
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,8 @@ hmpps-auth:
 app:
   features:
     lao-access-check-enabled: true
+    lao-badge-enabled: true
+    lao-view-restriction-enabled: true
   scheduling:
     referral-details-updated:
       cron: "0 0 1 * * *"  # every day at 1 AM

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,7 +11,6 @@ hmpps-auth:
 app:
   features:
     lao-access-check-enabled: true
-    lao-badge-enabled: true
     lao-view-restriction-enabled: true
   scheduling:
     referral-details-updated:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,7 +11,7 @@ hmpps-auth:
 app:
   features:
     lao-access-check-enabled: true
-    lao-view-restriction-enabled: true
+    exclusion-access-check-enabled: true
   scheduling:
     referral-details-updated:
       cron: "0 0 1 * * *"  # every day at 1 AM


### PR DESCRIPTION
This PR returns LAO status on the get session details endpoints

It also adds an LAO service class which can be used across the service and feature flagged in one place for ease of use